### PR TITLE
docs: SPECIFICATION.mdのディレクトリ構造にlib/log.shを追加

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -88,6 +88,7 @@ project-root/
 ├── lib/                     # シェルスクリプトライブラリ
 │   ├── config.sh            # 設定管理
 │   ├── github.sh            # GitHub CLI操作
+│   ├── log.sh               # ログ出力
 │   ├── tmux.sh              # tmux操作
 │   └── worktree.sh          # Git worktree操作
 └── scripts/                 # 実行スクリプト


### PR DESCRIPTION
## Summary
Closes #64

## Changes
- Added `lib/log.sh` entry to the directory structure in docs/SPECIFICATION.md
- Placed in alphabetical order between `github.sh` and `tmux.sh`

## Testing
- Verified the documentation change is correct
- No functional code changes, documentation only