### PR TITLE
enhancement: add logging and error handling utilities

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# log.sh - ログ出力とエラーハンドリング
+
+# ログレベル: DEBUG < INFO < WARN < ERROR < QUIET
+LOG_LEVEL="${LOG_LEVEL:-INFO}"
+
+# カラー出力（TTYの場合のみ）
+if [[ -t 2 ]]; then
+    _LOG_COLOR_RESET='\033[0m'
+    _LOG_COLOR_DEBUG='\033[0;36m'  # Cyan
+    _LOG_COLOR_INFO='\033[0;32m'   # Green
+    _LOG_COLOR_WARN='\033[0;33m'   # Yellow
+    _LOG_COLOR_ERROR='\033[0;31m'  # Red
+else
+    _LOG_COLOR_RESET=''
+    _LOG_COLOR_DEBUG=''
+    _LOG_COLOR_INFO=''
+    _LOG_COLOR_WARN=''
+    _LOG_COLOR_ERROR=''
+fi
+
+# ログレベルを数値に変換
+_log_level_to_num() {
+    case "$1" in
+        DEBUG) echo 0 ;;
+        INFO)  echo 1 ;;
+        WARN)  echo 2 ;;
+        ERROR) echo 3 ;;
+        QUIET) echo 4 ;;
+        *)     echo 1 ;;  # デフォルトはINFO
+    esac
+}
+
+# メインログ関数
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    
+    local current_level
+    current_level="$(_log_level_to_num "$LOG_LEVEL")"
+    local msg_level
+    msg_level="$(_log_level_to_num "$level")"
+    
+    # 現在のレベル以上のメッセージのみ出力
+    if [[ $msg_level -lt $current_level ]]; then
+        return 0
+    fi
+    
+    local timestamp
+    timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+    
+    local color=""
+    case "$level" in
+        DEBUG) color="$_LOG_COLOR_DEBUG" ;;
+        INFO)  color="$_LOG_COLOR_INFO" ;;
+        WARN)  color="$_LOG_COLOR_WARN" ;;
+        ERROR) color="$_LOG_COLOR_ERROR" ;;
+    esac
+    
+    printf "%b[%s] [%s]%b %s\n" "$color" "$timestamp" "$level" "$_LOG_COLOR_RESET" "$message" >&2
+}
+
+# 便利関数
+log_debug() { log DEBUG "$@"; }
+log_info()  { log INFO "$@"; }
+log_warn()  { log WARN "$@"; }
+log_error() { log ERROR "$@"; }
+
+# ログレベルを設定
+set_log_level() {
+    local level="$1"
+    case "$level" in
+        DEBUG|INFO|WARN|ERROR|QUIET)
+            LOG_LEVEL="$level"
+            ;;
+        *)
+            log_warn "Unknown log level: $level, using INFO"
+            LOG_LEVEL="INFO"
+            ;;
+    esac
+}
+
+# verbose/quietオプションの処理
+enable_verbose() {
+    LOG_LEVEL="DEBUG"
+}
+
+enable_quiet() {
+    LOG_LEVEL="ERROR"
+}
+
+# エラー時のクリーンアップハンドラを設定
+# 使用例: setup_cleanup_trap "cleanup_function"
+setup_cleanup_trap() {
+    local cleanup_func="${1:-}"
+    
+    _cleanup_handler() {
+        local exit_code=$?
+        if [[ $exit_code -ne 0 ]]; then
+            log_error "Script exited with code $exit_code"
+            if [[ -n "$cleanup_func" ]] && declare -f "$cleanup_func" > /dev/null 2>&1; then
+                log_debug "Running cleanup function: $cleanup_func"
+                "$cleanup_func" || true
+            fi
+        fi
+    }
+    
+    trap _cleanup_handler EXIT
+}
+
+# worktree作成時のクリーンアップ用
+# グローバル変数 _WORKTREE_TO_CLEANUP に設定されたパスを削除
+cleanup_worktree_on_error() {
+    if [[ -n "${_WORKTREE_TO_CLEANUP:-}" && -d "$_WORKTREE_TO_CLEANUP" ]]; then
+        log_warn "Cleaning up incomplete worktree: $_WORKTREE_TO_CLEANUP"
+        git worktree remove --force "$_WORKTREE_TO_CLEANUP" 2>/dev/null || true
+        unset _WORKTREE_TO_CLEANUP
+    fi
+}
+
+# worktreeパスを記録（エラー時クリーンアップ用）
+register_worktree_for_cleanup() {
+    _WORKTREE_TO_CLEANUP="$1"
+}
+
+# クリーンアップ対象から除外（成功時に呼び出す）
+unregister_worktree_for_cleanup() {
+    unset _WORKTREE_TO_CLEANUP
+}

