### PR TITLE
fix: 設定ファイル名の不整合を修正 (.pi-issue-runner.yml → .pi-runner.yml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ scripts/cleanup.sh pi-issue-42
 
 ## 設定
 
-プロジェクトルートに `.pi-issue-runner.yml` を作成して動作をカスタマイズできます：
+プロジェクトルートに `.pi-runner.yml` を作成して動作をカスタマイズできます：
 
 ```yaml
 # Git worktree設定
@@ -149,7 +149,7 @@ your-project/
 │   │   └── ...
 │   └── issue-43/           # Issue #43 のworktree
 │       └── ...
-└── .pi-issue-runner.yml    # 設定ファイル（オプション）
+└── .pi-runner.yml          # 設定ファイル（オプション）
 ```
 
 ## トラブルシューティング


### PR DESCRIPTION
## 変更内容

README.mdの設定ファイル名が実装(lib/config.sh)と異なっていたため修正しました。

### 修正箇所
- README.md 72行目: 設定ファイル説明
- README.md 152行目: ディレクトリ構造

### 変更
`.pi-issue-runner.yml` → `.pi-runner.yml`

Closes #35