### PR TITLE
docs: README.mdのgit clone URLをtakemo101に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ which jq
 piのスキルディレクトリにクローン:
 
 ```bash
-git clone https://github.com/yourusername/pi-issue-runner ~/.pi/agent/skills/pi-issue-runner
+git clone https://github.com/takemo101/pi-issue-runner ~/.pi/agent/skills/pi-issue-runner
 ```
 
 ## 使い方


### PR DESCRIPTION
## Summary
Closes #76

## Changes
- README.mdのインストール手順にあるgit clone URLを`yourusername`から`takemo101`に修正

## Testing
- ドキュメントの修正のみのためテスト不要