### PR TITLE
test: add Bats test framework and initial tests

### DIFF
--- a/tests/fixtures/sample-config.yml
+++ b/tests/fixtures/sample-config.yml
@@ -1,0 +1,14 @@
+# tests/fixtures/sample-config.yml
+# テスト用サンプル設定ファイル
+
+worktree:
+  base_dir: ".test-worktrees"
+  copy_files: ".env .envrc"
+
+tmux:
+  session_prefix: "test"
+  start_in_session: false
+
+pi:
+  command: "echo"
+  args: "--test"

--- a/tests/helpers/mocks.sh
+++ b/tests/helpers/mocks.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# mocks.sh - テスト用モック関数
+
+# モックディレクトリを作成
+setup_mocks() {
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+# ghコマンドのモック
+mock_gh() {
+    local mock_script="$MOCK_DIR/gh"
+    cat > "$mock_script" << 'EOF'
+#!/usr/bin/env bash
+case "$*" in
+    "issue view 42 --json"*)
+        echo '{"number":42,"title":"Test Issue","body":"Test body","labels":[],"state":"OPEN"}'
+        ;;
+    "auth status"*)
+        exit 0
+        ;;
+    "repo view --json nameWithOwner -q .nameWithOwner"*)
+        echo "owner/repo"
+        ;;
+    *)
+        echo "Mock gh: unknown command: $*" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod +x "$mock_script"
+}
+
+# tmuxコマンドのモック
+mock_tmux() {
+    local mock_script="$MOCK_DIR/tmux"
+    cat > "$mock_script" << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 1  # セッションが存在しない
+        ;;
+    "new-session")
+        exit 0
+        ;;
+    "kill-session")
+        exit 0
+        ;;
+    "list-sessions")
+        echo ""
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+EOF
+    chmod +x "$mock_script"
+}
+
+# gitコマンドのモック（部分的）
+mock_git_worktree() {
+    local mock_script="$MOCK_DIR/git"
+    cat > "$mock_script" << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "worktree")
+        case "$2" in
+            "add")
+                mkdir -p "$4" 2>/dev/null || mkdir -p "$3"
+                exit 0
+                ;;
+            "remove")
+                exit 0
+                ;;
+            "list")
+                echo ""
+                ;;
+        esac
+        ;;
+    "rev-parse")
+        exit 1  # ブランチが存在しない
+        ;;
+    "branch")
+        exit 0
+        ;;
+    *)
+        /usr/bin/git "$@"
+        ;;
+esac
+EOF
+    chmod +x "$mock_script"
+}
+
+# モックをクリーンアップ
+cleanup_mocks() {
+    rm -rf "$MOCK_DIR"
+}

