### PR TITLE
docs: SPECIFICATION.mdのattach.shセクションに詳細説明を追加

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -175,6 +175,17 @@ Options:
 
 ```bash
 ./scripts/attach.sh <session-name|issue-number>
+
+Arguments:
+    session-name    tmuxセッション名（例: pi-issue-42）
+    issue-number    GitHub Issue番号（例: 42）
+
+Options:
+    -h, --help      このヘルプを表示
+
+Examples:
+    ./scripts/attach.sh pi-issue-42
+    ./scripts/attach.sh 42
 ```
 
 ### stop.sh - セッション停止


### PR DESCRIPTION
## Summary
Closes #86

## Changes
- docs/SPECIFICATION.md: attach.shセクションにArguments、Options、Examplesを追加
- stop.shやcleanup.shと同様の形式に統一

## Testing
- ドキュメント変更のみのため、構文テストは不要