### PR TITLE
enhancement: add --reattach and --force options to run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -20,12 +20,16 @@ Options:
     --branch NAME   カスタムブランチ名（デフォルト: issue-<num>-<title>）
     --base BRANCH   ベースブランチ（デフォルト: HEAD）
     --no-attach     セッション作成後にアタッチしない
+    --reattach      既存セッションがあればアタッチ
+    --force         既存セッション/worktreeを削除して再作成
     --pi-args ARGS  piに渡す追加の引数
     -h, --help      このヘルプを表示
 
 Examples:
     $(basename "$0") 42
     $(basename "$0") 42 --no-attach
+    $(basename "$0") 42 --reattach
+    $(basename "$0") 42 --force
     $(basename "$0") 42 --branch custom-feature
     $(basename "$0") 42 --base develop
 EOF
@@ -36,6 +40,8 @@ main() {
     local custom_branch=""
     local base_branch="HEAD"
     local no_attach=false
+    local reattach=false
+    local force=false
     local extra_pi_args=""
 
     # 引数のパース
@@ -55,6 +61,14 @@ main() {
                 ;;
             --no-attach)
                 no_attach=true
+                shift
+                ;;
+            --reattach)
+                reattach=true
+                shift
+                ;;
+            --force)
+                force=true
                 shift
                 ;;
             --pi-args)
@@ -92,6 +106,29 @@ main() {
     # 設定読み込み
     load_config
 
+    # セッション名生成（早期に必要）
+    local session_name
+    session_name="$(generate_session_name "$issue_number")"
+
+    # 既存セッションのチェック
+    if session_exists "$session_name"; then
+        if [[ "$reattach" == "true" ]]; then
+            echo "Attaching to existing session: $session_name"
+            attach_session "$session_name"
+            exit 0
+        elif [[ "$force" == "true" ]]; then
+            echo "Removing existing session: $session_name"
+            kill_session "$session_name" || true
+        else
+            echo "Error: Session '$session_name' already exists." >&2
+            echo "" >&2
+            echo "Options:" >&2
+            echo "  --reattach  Attach to existing session" >&2
+            echo "  --force     Remove and recreate session" >&2
+            exit 1
+        fi
+    fi
+
     # Issue情報取得
     echo "Fetching Issue #$issue_number..."
     local issue_title
@@ -107,17 +144,28 @@ main() {
     fi
     echo "Branch: feature/$branch_name"
 
+    # 既存Worktreeのチェック
+    local worktree_path
+    local existing_worktree
+    if existing_worktree="$(find_worktree_by_issue "$issue_number" 2>/dev/null)"; then
+        if [[ "$force" == "true" ]]; then
+            echo "Removing existing worktree: $existing_worktree"
+            remove_worktree "$existing_worktree" true || true
+        else
+            echo "Error: Worktree already exists: $existing_worktree" >&2
+            echo "" >&2
+            echo "Options:" >&2
+            echo "  --force     Remove and recreate worktree" >&2
+            exit 1
+        fi
+    fi
+
     # Worktree作成
     echo ""
     echo "=== Creating Worktree ==="
-    local worktree_path
     worktree_path="$(create_worktree "$branch_name" "$base_branch")"
     local full_worktree_path
     full_worktree_path="$(cd "$worktree_path" && pwd)"
-
-    # セッション名生成
-    local session_name
-    session_name="$(generate_session_name "$issue_number")"
 
     # piコマンド構築
     local pi_command
@@ -125,8 +173,8 @@ main() {
     local pi_args
     pi_args="$(get_config pi_args)"
     
-    # Issue番号とタイトルをpiに渡す
-    local full_command="$pi_command $pi_args $extra_pi_args \"$issue_number --auto\""
+    # Issue番号をpiに渡す
+    local full_command="$pi_command $pi_args $extra_pi_args --auto \"$issue_number\""
 
     # tmuxセッション作成
     echo ""

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# run.sh のテスト
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_contains() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected to contain: '$expected'"
+        echo "  Actual: '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# ===================
+# Usage テスト
+# ===================
+echo "=== run.sh usage tests ==="
+
+usage_output=$("$PROJECT_ROOT/scripts/run.sh" --help 2>&1) || true
+
+assert_contains "--reattach option in usage" "--reattach" "$usage_output"
+assert_contains "--force option in usage" "--force" "$usage_output"
+assert_contains "reattach description" "既存セッション" "$usage_output"
+assert_contains "force description" "削除して再作成" "$usage_output"
+assert_contains "reattach example" "--reattach" "$usage_output"
+assert_contains "force example" "--force" "$usage_output"
+
+# ===================
+# オプションパース テスト
+# ===================
+echo ""
+echo "=== Option parsing tests ==="
+
+run_source=$(cat "$PROJECT_ROOT/scripts/run.sh")
+
+assert_contains "reattach variable exists" 'reattach=' "$run_source"
+assert_contains "--reattach case exists" '--reattach)' "$run_source"
+assert_contains "force variable exists" 'force=' "$run_source"
+assert_contains "--force case exists" '--force)' "$run_source"
+
+# ===================
+# 既存セッション検出ロジック テスト
+# ===================
+echo ""
+echo "=== Existing session detection tests ==="
+
+assert_contains "session_exists check" 'session_exists "$session_name"' "$run_source"
+assert_contains "reattach logic" 'if [[ "$reattach" == "true" ]]' "$run_source"
+assert_contains "force session removal" 'kill_session "$session_name"' "$run_source"
+assert_contains "error message for existing session" "already exists" "$run_source"
+
+# ===================
+# 既存Worktree検出ロジック テスト
+# ===================
+echo ""
+echo "=== Existing worktree detection tests ==="
+
+assert_contains "find_worktree_by_issue check" 'find_worktree_by_issue' "$run_source"
+assert_contains "force worktree removal" 'remove_worktree' "$run_source"
+
+# ===================
+# エラー時のヘルプ表示テスト
+# ===================
+echo ""
+echo "=== Error help tests ==="
+
+error_output=$("$PROJECT_ROOT/scripts/run.sh" 2>&1) || true
+
+assert_contains "error shows usage hint" "required" "$error_output"
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #11

## New Options

### --reattach
Attach to existing session if it already exists.

```bash
# Session exists? Attach immediately
./scripts/run.sh 42 --reattach
```

### --force
Remove existing session/worktree and recreate from scratch.

```bash
# Clean slate - removes existing and creates new
./scripts/run.sh 42 --force
```

## Behavior

### Without options (existing session)
```
Error: Session 'pi-issue-42' already exists.

Options:
  --reattach  Attach to existing session
  --force     Remove and recreate session
```

### Without options (existing worktree)
```
Error: Worktree already exists: .worktrees/issue-42-xxx

Options:
  --force     Remove and recreate worktree
```

## Changes

- `scripts/run.sh`: Add --reattach and --force options
- `test/run_test.sh`: Add test cases

## Testing

```bash
bash test/run_test.sh
```