### PR TITLE
chore: config.shのコメントをBash 4.0以上に修正

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# config.sh - 設定ファイル読み込み（Bash 3互換）
+# config.sh - 設定ファイル読み込み（Bash 4.0以上）
 
 # Note: set -euo pipefail はsource先の環境に影響するため、
 # このファイルでは設定しない（呼び出し元で設定）


### PR DESCRIPTION
## Summary
Closes #65

## Changes
- lib/config.sh のコメントを「Bash 3互換」から「Bash 4.0以上」に修正
- AGENTS.mdの技術スタック記載（Bash 4.0以上）と整合性を確保

## Testing
- `bash -n lib/config.sh` で構文チェック実行
- `./test/config_test.sh` で全11テスト合格