--- a/tests/lib/config.bats
+++ b/tests/lib/config.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# config.sh のテスト
+
+setup() {
+    load '../helpers/mocks'
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    source "$PROJECT_ROOT/lib/config.sh"
+}
+
+@test "get_config returns default worktree_base_dir" {
+    # デフォルト値をリセット
+    unset PI_RUNNER_WORKTREE_BASE_DIR
+    _CONFIG_LOADED=""
+    
+    run get_config worktree_base_dir
+    [ "$status" -eq 0 ]
+    [ "$output" = ".worktrees" ]
+}
+
+@test "get_config returns default tmux_session_prefix" {
+    unset PI_RUNNER_TMUX_SESSION_PREFIX
+    _CONFIG_LOADED=""
+    
+    run get_config tmux_session_prefix
+    [ "$status" -eq 0 ]
+    [ "$output" = "pi" ]
+}
+
+@test "get_config returns default pi_command" {
+    unset PI_RUNNER_PI_COMMAND
+    _CONFIG_LOADED=""
+    
+    run get_config pi_command
+    [ "$status" -eq 0 ]
+    [ "$output" = "pi" ]
+}
+
+@test "get_config returns empty for unknown key" {
+    run get_config unknown_key
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "environment variable overrides default" {
+    export PI_RUNNER_WORKTREE_BASE_DIR="custom_dir"
+    _CONFIG_LOADED=""
+    
+    run get_config worktree_base_dir
+    [ "$status" -eq 0 ]
+    [ "$output" = "custom_dir" ]
+    
+    unset PI_RUNNER_WORKTREE_BASE_DIR
+}
+
+@test "load_config sets _CONFIG_LOADED" {
+    _CONFIG_LOADED=""
+    load_config
+    [ "$_CONFIG_LOADED" = "true" ]
+}

--- a/tests/lib/github.bats
+++ b/tests/lib/github.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# github.sh のテスト
+
+setup() {
+    load '../helpers/mocks'
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    source "$PROJECT_ROOT/lib/github.sh"
+}
+
+@test "check_jq succeeds when jq is installed" {
+    # jqがインストールされている前提
+    if ! command -v jq &> /dev/null; then
+        skip "jq is not installed"
+    fi
+    
+    run check_jq
+    [ "$status" -eq 0 ]
+}
+
+@test "check_gh_cli function exists" {
+    run type check_gh_cli
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"function"* ]]
+}
+
+@test "issue_to_branch_name generates correct format" {
+    setup_mocks
+    mock_gh
+    
+    # jqが必要
+    if ! command -v jq &> /dev/null; then
+        skip "jq is not installed"
+    fi
+    
+    run issue_to_branch_name 42
+    [ "$status" -eq 0 ]
+    [[ "$output" == issue-42* ]]
+    
+    cleanup_mocks
+}
+
+@test "issue_to_branch_name falls back without jq" {
+    setup_mocks
+    
+    # jqを無効化するモック
+    cat > "$MOCK_DIR/jq" << 'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$MOCK_DIR/jq"
+    
+    run issue_to_branch_name 42
+    [ "$status" -eq 0 ]
+    [ "$output" = "issue-42" ]
+    
+    cleanup_mocks
+}
+
+@test "get_issue_title returns fallback on error" {
+    setup_mocks
+    
+    # ghが失敗するモック
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$MOCK_DIR/gh"
+    
+    run get_issue_title 99
+    [ "$output" = "Issue #99" ]
+    
+    cleanup_mocks
+}

