### PR TITLE
docs: READMEの前提条件にjqを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ which tmux
 
 # pi
 which pi
+
+# jq (JSON処理)
+which jq
 ```
 
 ## インストール


### PR DESCRIPTION
## 変更内容

READMEの前提条件セクションに `jq` コマンドを追加しました。

`jq` は必須の依存関係ですが、前提条件に記載されていなかったため追加しました。

Closes #39