### PR TITLE
docs: fix session_prefix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ worktree:
 
 # tmux設定
 tmux:
-  session_prefix: "pi-issue"
+  session_prefix: "pi"
   start_in_session: true
 
 # pi設定


### PR DESCRIPTION
## Summary
Closes #85

## Changes
- Fixed the `session_prefix` example in README.md from `"pi-issue"` to `"pi"`
- This matches the actual default value in lib/config.sh

## Explanation
Session names are generated as `{prefix}-issue-{number}`. With the default prefix `pi`, sessions are named like `pi-issue-42`. The previous example `pi-issue` was incorrect and would result in names like `pi-issue-issue-42`.

## Testing
- Verified the default value in lib/config.sh is `pi`
- Documentation-only change, no code testing required