--- a/tests/lib/tmux.bats
+++ b/tests/lib/tmux.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# tmux.sh のテスト
+
+setup() {
+    load '../helpers/mocks'
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/tmux.sh"
+}
+
+@test "generate_session_name creates correct format" {
+    run generate_session_name 42
+    [ "$status" -eq 0 ]
+    [ "$output" = "pi-issue-42" ]
+}
+
+@test "generate_session_name uses custom prefix" {
+    export PI_RUNNER_TMUX_SESSION_PREFIX="custom"
+    _CONFIG_LOADED=""
+    load_config
+    
+    run generate_session_name 99
+    [ "$status" -eq 0 ]
+    [ "$output" = "custom-issue-99" ]
+    
+    unset PI_RUNNER_TMUX_SESSION_PREFIX
+}
+
+@test "session_exists returns false for non-existent session" {
+    setup_mocks
+    mock_tmux
+    
+    run session_exists "non-existent-session"
+    [ "$status" -eq 1 ]
+    
+    cleanup_mocks
+}
+
+@test "create_session function exists" {
+    run type create_session
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"function"* ]]
+}
+
+@test "kill_session function exists" {
+    run type kill_session
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"function"* ]]
+}
+
+@test "attach_session function exists" {
+    run type attach_session
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"function"* ]]
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# テスト実行スクリプト
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Batsがインストールされているか確認
+if ! command -v bats &> /dev/null; then
+    echo "Error: bats is not installed" >&2
+    echo "Install: brew install bats-core (macOS) or apt install bats (Linux)" >&2
+    exit 1
+fi
+
+# テスト実行
+echo "Running Pi Issue Runner tests..."
+echo ""
+
+if [[ $# -gt 0 ]]; then
+    # 特定のテストファイルを実行
+    bats "$@"
+else
+    # 全テストを実行
+    bats "$SCRIPT_DIR"/{lib,scripts}/*.bats
+fi

--- a/tests/scripts/cleanup.bats
+++ b/tests/scripts/cleanup.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# cleanup.sh のテスト
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "cleanup.sh shows help with --help" {
+    run "$PROJECT_ROOT/scripts/cleanup.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "cleanup.sh shows help with -h" {
+    run "$PROJECT_ROOT/scripts/cleanup.sh" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "cleanup.sh fails without target" {
+    run "$PROJECT_ROOT/scripts/cleanup.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"required"* ]]
+}
+
+@test "cleanup.sh help contains --force option" {
+    run "$PROJECT_ROOT/scripts/cleanup.sh" --help
+    [[ "$output" == *"--force"* ]]
+}
+
+@test "cleanup.sh help contains --keep-session option" {
+    run "$PROJECT_ROOT/scripts/cleanup.sh" --help
+    [[ "$output" == *"--keep-session"* ]]
+}
+
+@test "cleanup.sh help contains --keep-worktree option" {
+    run "$PROJECT_ROOT/scripts/cleanup.sh" --help
+    [[ "$output" == *"--keep-worktree"* ]]
+}
+
+@test "cleanup.sh help contains examples" {
+    run "$PROJECT_ROOT/scripts/cleanup.sh" --help
+    [[ "$output" == *"Examples:"* ]]
+}

--- a/tests/scripts/run.bats
+++ b/tests/scripts/run.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# run.sh のテスト
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "run.sh shows help with --help" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "run.sh shows help with -h" {
+    run "$PROJECT_ROOT/scripts/run.sh" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "run.sh fails without issue number" {
+    run "$PROJECT_ROOT/scripts/run.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Issue number is required"* ]]
+}
+
+@test "run.sh shows usage on unknown option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --unknown-option
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown option"* ]]
+}
+
+@test "run.sh help contains --branch option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [[ "$output" == *"--branch"* ]]
+}
+
+@test "run.sh help contains --no-attach option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [[ "$output" == *"--no-attach"* ]]
+}
+
+@test "run.sh help contains --pi-args option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [[ "$output" == *"--pi-args"* ]]
+}
+
+@test "run.sh help contains examples" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [[ "$output" == *"Examples:"* ]]
+}

--- a/tests/scripts/status.bats
+++ b/tests/scripts/status.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# status.sh のテスト
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "status.sh shows help with --help" {
+    run "$PROJECT_ROOT/scripts/status.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "status.sh shows help with -h" {
+    run "$PROJECT_ROOT/scripts/status.sh" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "status.sh runs without arguments" {
+    # status.shは引数なしでも動作する
+    run "$PROJECT_ROOT/scripts/status.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "status.sh help contains --all option" {
+    run "$PROJECT_ROOT/scripts/status.sh" --help
+    [[ "$output" == *"--all"* ]]
+}
+
+@test "status.sh help contains --json option" {
+    run "$PROJECT_ROOT/scripts/status.sh" --help
+    [[ "$output" == *"--json"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes #8

## Changes

Add comprehensive test suite using Bats (Bash Automated Testing System).

### Directory Structure

```
tests/
├── lib/                    # Unit tests
│   ├── config.bats         # Config loading tests
│   ├── github.bats         # GitHub CLI wrapper tests
│   └── tmux.bats           # Tmux session tests
├── scripts/                # Integration tests
│   ├── run.bats            # run.sh CLI tests
│   ├── cleanup.bats        # cleanup.sh CLI tests
│   └── status.bats         # status.sh CLI tests
├── helpers/
│   └── mocks.sh            # Mock functions for gh, tmux, git
├── fixtures/
│   └── sample-config.yml   # Test configuration
└── run_tests.sh            # Test runner script
```

### Test Coverage

- **config.sh**: Default values, environment variable overrides
- **github.sh**: jq check, issue_to_branch_name, fallback handling
- **tmux.sh**: Session name generation, function existence
- **run.sh**: Help output, required arguments, options
- **cleanup.sh**: Help output, required arguments, options
- **status.sh**: Help output, optional arguments

## Usage

```bash
# Install Bats
brew install bats-core  # macOS
apt install bats        # Linux

# Run all tests
./tests/run_tests.sh

# Run specific test file
bats tests/lib/config.bats
```