### PR TITLE
feat: セッション終了時の自動クリーンアップ機能

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ pi-issue-runner/
 │   ├── status.sh      # 状態確認
 │   ├── attach.sh      # セッションアタッチ
 │   ├── stop.sh        # セッション停止
-│   └── cleanup.sh     # クリーンアップ
+│   ├── cleanup.sh     # クリーンアップ
+│   └── post-session.sh # セッション終了後処理
 ├── lib/               # 共通ライブラリ
 │   ├── config.sh      # 設定読み込み
 │   ├── github.sh      # GitHub CLI操作

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ scripts/run.sh 42 --reattach
 
 # 既存セッション/worktreeを削除して再作成
 scripts/run.sh 42 --force
+
+# セッション終了時に自動クリーンアップ
+scripts/run.sh 42 --auto-cleanup
+
+# バックグラウンド実行 + 自動クリーンアップ
+scripts/run.sh 42 --no-attach --auto-cleanup
+
+# クリーンアッププロンプトを無効化
+scripts/run.sh 42 --no-cleanup
 ```
 
 ### セッション管理
@@ -136,7 +145,8 @@ pi-issue-runner/
 │   ├── status.sh           # 状態確認
 │   ├── attach.sh           # セッションアタッチ
 │   ├── stop.sh             # セッション停止
-│   └── cleanup.sh          # クリーンアップ
+│   ├── cleanup.sh          # クリーンアップ
+│   └── post-session.sh     # セッション終了後処理
 ├── lib/
 │   ├── config.sh           # 設定読み込み
 │   ├── github.sh           # GitHub API操作

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,6 +17,8 @@ Options:
   --no-attach       バックグラウンドで起動
   --reattach        既存セッションにアタッチ
   --force           強制再作成
+  --auto-cleanup    セッション終了時に自動クリーンアップ
+  --no-cleanup      クリーンアッププロンプトを無効化
   --branch <name>   カスタムブランチ名
   --base <branch>   ベースブランチ
   --pi-args <args>  piへの追加引数

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -51,6 +51,13 @@ Pi Issue RunnerはGitHub Issueを入力として、Git worktreeとtmuxセッシ�
 - tmuxセッションの終了
 - ブランチの削除（`--delete-branch`オプション）
 
+### 7. 自動クリーンアップ
+
+- piセッション終了後のクリーンアッププロンプト表示（デフォルト）
+- `--auto-cleanup`オプションで確認なしの自動クリーンアップ
+- `--no-cleanup`オプションでクリーンアップを無効化
+- バックグラウンド実行（`--no-attach`）との併用サポート
+
 ## コアコンセプト
 
 ### 実行フロー
@@ -97,7 +104,8 @@ project-root/
     ├── status.sh            # 状態確認
     ├── attach.sh            # セッションアタッチ
     ├── stop.sh              # セッション停止
-    └── cleanup.sh           # クリーンアップ
+    ├── cleanup.sh           # クリーンアップ
+    └── post-session.sh      # セッション終了後処理
 ```
 
 ## 設定
@@ -144,8 +152,23 @@ Options:
     --no-attach     セッション作成後にアタッチしない
     --reattach      既存セッションがあればアタッチ
     --force         既存セッション/worktreeを削除して再作成
