### PR TITLE
docs: update directory structure in AGENTS.md and README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
 ```
 pi-issue-runner/
 ├── SKILL.md           # スキル定義（必須）
+├── AGENTS.md          # 開発ガイド（このファイル）
+├── README.md          # プロジェクト説明
 ├── scripts/           # 実行スクリプト
 │   ├── run.sh         # メインエントリーポイント
 │   ├── list.sh        # セッション一覧
@@ -28,7 +30,9 @@ pi-issue-runner/
 │   ├── worktree.sh    # Git worktree操作
 │   └── tmux.sh        # tmux操作
 ├── docs/              # ドキュメント
-└── tests/             # テスト（Bats）
+├── test/              # 単体テスト（*_test.sh形式）
+├── tests/             # Batsテスト（fixtures, helpers含む）
+└── .worktrees/        # 実行時に作成されるworktreeディレクトリ
 ```
 
 ## 開発コマンド
@@ -37,7 +41,10 @@ pi-issue-runner/
 # スクリプト実行
 ./scripts/run.sh 42
 
-# テスト実行（Batsがインストールされている場合）
+# 単体テスト実行
+./test/config_test.sh
+
+# Batsテスト実行（Batsがインストールされている場合）
 bats tests/
 
 # シェルスクリプトの構文チェック

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ pi:
 ```
 pi-issue-runner/
 ├── SKILL.md                 # スキル定義
+├── AGENTS.md                # 開発ガイド
+├── README.md                # このファイル
 ├── scripts/
 │   ├── run.sh              # Issue実行
 │   ├── list.sh             # セッション一覧
@@ -108,8 +110,9 @@ pi-issue-runner/
 │   ├── tmux.sh             # tmux操作
 │   └── github.sh           # GitHub API操作
 ├── docs/                    # ドキュメント
-├── README.md               # このファイル
-└── CLAUDE.md               # 開発ガイド
+├── test/                    # 単体テスト
+├── tests/                   # Batsテスト
+└── .worktrees/              # worktree作成先（実行時に生成）
 ```
 
 ## ワークフロー例


### PR DESCRIPTION
## Summary

Closes #28

## Changes

**AGENTS.md:**
- Add AGENTS.md itself to directory structure
- Add README.md to directory structure  
- Update tests/ → test/ (unit tests) and tests/ (Bats tests)
- Add .worktrees/ (created at runtime)
- Add unit test execution example

**README.md:**
- Fix CLAUDE.md → AGENTS.md reference
- Add test/, tests/, .worktrees/ to directory structure

*Implemented by pi-issue-runner (separate pi instance)*