### PR TITLE
docs: Bashバージョン要件の矛盾を解消

### DIFF
--- a/.pi-prompt.md
+++ b/.pi-prompt.md
@@ -1,0 +1,86 @@
+Implement GitHub Issue #40
+
+## Title
+docs: Bashバージョン要件の矛盾を解消
+
+## Description
+## 概要
+
+AGENTS.mdとSPECIFICATION.mdでBashバージョン要件が矛盾している。
+
+## 現状
+
+| ファイル | 記載 |
+|----------|------|
+| AGENTS.md | 「POSIX互換」「Bash 3互換」 |
+| SPECIFICATION.md | 「Bash 4.0以上」 |
+
+## 実際の要件
+
+コードは `BASH_REMATCH` を使用しており、**Bash 3では動作しない**。
+
+```bash
+# lib/tmux.sh
+if [[ "$session_name" =~ -issue-([0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"  # Bash 3では動作しない
+fi
+```
+
+## 修正内容
+
+AGENTS.mdを「Bash 4.0+」に修正：
+
+```markdown
+## 技術スタック
+
+- **言語**: Bash 4.0以上
+```
+
+## 優先度
+P1 (Medium)
+
+---
+
+## Instructions
+
+You are implementing GitHub Issue #40 in an isolated worktree.
+
+### Step 1: Understand the Issue
+- Read the issue description carefully
+- If unclear, check related files in the codebase
+
+### Step 2: Implement
+- Follow existing code style and patterns
+- Keep changes minimal and focused
+- Add/update tests if applicable
+
+### Step 3: Verify
+- Run existing tests if available
+- Check for syntax errors: `bash -n <file>`
+
+### Step 4: Commit & Push
+```bash
+git add -A
+git commit -m "<type>: <description>
+
+Closes #40"
+git push -u origin feature/issue-40-docs-bash
+```
+
+### Step 5: Create & Merge PR
+```bash
+gh pr create --title "<type>: <short description>" --body "Closes #40"
+gh pr merge --merge --delete-branch
+```
+
+### Commit Types
+- feat: New feature
+- fix: Bug fix  
+- docs: Documentation
+- refactor: Code refactoring
+- test: Adding tests
+- chore: Maintenance
+
+### On Error
+- If tests fail, fix the issue before committing
+- If PR merge fails, report the error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## 技術スタック
 
-- **言語**: Bash (POSIX互換)
+- **言語**: Bash 4.0以上
 - **依存ツール**: `gh` (GitHub CLI), `tmux`, `git`, `jq`
 - **テストフレームワーク**: Bats (Bash Automated Testing System)
 


### PR DESCRIPTION
## 概要
AGENTS.mdのBashバージョン要件をSPECIFICATION.mdと整合するよう修正。

## 変更内容
- AGENTS.md: 「Bash (POSIX互換)」→「Bash 4.0以上」

## 理由
コードは`BASH_REMATCH`を使用しており、Bash 4.0以上が必要。

Closes #40