### PR TITLE
docs: add --reattach and --force options to SPECIFICATION.md

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -139,6 +139,8 @@ Options:
     --branch NAME   カスタムブランチ名
     --base BRANCH   ベースブランチ（デフォルト: HEAD）
     --no-attach     セッション作成後にアタッチしない
+    --reattach      既存セッションがあればアタッチ
+    --force         既存セッション/worktreeを削除して再作成
     --pi-args ARGS  piに渡す追加の引数
 ```
 


### PR DESCRIPTION
## Summary
Closes #63

## Changes
- Added `--reattach` option documentation to run.sh section in SPECIFICATION.md
- Added `--force` option documentation to run.sh section in SPECIFICATION.md

## Testing
- Verified the change matches the actual implementation in scripts/run.sh