### PR TITLE
enhancement: add error cleanup for worktree in run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,6 +8,10 @@ source "$SCRIPT_DIR/../lib/config.sh"
 source "$SCRIPT_DIR/../lib/github.sh"
 source "$SCRIPT_DIR/../lib/worktree.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+
+# エラー時のクリーンアップを設定
+setup_cleanup_trap cleanup_worktree_on_error
 
 usage() {
     cat << EOF
@@ -169,6 +173,9 @@ main() {
     worktree_path="$(create_worktree "$branch_name" "$base_branch")"
     local full_worktree_path
     full_worktree_path="$(cd "$worktree_path" && pwd)"
+    
+    # エラー時クリーンアップ用にworktreeを登録
+    register_worktree_for_cleanup "$full_worktree_path"
 
     # piコマンド構築
     local pi_command
@@ -198,6 +205,9 @@ EOF
     echo ""
     echo "=== Starting Pi Session ==="
     create_session "$session_name" "$full_worktree_path" "$full_command"
+    
+    # セッション作成成功 - クリーンアップ対象から除外
+    unregister_worktree_for_cleanup
 
     echo ""
     echo "=== Summary ==="


### PR DESCRIPTION
## Summary

Closes #25

## Problem

When tmux session creation fails after worktree is created, the worktree remains orphaned, causing 'Worktree already exists' errors on re-run.

## Solution

Integrate lib/log.sh cleanup utilities:

```bash
# Set up cleanup trap
setup_cleanup_trap cleanup_worktree_on_error

# After worktree creation
register_worktree_for_cleanup "$full_worktree_path"

# After successful session creation  
unregister_worktree_for_cleanup
```

## Behavior

- If script exits with error after worktree creation → worktree is automatically removed
- If script completes successfully → worktree is preserved