### PR TITLE
docs: README.mdとSKILL.mdの重複を解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gh auth status
 # tmux
 which tmux
 
-# pi-mono
+# pi
 which pi
 ```
 
@@ -27,7 +27,7 @@ which pi
 piのスキルディレクトリにクローン:
 
 ```bash
-git clone https://github.com/yourusername/pi-issue-runner ~/.pi/skills/pi-issue-runner
+git clone https://github.com/yourusername/pi-issue-runner ~/.pi/agent/skills/pi-issue-runner
 ```
 
 ## 使い方
@@ -90,31 +90,6 @@ pi:
   args: []
 ```
 
-## ディレクトリ構造
-
-```
-pi-issue-runner/
-├── SKILL.md                 # スキル定義
-├── AGENTS.md                # 開発ガイド
-├── README.md                # このファイル
-├── scripts/
-│   ├── run.sh              # Issue実行
-│   ├── list.sh             # セッション一覧
-│   ├── status.sh           # 状態確認
-│   ├── attach.sh           # セッションアタッチ
-│   ├── stop.sh             # セッション停止
-│   └── cleanup.sh          # クリーンアップ
-├── lib/
-│   ├── config.sh           # 設定読み込み
-│   ├── worktree.sh         # Git worktree操作
-│   ├── tmux.sh             # tmux操作
-│   └── github.sh           # GitHub API操作
-├── docs/                    # ドキュメント
-├── test/                    # 単体テスト
-├── tests/                   # Batsテスト
-└── .worktrees/              # worktree作成先（実行時に生成）
-```
-
 ## ワークフロー例
 
 ### 複数Issueの並列作業
@@ -139,14 +114,43 @@ scripts/attach.sh 42
 scripts/cleanup.sh 42
 ```
 
-## ドキュメント
+## ディレクトリ構造
 
-- [スキル仕様](SKILL.md) - スキルの使い方と設定
-- [アーキテクチャ](docs/architecture.md) - システム設計
-- [Git Worktree管理](docs/worktree-management.md) - worktree運用
-- [tmux統合](docs/tmux-integration.md) - tmuxセッション管理
-- [並列実行](docs/parallel-execution.md) - 複数タスクの並列処理
-- [設定リファレンス](docs/configuration.md) - 設定オプション
+```
+pi-issue-runner/
+├── SKILL.md                 # スキル定義（piから参照）
+├── AGENTS.md                # 開発ガイド
+├── README.md                # このファイル
+├── scripts/
+│   ├── run.sh              # Issue実行
+│   ├── list.sh             # セッション一覧
+│   ├── status.sh           # 状態確認
+│   ├── attach.sh           # セッションアタッチ
+│   ├── stop.sh             # セッション停止
+│   └── cleanup.sh          # クリーンアップ
+├── lib/
+│   ├── config.sh           # 設定読み込み
+│   ├── worktree.sh         # Git worktree操作
+│   ├── tmux.sh             # tmux操作
+│   └── github.sh           # GitHub API操作
+├── docs/                    # ドキュメント
+├── test/                    # 単体テスト
+├── tests/                   # Batsテスト
+└── .worktrees/              # worktree作成先（実行時に生成）
+```
+
+実行時に対象プロジェクトに作成されるworktree構造:
+
+```
+your-project/
+├── .worktrees/
+│   ├── issue-42/           # Issue #42 のworktree
+│   │   ├── .env            # コピーされたファイル
+│   │   └── ...
+│   └── issue-43/           # Issue #43 のworktree
+│       └── ...
+└── .pi-issue-runner.yml    # 設定ファイル（オプション）
+```
 
 ## トラブルシューティング
 
@@ -179,6 +183,18 @@ gh auth status
 # 再認証
 gh auth login
 ```
+
+## ドキュメント
+
+- [アーキテクチャ](docs/architecture.md) - システム設計
+- [Git Worktree管理](docs/worktree-management.md) - worktree運用
+- [tmux統合](docs/tmux-integration.md) - tmuxセッション管理
+- [並列実行](docs/parallel-execution.md) - 複数タスクの並列処理
+- [設定リファレンス](docs/configuration.md) - 設定オプション
+
+## 開発
+
+開発に参加する場合は [AGENTS.md](AGENTS.md) を参照してください。
 
 ## ライセンス
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,112 +7,26 @@ description: GitHub IssueからGit worktreeを作成し、tmuxセッション内
 
 GitHub Issueを入力として、Git worktreeを作成し、tmuxセッション内で独立したpiインスタンスを起動します。
 
