### PR TITLE
docs: SPECIFICATION.mdのstatus.shオプションを実際の実装に合わせて修正

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -160,11 +160,15 @@ Options:
 ### status.sh - 状態確認
 
 ```bash
-./scripts/status.sh [options]
+./scripts/status.sh <session-name|issue-number> [options]
+
+Arguments:
+    session-name    tmuxセッション名（例: pi-issue-42）
+    issue-number    GitHub Issue番号（例: 42）
 
 Options:
-    --all           すべてのセッションを表示
-    --json          JSON形式で出力
+    --output N      セッション出力の最新N行を表示（デフォルト: 20）
+    -h, --help      このヘルプを表示
 ```
 
 ### attach.sh - セッションアタッチ


### PR DESCRIPTION
## Summary
Closes #79

## Changes
- docs/SPECIFICATION.mdのstatus.shセクションを実際の実装に合わせて修正
- 引数（session-name, issue-number）を追加
- オプション（--output, -h/--help）を実際の実装に更新
- 未実装のオプション（--all, --json）を削除

## Testing
- git diffで変更内容を確認
- scripts/status.shのusage関数と比較し、一致を確認