### PR TITLE
fix: correct issue number extraction from session names

### DIFF
--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -19,7 +19,30 @@ generate_session_name() {
     local issue_number="$1"
     
     load_config
-    echo "$(get_config tmux_session_prefix)-$issue_number"
+    local prefix
+    prefix="$(get_config tmux_session_prefix)"
+    echo "${prefix}-issue-${issue_number}"
+}
+
+# セッション名からIssue番号を抽出
+# 例: "pi-issue-42" -> "42", "pi-issue-42-feature" -> "42"
+extract_issue_number() {
+    local session_name="$1"
+    
+    # 正規表現で issue-(\d+) パターンを抽出
+    if [[ "$session_name" =~ issue-([0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    
+    # フォールバック: 最後の数字部分を抽出
+    if [[ "$session_name" =~ ([0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    
+    echo ""
+    return 1
 }
 
 # セッションを作成してコマンドを実行

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -82,7 +82,7 @@ main() {
         session_name="$(generate_session_name "$issue_number")"
     else
         session_name="$target"
-        issue_number="${session_name##*-}"
+        issue_number="$(extract_issue_number "$session_name")"
     fi
 
     echo "=== Cleanup ==="

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -68,7 +68,7 @@ main() {
     else
         # セッション名
         session_name="$target"
-        issue_number="${session_name##*-}"
+        issue_number="$(extract_issue_number "$session_name")"
     fi
 
     echo "=== Task Status ==="

--- a/test/tmux_test.sh
+++ b/test/tmux_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tmux.sh のテスト（Issue番号抽出）
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/tmux.sh"
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# ===================
+# extract_issue_number テスト
+# ===================
+echo "=== extract_issue_number tests ==="
+
+# 基本パターン
+assert_equals "pi-issue-42" "42" "$(extract_issue_number "pi-issue-42")"
+assert_equals "pi-issue-123" "123" "$(extract_issue_number "pi-issue-123")"
+assert_equals "pi-issue-1" "1" "$(extract_issue_number "pi-issue-1")"
+
+# サフィックス付き（問題のケース）
+assert_equals "pi-issue-42-feature" "42" "$(extract_issue_number "pi-issue-42-feature")"
+assert_equals "pi-issue-42-bug-fix" "42" "$(extract_issue_number "pi-issue-42-bug-fix")"
+assert_equals "pi-issue-99-test-branch-name" "99" "$(extract_issue_number "pi-issue-99-test-branch-name")"
+
+# 異なるプレフィックス
+assert_equals "custom-issue-55" "55" "$(extract_issue_number "custom-issue-55")"
+assert_equals "dev-issue-100-feature" "100" "$(extract_issue_number "dev-issue-100-feature")"
+
+# フォールバックケース
+assert_equals "session-42" "42" "$(extract_issue_number "session-42")"
+assert_equals "task-123-name" "123" "$(extract_issue_number "task-123-name")"
+
+# ===================
+# generate_session_name テスト
+# ===================
+echo ""
+echo "=== generate_session_name tests ==="
+
+# デフォルトプレフィックスの場合
+_CONFIG_LOADED=""
+CONFIG_TMUX_SESSION_PREFIX="pi"
+result="$(generate_session_name 42)"
+assert_equals "generate_session_name 42" "pi-issue-42" "$result"
+
+result="$(generate_session_name 123)"
+assert_equals "generate_session_name 123" "pi-issue-123" "$result"
+
+# ===================
+# 往復テスト（generate → extract）
+# ===================
+echo ""
+echo "=== Round-trip tests ==="
+
+for issue_num in 1 42 99 123 9999; do
+    session="$(generate_session_name "$issue_num")"
+    extracted="$(extract_issue_number "$session")"
+    assert_equals "round-trip for issue $issue_num" "$issue_num" "$extracted"
+done
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #3

## Problem

```bash
# Before: extracted 'feature' instead of '42'
session_name="pi-issue-42-feature"
issue_number="${session_name##*-}"  # Returns 'feature'
```

## Solution

Add `extract_issue_number()` function using regex:

```bash
# After: correctly extracts '42'
extract_issue_number "pi-issue-42-feature"  # Returns '42'
```

### Pattern Matching
1. Primary: `issue-([0-9]+)` - extracts number after 'issue-'
2. Fallback: `([0-9]+)` - extracts first number found

## Changes

- `lib/tmux.sh`: Add `extract_issue_number()`, update `generate_session_name()`
- `scripts/cleanup.sh`: Use `extract_issue_number()`
- `scripts/status.sh`: Use `extract_issue_number()`
- `test/tmux_test.sh`: Comprehensive test suite

## Test Cases

| Input | Expected | Result |
|-------|----------|--------|
| pi-issue-42 | 42 | ✓ |
| pi-issue-42-feature | 42 | ✓ |
| pi-issue-99-test-branch | 99 | ✓ |
| custom-issue-55 | 55 | ✓ |

## Testing

```bash
bash test/tmux_test.sh
```