### PR TITLE
docs: add list.sh CLI command details to SPECIFICATION.md

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -147,6 +147,16 @@ Options:
     --pi-args ARGS  piに渡す追加の引数
 ```
 
+### list.sh - セッション一覧
+
+```bash
+./scripts/list.sh [options]
+
+Options:
+    -v, --verbose   詳細情報を表示
+    -h, --help      このヘルプを表示
+```
+
 ### status.sh - 状態確認
 
 ```bash


### PR DESCRIPTION
## Summary
Closes #80

## Changes
- Added list.sh command documentation to the CLI コマンド section in SPECIFICATION.md
- Documentation includes available options (-v/--verbose, -h/--help)

## Testing
- Verified the markdown format is correct
- Confirmed documentation matches actual script implementation