### PR TITLE
fix: critical issues - prompt, session names, config file

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -14,7 +14,7 @@ CONFIG_PI_ARGS="${CONFIG_PI_ARGS:-}"
 # 設定ファイルを探す
 find_config_file() {
     local start_dir="${1:-.}"
-    local config_name=".pi-issue-runner.yml"
+    local config_name=".pi-runner.yml"
     local current_dir
     current_dir="$(cd "$start_dir" && pwd)"
 

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -15,11 +15,46 @@ check_tmux() {
 }
 
 # セッション名を生成
+# 形式: {prefix}-issue-{number} (例: pi-issue-42)
 generate_session_name() {
     local issue_number="$1"
     
     load_config
-    echo "$(get_config tmux_session_prefix)-$issue_number"
+    local prefix
+    prefix="$(get_config tmux_session_prefix)"
+    # prefixに既に"-issue"が含まれている場合は追加しない
+    if [[ "$prefix" == *"-issue" ]]; then
+        echo "${prefix}-${issue_number}"
+    else
+        echo "${prefix}-issue-${issue_number}"
+    fi
+}
+
+# セッション名からIssue番号を抽出
+# 例: "pi-issue-42" -> "42", "pi-issue-42-feature" -> "42"
+extract_issue_number() {
+    local session_name="$1"
+    
+    # パターン: -issue-{数字} を探す
+    if [[ "$session_name" =~ -issue-([0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    
+    # フォールバック: 最後のハイフン以降の数字
+    if [[ "$session_name" =~ -([0-9]+)$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    
+    # さらにフォールバック: 最初に見つかる数字列
+    if [[ "$session_name" =~ ([0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    
+    echo ""
+    return 1
 }
 
 # セッションを作成してコマンドを実行

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -82,7 +82,7 @@ main() {
         session_name="$(generate_session_name "$issue_number")"
     else
         session_name="$target"
-        issue_number="${session_name##*-}"
+        issue_number="$(extract_issue_number "$session_name")"
     fi
 
     echo "=== Cleanup ==="

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -97,6 +97,9 @@ main() {
     local issue_title
     issue_title="$(get_issue_title "$issue_number")"
     echo "Title: $issue_title"
+    
+    local issue_body
+    issue_body="$(get_issue_body "$issue_number" 2>/dev/null)" || issue_body=""
 
     # ブランチ名決定
     local branch_name
@@ -125,8 +128,23 @@ main() {
     local pi_args
     pi_args="$(get_config pi_args)"
     
-    # Issue番号とタイトルをpiに渡す
-    local full_command="$pi_command $pi_args $extra_pi_args \"$issue_number --auto\""
+    # プロンプトファイルを作成（シェルエスケープ問題を回避）
+    local prompt_file="$full_worktree_path/.pi-prompt.md"
+    cat > "$prompt_file" << EOF
+Implement GitHub Issue #$issue_number
+
+## Title
+$issue_title
+
+## Description
+$issue_body
+
+---
+Please implement this issue following the project's coding standards.
+EOF
+    
+    # Issue本文をpiに渡す（catでパイプ）
+    local full_command="cat \"$prompt_file\" | $pi_command $pi_args $extra_pi_args --auto"
 
     # tmuxセッション作成
     echo ""

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -68,7 +68,7 @@ main() {
     else
         # セッション名
         session_name="$target"
-        issue_number="${session_name##*-}"
+        issue_number="$(extract_issue_number "$session_name")"
     fi
 
     echo "=== Task Status ==="

--- a/test/critical_fixes_test.sh
+++ b/test/critical_fixes_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Issue #21, #22, #23 の修正テスト
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$PROJECT_ROOT/lib/config.sh"
+source "$PROJECT_ROOT/lib/tmux.sh"
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_contains() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected to contain: '$expected'"
+        echo "  Actual: '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# ===================
+# Issue #23: 設定ファイル名テスト
+# ===================
+echo "=== Issue #23: Config file name tests ==="
+
+config_source=$(cat "$PROJECT_ROOT/lib/config.sh")
+assert_contains "config uses .pi-runner.yml" '.pi-runner.yml' "$config_source"
+
+# ===================
+# Issue #22: セッション名テスト
+# ===================
+echo ""
+echo "=== Issue #22: Session name tests ==="
+
+# デフォルトprefix "pi-issue" の場合
+CONFIG_TMUX_SESSION_PREFIX="pi-issue"
+result="$(generate_session_name 42)"
+assert_equals "generate_session_name with pi-issue prefix" "pi-issue-42" "$result"
+
+# カスタムprefix "dev" の場合
+CONFIG_TMUX_SESSION_PREFIX="dev"
+result="$(generate_session_name 42)"
+assert_equals "generate_session_name with dev prefix" "dev-issue-42" "$result"
+
+# extract_issue_number テスト
+assert_equals "extract from pi-issue-42" "42" "$(extract_issue_number "pi-issue-42")"
+assert_equals "extract from dev-issue-99" "99" "$(extract_issue_number "dev-issue-99")"
+assert_equals "extract from pi-issue-42-feature" "42" "$(extract_issue_number "pi-issue-42-feature")"
+assert_equals "extract from custom-issue-123-bugfix" "123" "$(extract_issue_number "custom-issue-123-bugfix")"
+
+# 往復テスト
+CONFIG_TMUX_SESSION_PREFIX="pi-issue"
+for num in 1 42 99 123; do
+    session="$(generate_session_name "$num")"
+    extracted="$(extract_issue_number "$session")"
+    assert_equals "round-trip for issue $num" "$num" "$extracted"
+done
+
+# ===================
+# Issue #21: プロンプト構築テスト
+# ===================
+echo ""
+echo "=== Issue #21: Prompt construction tests ==="
+
+run_source=$(cat "$PROJECT_ROOT/scripts/run.sh")
+
+assert_contains "run.sh gets issue body" 'get_issue_body' "$run_source"
+assert_contains "run.sh creates prompt file" '.pi-prompt.md' "$run_source"
+assert_contains "run.sh includes issue title in prompt" 'issue_title' "$run_source"
+assert_contains "run.sh includes issue body in prompt" 'issue_body' "$run_source"
+# grepで直接検索（シェル変数展開の問題を回避）
+if grep -q 'cat.*prompt_file.*pi_command' "$PROJECT_ROOT/scripts/run.sh"; then
+    echo "✓ run.sh uses cat to pipe prompt"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ run.sh uses cat to pipe prompt"
+    ((TESTS_FAILED++)) || true
+fi
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #21, #22, #23

## Issue #21: Pass Issue body to pi as prompt

**Before:**
```bash
pi "42 --auto"  # pi receives only issue number
```

**After:**
```bash
cat ".pi-prompt.md" | pi --auto
# .pi-prompt.md contains:
# - Issue number
# - Issue title  
# - Full issue body
# - Implementation instructions
```

## Issue #22: Consistent session name format

**Session name format:** `{prefix}-issue-{number}`

```bash
# Examples
generate_session_name 42  # -> "pi-issue-42"
extract_issue_number "pi-issue-42"  # -> "42"
extract_issue_number "pi-issue-42-feature"  # -> "42"
```

## Issue #23: Unified config file name

**Changed:** `.pi-issue-runner.yml` → `.pi-runner.yml`

## Files Changed

| File | Change |
|------|--------|
| `lib/config.sh` | Config file name |
| `lib/tmux.sh` | Session name functions |
| `scripts/run.sh` | Prompt file creation |
| `scripts/cleanup.sh` | Use extract_issue_number |
| `scripts/status.sh` | Use extract_issue_number |
| `test/critical_fixes_test.sh` | Test suite |

## Testing

```bash
bash test/critical_fixes_test.sh
```