+## クイックリファレンス
+
+```bash
+# Issue実行（メインコマンド）
+scripts/run.sh <issue-number> [--no-attach] [--branch <name>] [--base <branch>]
+
+# セッション管理
+scripts/list.sh              # セッション一覧
+scripts/attach.sh <session>  # セッションにアタッチ
+scripts/status.sh <session>  # 状態確認
+scripts/stop.sh <session>    # セッション停止
+scripts/cleanup.sh <session> # クリーンアップ
+```
+
 ## 前提条件
 
-```bash
-# 必須ツール
-gh auth status    # GitHub CLI（認証済み）
-which tmux        # tmux
-which pi          # pi-mono
-```
+- `gh` (GitHub CLI、認証済み)
+- `tmux`
+- `pi`
 
-## 基本的な使い方
+## 詳細ドキュメント
 
-### Issue実行
-
-```bash
-# Issue #42 からworktreeを作成してpiを起動
-scripts/run.sh 42
-
-# 自動アタッチせずにバックグラウンドで起動
-scripts/run.sh 42 --no-attach
-
-# カスタムブランチ名で作成
-scripts/run.sh 42 --branch custom-feature-name
-
-# 特定のベースブランチから作成
-scripts/run.sh 42 --base develop
-```
-
-### セッション管理
-
-```bash
-# 実行中のセッション一覧
-scripts/list.sh
-
-# セッションにアタッチ
-scripts/attach.sh pi-issue-42
-
-# セッションを終了
-scripts/stop.sh pi-issue-42
-
-# 状態確認
-scripts/status.sh pi-issue-42
-
-# セッションとworktreeをクリーンアップ
-scripts/cleanup.sh pi-issue-42
-```
-
-## 設定
-
-プロジェクトルートに `.pi-issue-runner.yml` を作成して動作をカスタマイズできます：
-
-```yaml
-# Git worktree設定
-worktree:
-  base_dir: ".worktrees"
-  copy_files:
-    - ".env"
-    - ".env.local"
-
-# tmux設定
-tmux:
-  session_prefix: "pi-issue"
-  start_in_session: true
-
-# pi設定
-pi:
-  command: "pi"
-  args: []
-```
-
-## ワークフロー例
-
-### 複数Issueの並列作業
-
-```bash
-# 複数のIssueをバックグラウンドで起動
-scripts/run.sh 42 --no-attach
-scripts/run.sh 43 --no-attach
-scripts/run.sh 44 --no-attach
-
-# 一覧確認
-scripts/list.sh
-
-# 必要に応じてアタッチ
-scripts/attach.sh pi-issue-42
-```
-
-### 完了後のクリーンアップ
-
-```bash
-# PR作成後、worktreeをクリーンアップ
-scripts/cleanup.sh pi-issue-42
-```
-
-## ディレクトリ構造
-
-```
-your-project/
-├── .worktrees/
-│   ├── issue-42/           # Issue #42 のworktree
-│   │   ├── .env            # コピーされたファイル
-│   │   └── ...
-│   └── issue-43/           # Issue #43 のworktree
-│       └── ...
-└── .pi-issue-runner.yml    # 設定ファイル（オプション）
-```
-
-## トラブルシューティング
-
-詳細は [docs/](docs/) を参照してください。
+詳しい使い方、設定、トラブルシューティングは [README.md](README.md) を参照してください。


### PR DESCRIPTION
## 概要

Issue #27 の案3を実装しました。

## 変更内容

- **SKILL.md**: piスキル定義に特化（最小限のメタデータ+クイックリファレンス）
- **README.md**: 一般ユーザー向け詳細ドキュメント（インストール、設定、トラブルシューティング）

## サイズ変化

| ファイル | Before | After |
|---------|--------|-------|
| SKILL.md | 約2.5KB | 約1KB (60%削減) |
| README.md | 約2.7KB | 約3.3KB |

Closes #27