### PR TITLE
docs: README.mdの使用例に--reattachと--forceを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ scripts/run.sh 42 --branch custom-feature
 
 # 特定のベースブランチから作成
 scripts/run.sh 42 --base develop
+
+# 既存セッションがあればアタッチ
+scripts/run.sh 42 --reattach
+
+# 既存セッション/worktreeを削除して再作成
+scripts/run.sh 42 --force
 ```
 
 ### セッション管理


### PR DESCRIPTION
## Summary
Closes #71

## Changes
- README.mdのIssue実行セクションに`--reattach`と`--force`オプションの使用例を追加

## Testing
- ドキュメントのみの変更のため、構文テストは不要