### PR TITLE
fix: add --delete-branch option to cleanup.sh

### DIFF
--- a/test/cleanup_test.sh
+++ b/test/cleanup_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# cleanup.sh のテスト
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_contains() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected to contain: $expected"
+        echo "  Actual: $actual"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# ===================
+# Usage テスト
+# ===================
+echo "=== cleanup.sh usage tests ==="
+
+usage_output=$("$SCRIPT_DIR/../scripts/cleanup.sh" --help 2>&1) || true
+
+assert_contains "--delete-branch option in usage" "--delete-branch" "$usage_output"
+assert_contains "delete branch description" "Gitブランチも削除" "$usage_output"
+assert_contains "example with --delete-branch" "--delete-branch" "$usage_output"
+
+# ===================
+# オプションパース テスト
+# ===================
+echo ""
+echo "=== Option parsing tests ==="
+
+# cleanup.shのソースを確認
+cleanup_source=$(cat "$SCRIPT_DIR/../scripts/cleanup.sh")
+
+assert_contains "delete_branch variable exists" 'delete_branch=' "$cleanup_source"
+assert_contains "--delete-branch case exists" '--delete-branch)' "$cleanup_source"
+assert_contains "branch deletion logic exists" 'git branch -d' "$cleanup_source"
+assert_contains "force branch deletion logic exists" 'git branch -D' "$cleanup_source"
+assert_contains "get_worktree_branch call exists" 'get_worktree_branch' "$cleanup_source"
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #6

## Problem

When running `cleanup.sh`, the worktree is deleted but the corresponding Git branch remains, causing:
- Branch accumulation over time
- Potential reuse of old branches on re-run

## Solution

Add `--delete-branch` option to `cleanup.sh` that:
1. Retrieves the branch name before worktree deletion
2. Safely deletes the branch with `git branch -d`
3. Force deletes with `git branch -D` when `--force` is also specified

## Usage

```bash
# Delete worktree and branch
./scripts/cleanup.sh 42 --delete-branch

# Force delete (including unmerged branches)
./scripts/cleanup.sh 42 --delete-branch --force
```

## Changes

- `scripts/cleanup.sh`: Add `--delete-branch` option and branch deletion logic
- `test/cleanup_test.sh`: Add test cases

## Testing

```bash
bash test/cleanup_test.sh
```