### PR TITLE
enhancement: add parallel session limit

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -14,6 +14,7 @@ CONFIG_TMUX_SESSION_PREFIX="${CONFIG_TMUX_SESSION_PREFIX:-pi}"
 CONFIG_TMUX_START_IN_SESSION="${CONFIG_TMUX_START_IN_SESSION:-true}"
 CONFIG_PI_COMMAND="${CONFIG_PI_COMMAND:-pi}"
 CONFIG_PI_ARGS="${CONFIG_PI_ARGS:-}"
+CONFIG_PARALLEL_MAX_CONCURRENT="${CONFIG_PARALLEL_MAX_CONCURRENT:-0}"  # 0 = unlimited
 
 # 設定ファイルを探す
 find_config_file() {
@@ -132,6 +133,9 @@ _parse_config_file() {
                     # スペース区切りの単一行形式
                     CONFIG_PI_ARGS="$value"
                     ;;
+                parallel_max_concurrent)
+                    CONFIG_PARALLEL_MAX_CONCURRENT="$value"
+                    ;;
             esac
             continue
         fi
@@ -189,6 +193,9 @@ _apply_env_overrides() {
     if [[ -n "${PI_RUNNER_PI_ARGS:-}" ]]; then
         CONFIG_PI_ARGS="$PI_RUNNER_PI_ARGS"
     fi
+    if [[ -n "${PI_RUNNER_PARALLEL_MAX_CONCURRENT:-}" ]]; then
+        CONFIG_PARALLEL_MAX_CONCURRENT="$PI_RUNNER_PARALLEL_MAX_CONCURRENT"
+    fi
 }
 
 # 設定値を取得
@@ -212,6 +219,9 @@ get_config() {
             ;;
         pi_args)
             echo "$CONFIG_PI_ARGS"
+            ;;
+        parallel_max_concurrent)
+            echo "$CONFIG_PARALLEL_MAX_CONCURRENT"
             ;;
         *)
             echo ""

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -133,6 +133,13 @@ main() {
         fi
     fi
 
+    # 並列実行数の制限チェック（--forceの場合はスキップ）
+    if [[ "$force" != "true" ]]; then
+        if ! check_concurrent_limit; then
+            exit 1
+        fi
+    fi
+
     # Issue情報取得
     echo "Fetching Issue #$issue_number..."
     local issue_title


### PR DESCRIPTION
## Summary

Closes #26

## Changes

**lib/config.sh:**
- Add `CONFIG_PARALLEL_MAX_CONCURRENT` (default: 0 = unlimited)
- Parse `parallel.max_concurrent` from config file
- Support `PI_RUNNER_PARALLEL_MAX_CONCURRENT` env override

**lib/tmux.sh:**
- Add `count_active_sessions()` function
- Add `check_concurrent_limit()` function

**scripts/run.sh:**
- Call `check_concurrent_limit()` before creating new session
- Skip limit check when `--force` is used

## Usage

```yaml
# .pi-runner.yml
parallel:
  max_concurrent: 5
```

```bash
# Or via environment variable
PI_RUNNER_PARALLEL_MAX_CONCURRENT=5 ./scripts/run.sh 42
```

## Behavior

When limit is reached:
```
Error: Maximum concurrent sessions (5) reached.
Currently running (5 sessions):
  - pi-issue-1
  - pi-issue-2
  ...
Use --force to override or cleanup existing sessions.
```