### PR TITLE
fix: add jq dependency check to prevent silent failures

### DIFF
--- a/lib/github.sh
+++ b/lib/github.sh
@@ -3,6 +3,15 @@
 
 set -euo pipefail
 
+# jqがインストールされているか確認
+check_jq() {
+    if ! command -v jq &> /dev/null; then
+        echo "Error: jq is not installed" >&2
+        echo "Install: brew install jq (macOS) or apt install jq (Linux)" >&2
+        return 1
+    fi
+}
+
 # gh CLIがインストールされているか確認
 check_gh_cli() {
     if ! command -v gh &> /dev/null; then
@@ -16,6 +25,12 @@ check_gh_cli() {
         echo "Run: gh auth login" >&2
         return 1
     fi
+}
+
+# 全ての依存関係をチェック
+check_dependencies() {
+    check_jq || return 1
+    check_gh_cli || return 1
 }
 
 # Issue情報を取得
@@ -32,7 +47,12 @@ issue_to_branch_name() {
     local issue_number="$1"
     local title
     
-    title=$(get_issue "$issue_number" | jq -r '.title' 2>/dev/null) || {
+    check_jq || {
+        echo "issue-$issue_number"
+        return
+    }
+    
+    title=$(get_issue "$issue_number" | jq -r '.title') || {
         echo "issue-$issue_number"
         return
     }
@@ -48,21 +68,30 @@ issue_to_branch_name() {
 get_issue_title() {
     local issue_number="$1"
     
-    get_issue "$issue_number" | jq -r '.title' 2>/dev/null || echo "Issue #$issue_number"
+    check_jq || {
+        echo "Issue #$issue_number"
+        return
+    }
+    
+    get_issue "$issue_number" | jq -r '.title' || echo "Issue #$issue_number"
 }
 
 # Issueの本文を取得
 get_issue_body() {
     local issue_number="$1"
     
-    get_issue "$issue_number" | jq -r '.body // empty' 2>/dev/null
+    check_jq || return 1
+    
+    get_issue "$issue_number" | jq -r '.body // empty'
 }
 
 # Issueの状態を取得
 get_issue_state() {
     local issue_number="$1"
     
-    get_issue "$issue_number" | jq -r '.state' 2>/dev/null
+    check_jq || return 1
+    
+    get_issue "$issue_number" | jq -r '.state'
 }
 
 # リポジトリ情報を取得

--- a/test/github_test.sh
+++ b/test/github_test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# github.sh のテスト
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/github.sh"
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# テストヘルパー
+assert_success() {
+    local description="$1"
+    shift
+    if "$@" > /dev/null 2>&1; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_failure() {
+    local description="$1"
+    shift
+    if ! "$@" > /dev/null 2>&1; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_contains() {
+    local description="$1"
+    local expected="$2"
+    shift 2
+    local output
+    output=$("$@" 2>&1) || true
+    if [[ "$output" == *"$expected"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description (expected '$expected' in output)"
+        echo "  Got: $output"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# ===================
+# check_jq テスト
+# ===================
+echo "=== check_jq tests ==="
+
+# check_jq関数が存在するかテスト
+if declare -f check_jq > /dev/null 2>&1; then
+    echo "✓ check_jq function exists"
+    ((TESTS_PASSED++)) || true
+    
+    # jqが存在する場合のテスト
+    if command -v jq &> /dev/null; then
+        assert_success "check_jq succeeds when jq is installed" check_jq
+    fi
+else
+    echo "✗ check_jq function does not exist"
+    ((TESTS_FAILED++)) || true
+fi
+
+# ===================
+# check_dependencies テスト
+# ===================
+echo ""
+echo "=== check_dependencies tests ==="
+
+# check_dependencies関数が存在するかテスト
+if declare -f check_dependencies > /dev/null 2>&1; then
+    echo "✓ check_dependencies function exists"
+    ((TESTS_PASSED++)) || true
+    
+    # 依存関係チェック（gh auth statusはスキップ可能）
+    if command -v jq &> /dev/null && command -v gh &> /dev/null && gh auth status &> /dev/null; then
+        assert_success "check_dependencies succeeds when all deps installed and authenticated" check_dependencies
+    else
+        echo "⊘ Skipping check_dependencies test (gh not authenticated)"
+    fi
+else
+    echo "✗ check_dependencies function does not exist"
+    ((TESTS_FAILED++)) || true
+fi
+
+# ===================
+# check_gh_cli テスト
+# ===================
+echo ""
+echo "=== check_gh_cli tests ==="
+
+if declare -f check_gh_cli > /dev/null 2>&1; then
+    echo "✓ check_gh_cli function exists"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ check_gh_cli function does not exist"
+    ((TESTS_FAILED++)) || true
+fi
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #4

## Changes

- Add `check_jq()` function to verify jq is installed before use
- Add `check_dependencies()` for comprehensive dependency checking
- Update all jq-using functions to validate dependency first
- Provide clear error messages with installation instructions
- Remove `2>/dev/null` error suppression for better debugging
- Add test cases for dependency checking

## Testing

```bash
bash test/github_test.sh
```

## Before

```
# Silent failure when jq not installed
title=$(get_issue "$issue_number" | jq -r '.title' 2>/dev/null)
```

## After

```
Error: jq is not installed
Install: brew install jq (macOS) or apt install jq (Linux)
```