### PR TITLE
fix: run.shで依存関係チェックを呼び出すように修正

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,6 +10,9 @@ source "$SCRIPT_DIR/../lib/worktree.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
 
+# 依存関係チェック
+check_dependencies || exit 1
+
 # エラー時のクリーンアップを設定
 setup_cleanup_trap cleanup_worktree_on_error
 


### PR DESCRIPTION
## 概要
run.shで依存関係チェック(check_dependencies)が呼び出されていない問題を修正しました。

## 変更内容
- lib/github.shのcheck_dependencies()をrun.shの冒頭で呼び出すよう追加
- スクリプト実行前にjqおよびgh CLIの存在をチェック

## 影響
- jqがインストールされていない場合、スクリプト開始時に明確なエラーメッセージが表示される
- Issue情報取得時ではなく、早い段階で依存関係の問題を検知できる

Closes #38