--- a/test/log_test.sh
+++ b/test/log_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# log.sh のテスト
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/log.sh"
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_contains() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected to contain: '$expected'"
+        echo "  Actual: '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_not_contains() {
+    local description="$1"
+    local pattern="$2"
+    local actual="$3"
+    if [[ "$actual" != *"$pattern"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Should not contain: '$pattern'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# ===================
+# ログ出力テスト
+# ===================
+echo "=== Log output tests ==="
+
+LOG_LEVEL="INFO"
+output=$(log_info "Test message" 2>&1)
+assert_contains "log_info includes INFO" "[INFO]" "$output"
+assert_contains "log_info includes message" "Test message" "$output"
+assert_contains "log_info includes timestamp format" "$(date '+%Y-%m-%d')" "$output"
+
+output=$(log_error "Error message" 2>&1)
+assert_contains "log_error includes ERROR" "[ERROR]" "$output"
+
+output=$(log_warn "Warning message" 2>&1)
+assert_contains "log_warn includes WARN" "[WARN]" "$output"
+
+# ===================
+# ログレベルテスト
+# ===================
+echo ""
+echo "=== Log level tests ==="
+
+LOG_LEVEL="INFO"
+output=$(log_debug "Debug message" 2>&1)
+assert_equals "DEBUG hidden when level is INFO" "" "$output"
+
+LOG_LEVEL="DEBUG"
+output=$(log_debug "Debug message" 2>&1)
+assert_contains "DEBUG shown when level is DEBUG" "[DEBUG]" "$output"
+
+LOG_LEVEL="ERROR"
+output=$(log_info "Info message" 2>&1)
+assert_equals "INFO hidden when level is ERROR" "" "$output"
+
+output=$(log_error "Error message" 2>&1)
+assert_contains "ERROR shown when level is ERROR" "[ERROR]" "$output"
+
+# ===================
+# set_log_level テスト
+# ===================
+echo ""
+echo "=== set_log_level tests ==="
+
+set_log_level "DEBUG"
+assert_equals "set_log_level DEBUG" "DEBUG" "$LOG_LEVEL"
+
+set_log_level "WARN"
+assert_equals "set_log_level WARN" "WARN" "$LOG_LEVEL"
+
+set_log_level "INVALID" 2>/dev/null
+assert_equals "invalid level defaults to INFO" "INFO" "$LOG_LEVEL"
+
+# ===================
+# enable_verbose/quiet テスト
+# ===================
+echo ""
+echo "=== verbose/quiet tests ==="
+
+enable_verbose
+assert_equals "enable_verbose sets DEBUG" "DEBUG" "$LOG_LEVEL"
+
+enable_quiet
+assert_equals "enable_quiet sets ERROR" "ERROR" "$LOG_LEVEL"
+
+# ===================
+# 関数存在テスト
+# ===================
+echo ""
+echo "=== Function existence tests ==="
+
+for func in log log_debug log_info log_warn log_error set_log_level \
+            enable_verbose enable_quiet setup_cleanup_trap \
+            cleanup_worktree_on_error register_worktree_for_cleanup; do
+    if declare -f "$func" > /dev/null 2>&1; then
+        echo "✓ $func exists"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $func does not exist"
+        ((TESTS_FAILED++)) || true
+    fi
+done
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #10

## New Features

### Log Levels
```
DEBUG < INFO < WARN < ERROR < QUIET
```

### Usage
```bash
source lib/log.sh

log_info "Starting operation..."
log_warn "Something might be wrong"
log_error "Operation failed"
log_debug "Debug info (only with --verbose)"
```

### Output Format
```
[2024-01-30 22:45:00] [INFO] Starting operation...
[2024-01-30 22:45:01] [ERROR] Operation failed
```

### Color Support
- Colored output when stderr is a TTY
- No colors when piped or redirected

### Options Support
```bash
# Enable debug logging
enable_verbose  # or set LOG_LEVEL=DEBUG

# Show errors only
enable_quiet    # or set LOG_LEVEL=ERROR
```

### Error Cleanup
```bash
# Register worktree for cleanup on error
register_worktree_for_cleanup "/path/to/worktree"

# Set up automatic cleanup on script exit
setup_cleanup_trap cleanup_worktree_on_error

# On success, unregister
unregister_worktree_for_cleanup
```

## Files

- `lib/log.sh`: Logging and error handling library
- `test/log_test.sh`: Test suite

## Testing

```bash
bash test/log_test.sh
```