+    --auto-cleanup  セッション終了時に確認なしで自動クリーンアップ
+    --no-cleanup    セッション終了時のクリーンアッププロンプトを無効化
     --pi-args ARGS  piに渡す追加の引数
 ```
+
+### post-session.sh - セッション終了後処理
+
+```bash
+./scripts/post-session.sh <issue-number> [options]
+
+Options:
+    --auto          確認なしで自動クリーンアップ
+    --worktree PATH worktreeパス
+    --session NAME  セッション名
+```
+
+※ このスクリプトは通常、piセッション終了後に自動的に呼び出されます。
 
 ### list.sh - セッション一覧
 

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -59,10 +59,18 @@ extract_issue_number() {
 }
 
 # セッションを作成してコマンドを実行
+# 引数:
+#   $1 - session_name: セッション名
+#   $2 - working_dir: 作業ディレクトリ
+#   $3 - command: 実行するコマンド
+#   $4 - cleanup_mode: クリーンアップモード (optional: "auto", "prompt", "none")
+#   $5 - issue_number: Issue番号 (cleanup_mode使用時に必要)
 create_session() {
     local session_name="$1"
     local working_dir="$2"
     local command="$3"
+    local cleanup_mode="${4:-none}"
+    local issue_number="${5:-}"
     
     check_tmux || return 1
     
@@ -74,12 +82,33 @@ create_session() {
     log_info "Creating tmux session: $session_name"
     log_debug "Working directory: $working_dir"
     log_debug "Command: $command"
+    log_debug "Cleanup mode: $cleanup_mode"
     
     # デタッチ状態でセッション作成
     tmux new-session -d -s "$session_name" -c "$working_dir"
     
-    # コマンドを送信
-    tmux send-keys -t "$session_name" "$command" Enter
+    # クリーンアップモードが設定されている場合、セッション終了後に処理を実行
+    if [[ "$cleanup_mode" != "none" && -n "$issue_number" ]]; then
+        # remain-on-exitを有効にして、メインコマンド終了後もセッションを維持
+        tmux set-option -t "$session_name" remain-on-exit on
+        
+        # スクリプトディレクトリを取得
+        local script_dir
+        script_dir="$(cd "$SCRIPT_DIR/.." && pwd)/scripts"
+        
+        # post-session.shへの引数を構築
+        local post_session_args="$issue_number --session \"$session_name\" --worktree \"$working_dir\""
+        if [[ "$cleanup_mode" == "auto" ]]; then
+            post_session_args="$post_session_args --auto"
+        fi
+        
+        # メインコマンドとpost-session.shを連続実行
+        local full_command="$command; \"$script_dir/post-session.sh\" $post_session_args"
+        tmux send-keys -t "$session_name" "$full_command" Enter
+    else
+        # クリーンアップなしの場合は通常実行
+        tmux send-keys -t "$session_name" "$command" Enter
+    fi
     
     log_info "Session created: $session_name"
 }

--- a/scripts/post-session.sh
+++ b/scripts/post-session.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# post-session.sh - piセッション終了後の処理
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/tmux.sh"
+source "$SCRIPT_DIR/../lib/worktree.sh"
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") <issue-number> [options]
+
+Arguments:
+    issue-number    GitHub Issue番号
+
+Options:
+    --auto          確認なしで自動クリーンアップ
+    --worktree PATH worktreeパス
+    --session NAME  セッション名
+    -h, --help      このヘルプを表示
+
+This script is typically called automatically after a pi session ends.
+EOF
+}
+
+# ユーザーに確認プロンプトを表示
+prompt_cleanup() {
+    local issue_number="$1"
+    local session_name="$2"
+    local worktree_path="$3"
+    
+    echo ""
+    echo "==================================="
+    echo "タスクが完了しました。"
+    echo "Issue: #$issue_number"
+    echo "Session: $session_name"
+    echo "Worktree: $worktree_path"
+    echo "==================================="
+    echo ""
+    
+    # ユーザー入力を待つ
+    local response
+    read -r -p "クリーンアップしますか？ [Y/n]: " response
+    
+    # デフォルトはYes
+    case "$response" in
+        [nN]|[nN][oO])
+            echo ""
+            echo "クリーンアップをスキップしました。"
+            echo "手動でクリーンアップする場合: $SCRIPT_DIR/cleanup.sh $issue_number"
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# クリーンアップを実行
+do_cleanup() {
+    local issue_number="$1"
+    local session_name="$2"
+    local worktree_path="$3"
+    
+    log_info "クリーンアップを実行中..."
+    
+    # Worktree削除
+    if [[ -n "$worktree_path" && -d "$worktree_path" ]]; then
+        log_info "Removing worktree: $worktree_path"
+        git worktree remove --force "$worktree_path" 2>/dev/null || {
+            log_warn "Failed to remove worktree automatically. Manual cleanup may be required."
+        }
+    fi
+    
+    # セッション削除（自分自身のセッションを終了）
+    if [[ -n "$session_name" ]] && session_exists "$session_name"; then
+        log_info "Killing session: $session_name"
+        # セッション終了は最後に行う（自分自身が動作中なので）
+        tmux kill-session -t "$session_name" 2>/dev/null || true
+    fi
+    
+    log_info "クリーンアップ完了"
+}
+
+main() {
+    local issue_number=""
+    local auto_cleanup=false
+    local worktree_path=""
+    local session_name=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --auto)
+                auto_cleanup=true
+                shift
+                ;;
+            --worktree)
+                worktree_path="$2"
+                shift 2
+                ;;
+            --session)
+                session_name="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage >&2
+                exit 1
+                ;;
+            *)
+                if [[ -z "$issue_number" ]]; then
+                    issue_number="$1"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$issue_number" ]]; then
+        log_error "Issue number is required"
+        usage >&2
+        exit 1
+    fi
+
+    load_config
+
+    # セッション名が指定されていない場合は生成
+    if [[ -z "$session_name" ]]; then
+        session_name="$(generate_session_name "$issue_number")"
+    fi
+
+    # worktreeパスが指定されていない場合は検索
+    if [[ -z "$worktree_path" ]]; then
+        worktree_path="$(find_worktree_by_issue "$issue_number" 2>/dev/null)" || worktree_path=""
+    fi
+
+    if [[ "$auto_cleanup" == "true" ]]; then
+        # 自動クリーンアップモード
+        log_info "Auto-cleanup mode: cleaning up Issue #$issue_number"
+        do_cleanup "$issue_number" "$session_name" "$worktree_path"
+    else
+        # プロンプト表示モード
+        if prompt_cleanup "$issue_number" "$session_name" "$worktree_path"; then
+            do_cleanup "$issue_number" "$session_name" "$worktree_path"
+        fi
+    fi
+}
+
+main "$@"

--- a/test/post_session_test.sh
+++ b/test/post_session_test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# post-session.sh のテスト
+
+# テスト用にエラーで終了しないように
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# lib に必要な依存関係
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/tmux.sh"
+source "$SCRIPT_DIR/../lib/worktree.sh"
+
+# テスト用にエラーで終了しないように再設定
+set +e
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_contains() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected to contain: '$expected'"
+        echo "  Actual: '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_success() {
+    local description="$1"
+    local exit_code="$2"
+    if [[ "$exit_code" -eq 0 ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description (exit code: $exit_code)"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_failure() {
+    local description="$1"
+    local exit_code="$2"
+    if [[ "$exit_code" -ne 0 ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description (expected failure but got success)"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# ===================
+# post-session.sh 基本テスト
+# ===================
+echo "=== post-session.sh basic tests ==="
+
+# スクリプトの存在確認
+if [[ -f "$SCRIPT_DIR/../scripts/post-session.sh" ]]; then
+    echo "✓ post-session.sh exists"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ post-session.sh not found"
+    ((TESTS_FAILED++)) || true
+fi
+
+# 実行可能か確認
+if [[ -x "$SCRIPT_DIR/../scripts/post-session.sh" ]]; then
+    echo "✓ post-session.sh is executable"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ post-session.sh is not executable"
+    ((TESTS_FAILED++)) || true
+fi
+
+# 構文チェック
+bash -n "$SCRIPT_DIR/../scripts/post-session.sh" 2>/dev/null
+exit_code=$?
+assert_success "post-session.sh has valid syntax" "$exit_code"
+
+# ヘルプ表示
+output=$("$SCRIPT_DIR/../scripts/post-session.sh" --help 2>&1)
+exit_code=$?
+assert_success "post-session.sh --help exits with 0" "$exit_code"
+assert_contains "post-session.sh --help shows usage" "Usage:" "$output"
+assert_contains "post-session.sh --help shows --auto option" "--auto" "$output"
+assert_contains "post-session.sh --help shows --worktree option" "--worktree" "$output"
+assert_contains "post-session.sh --help shows --session option" "--session" "$output"
+
+# 引数なしで実行（エラーになるべき）
+output=$("$SCRIPT_DIR/../scripts/post-session.sh" 2>&1)
+exit_code=$?
+assert_failure "post-session.sh without arguments fails" "$exit_code"
+assert_contains "post-session.sh without arguments shows error" "Issue number is required" "$output"
+
+# ===================
+# オプションパースのテスト
+# ===================
+echo ""
+echo "=== Option parsing tests ==="
+
+# 不明なオプション
+output=$("$SCRIPT_DIR/../scripts/post-session.sh" --unknown-option 2>&1)
+exit_code=$?
+assert_failure "post-session.sh with unknown option fails" "$exit_code"
+assert_contains "post-session.sh shows error for unknown option" "Unknown option" "$output"
+
+# ===================
+# run.sh のオプションテスト
+# ===================
+echo ""
+echo "=== run.sh option tests ==="
+
+# run.shの構文チェック
+bash -n "$SCRIPT_DIR/../scripts/run.sh" 2>/dev/null
+exit_code=$?
+assert_success "run.sh has valid syntax" "$exit_code"
+
+# ヘルプに--auto-cleanupが含まれているか
+output=$("$SCRIPT_DIR/../scripts/run.sh" --help 2>&1)
+assert_contains "run.sh --help shows --auto-cleanup option" "--auto-cleanup" "$output"
+assert_contains "run.sh --help shows --no-cleanup option" "--no-cleanup" "$output"
+
+# ===================
+# lib/tmux.sh create_session テスト
+# ===================
+echo ""
+echo "=== lib/tmux.sh create_session tests ==="
+
+# tmux.shの構文チェック
+bash -n "$SCRIPT_DIR/../lib/tmux.sh" 2>/dev/null
+exit_code=$?
+assert_success "lib/tmux.sh has valid syntax" "$exit_code"
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Closes #100

## Changes
- Added `--auto-cleanup` option to `scripts/run.sh` for automatic cleanup after session ends
- Added `--no-cleanup` option to disable cleanup prompt
- Created `scripts/post-session.sh` for post-session processing
- Updated `lib/tmux.sh` `create_session()` to support cleanup modes
- Default behavior: show cleanup prompt after pi session ends
- Updated documentation (README.md, SKILL.md, docs/SPECIFICATION.md, AGENTS.md)

## New Options
| Option | Description |
|--------|-------------|
| `--auto-cleanup` | Automatically cleanup worktree and session after pi exits (no prompt) |
| `--no-cleanup` | Disable cleanup prompt (keep worktree and session after pi exits) |

## Testing
- All 134 tests pass
- Added `test/post_session_test.sh` with 16 new tests
- Verified syntax with `bash -n` for all modified scripts
- Verified documentation consistency across all docs

## Usage Examples
```bash
# Default: show cleanup prompt after session ends
./scripts/run.sh 42

# Auto cleanup (no prompt)
./scripts/run.sh 42 --auto-cleanup

# Background + auto cleanup
./scripts/run.sh 42 --no-attach --auto-cleanup

# Disable cleanup completely
./scripts/run.sh 42 --no-cleanup
```