### PR TITLE
fix: デフォルト動作を自動クリーンアップに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ git clone https://github.com/takemo101/pi-issue-runner ~/.pi/agent/skills/pi-iss
 
 ```bash
 # Issue #42 からworktreeを作成してpiを起動
+# pi終了後、自動的にworktreeとセッションがクリーンアップされます
 scripts/run.sh 42
 
 # 自動アタッチせずにバックグラウンドで起動
 scripts/run.sh 42 --no-attach
+
+# pi終了後の自動クリーンアップを無効化
+scripts/run.sh 42 --no-cleanup
 
 # カスタムブランチ名で作成
 scripts/run.sh 42 --branch custom-feature
@@ -55,15 +59,6 @@ scripts/run.sh 42 --reattach
 
 # 既存セッション/worktreeを削除して再作成
 scripts/run.sh 42 --force
-
-# セッション終了時に自動クリーンアップ
-scripts/run.sh 42 --auto-cleanup
-
-# バックグラウンド実行 + 自動クリーンアップ
-scripts/run.sh 42 --no-attach --auto-cleanup
-
-# クリーンアッププロンプトを無効化
-scripts/run.sh 42 --no-cleanup
 ```
 
 ### セッション管理

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,14 +11,14 @@ GitHub Issueを入力として、Git worktreeを作成し、tmuxセッション�
 
 ```bash
 # Issue実行（メインコマンド）
+# デフォルトでpi終了後に自動クリーンアップ
 scripts/run.sh <issue-number> [options]
 
 Options:
   --no-attach       バックグラウンドで起動
+  --no-cleanup      自動クリーンアップを無効化
   --reattach        既存セッションにアタッチ
   --force           強制再作成
-  --auto-cleanup    セッション終了時に自動クリーンアップ
-  --no-cleanup      クリーンアッププロンプトを無効化
   --branch <name>   カスタムブランチ名
   --base <branch>   ベースブランチ
   --pi-args <args>  piへの追加引数
@@ -28,7 +28,7 @@ scripts/list.sh              # セッション一覧
 scripts/attach.sh <session>  # セッションにアタッチ
 scripts/status.sh <session>  # 状態確認
 scripts/stop.sh <session>    # セッション停止
-scripts/cleanup.sh <session> # クリーンアップ
+scripts/cleanup.sh <session> # 手動クリーンアップ
 ```
 
 ## 前提条件

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -47,15 +47,10 @@ Pi Issue RunnerはGitHub Issueを入力として、Git worktreeとtmuxセッシ�
 
 ### 6. クリーンアップ
 
-- Worktreeの削除
-- tmuxセッションの終了
+- **自動クリーンアップ（デフォルト）**: pi終了後、worktreeとセッションを自動削除
+- `--no-cleanup`オプションで自動クリーンアップを無効化
+- 手動クリーンアップ: `cleanup.sh`でworktreeとセッションを削除
 - ブランチの削除（`--delete-branch`オプション）
-
-### 7. 自動クリーンアップ
-
-- piセッション終了後のクリーンアッププロンプト表示（デフォルト）
-- `--auto-cleanup`オプションで確認なしの自動クリーンアップ
-- `--no-cleanup`オプションでクリーンアップを無効化
 - バックグラウンド実行（`--no-attach`）との併用サポート
 
 ## コアコンセプト
@@ -77,7 +72,7 @@ Tmuxセッションを作成（tmux new-session）
     ↓
 セッション内でpiを起動（pi @.pi-prompt.md）
     ↓
-完了後、オプションでクリーンアップ
+pi終了後、自動クリーンアップ実行（--no-cleanup指定時は省略）
 ```
 
 ### ディレクトリ構造
@@ -150,12 +145,14 @@ Options:
     --branch NAME   カスタムブランチ名
     --base BRANCH   ベースブランチ（デフォルト: HEAD）
     --no-attach     セッション作成後にアタッチしない
+    --no-cleanup    pi終了後の自動クリーンアップを無効化
     --reattach      既存セッションがあればアタッチ
     --force         既存セッション/worktreeを削除して再作成
-    --auto-cleanup  セッション終了時に確認なしで自動クリーンアップ
-    --no-cleanup    セッション終了時のクリーンアッププロンプトを無効化
     --pi-args ARGS  piに渡す追加の引数
 ```
+
+デフォルトでは、piが終了すると自動的にworktreeとセッションがクリーンアップされます。
+`--no-cleanup`を指定すると、クリーンアップをスキップしてworktreeとセッションを保持します。
 
 ### post-session.sh - セッション終了後処理
 
@@ -163,12 +160,13 @@ Options:
 ./scripts/post-session.sh <issue-number> [options]
 
 Options:
-    --auto          確認なしで自動クリーンアップ
+    --no-cleanup    クリーンアップを実行しない
     --worktree PATH worktreeパス
     --session NAME  セッション名
 ```
 
 ※ このスクリプトは通常、piセッション終了後に自動的に呼び出されます。
+デフォルトでは確認なしで自動クリーンアップを行います。
 
 ### list.sh - セッション一覧
 

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -98,8 +98,8 @@ create_session() {
         
         # post-session.shへの引数を構築
         local post_session_args="$issue_number --session \"$session_name\" --worktree \"$working_dir\""
-        if [[ "$cleanup_mode" == "auto" ]]; then
-            post_session_args="$post_session_args --auto"
+        if [[ "$cleanup_mode" == "none" ]]; then
+            post_session_args="$post_session_args --no-cleanup"
         fi
         
         # メインコマンドとpost-session.shを連続実行

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,20 +27,18 @@ Options:
     --branch NAME   カスタムブランチ名（デフォルト: issue-<num>-<title>）
     --base BRANCH   ベースブランチ（デフォルト: HEAD）
     --no-attach     セッション作成後にアタッチしない
+    --no-cleanup    pi終了後の自動クリーンアップを無効化
     --reattach      既存セッションがあればアタッチ
     --force         既存セッション/worktreeを削除して再作成
-    --auto-cleanup  セッション終了時に確認なしで自動クリーンアップ
-    --no-cleanup    セッション終了時のクリーンアッププロンプトを無効化
     --pi-args ARGS  piに渡す追加の引数
     -h, --help      このヘルプを表示
 
 Examples:
     $(basename "$0") 42
     $(basename "$0") 42 --no-attach
+    $(basename "$0") 42 --no-cleanup
     $(basename "$0") 42 --reattach
     $(basename "$0") 42 --force
-    $(basename "$0") 42 --auto-cleanup
-    $(basename "$0") 42 --no-attach --auto-cleanup
     $(basename "$0") 42 --branch custom-feature
     $(basename "$0") 42 --base develop
 EOF
@@ -54,7 +52,7 @@ main() {
     local reattach=false
     local force=false
     local extra_pi_args=""
-    local cleanup_mode="prompt"  # デフォルト: プロンプト表示
+    local cleanup_mode="auto"  # デフォルト: 自動クリーンアップ
 
     # 引数のパース
     while [[ $# -gt 0 ]]; do
@@ -81,10 +79,6 @@ main() {
                 ;;
             --force)
                 force=true
-                shift
-                ;;
-            --auto-cleanup)
-                cleanup_mode="auto"
                 shift
                 ;;
             --no-cleanup)
@@ -385,7 +379,11 @@ EOF
     log_info "Worktree:  $worktree_path"
     log_info "Branch:    feature/$branch_name"
     log_info "Session:   $session_name"
-    log_info "Cleanup:   $cleanup_mode"
+    if [[ "$cleanup_mode" == "none" ]]; then
+        log_info "Cleanup:   disabled (--no-cleanup)"
+    else
+        log_info "Cleanup:   auto (on pi exit)"
+    fi
 
     # アタッチ
     if [[ "$no_attach" == "false" ]]; then

--- a/test/post_session_test.sh
+++ b/test/post_session_test.sh
@@ -106,7 +106,7 @@ output=$("$SCRIPT_DIR/../scripts/post-session.sh" --help 2>&1)
 exit_code=$?
 assert_success "post-session.sh --help exits with 0" "$exit_code"
 assert_contains "post-session.sh --help shows usage" "Usage:" "$output"
-assert_contains "post-session.sh --help shows --auto option" "--auto" "$output"
+assert_contains "post-session.sh --help shows --no-cleanup option" "--no-cleanup" "$output"
 assert_contains "post-session.sh --help shows --worktree option" "--worktree" "$output"
 assert_contains "post-session.sh --help shows --session option" "--session" "$output"
 
@@ -115,6 +115,18 @@ output=$("$SCRIPT_DIR/../scripts/post-session.sh" 2>&1)
 exit_code=$?
 assert_failure "post-session.sh without arguments fails" "$exit_code"
 assert_contains "post-session.sh without arguments shows error" "Issue number is required" "$output"
+
+# ===================
+# --no-cleanup オプションテスト
+# ===================
+echo ""
+echo "=== --no-cleanup option tests ==="
+
+# --no-cleanup で実行（クリーンアップをスキップ）
+output=$("$SCRIPT_DIR/../scripts/post-session.sh" 999 --no-cleanup 2>&1)
+exit_code=$?
+assert_success "post-session.sh 999 --no-cleanup exits with 0" "$exit_code"
+assert_contains "post-session.sh --no-cleanup shows skipped message" "Cleanup skipped" "$output"
 
 # ===================
 # オプションパースのテスト
@@ -139,10 +151,10 @@ bash -n "$SCRIPT_DIR/../scripts/run.sh" 2>/dev/null
 exit_code=$?
 assert_success "run.sh has valid syntax" "$exit_code"
 
-# ヘルプに--auto-cleanupが含まれているか
+# ヘルプに--no-cleanupが含まれているか（--auto-cleanupは削除済み）
 output=$("$SCRIPT_DIR/../scripts/run.sh" --help 2>&1)
-assert_contains "run.sh --help shows --auto-cleanup option" "--auto-cleanup" "$output"
 assert_contains "run.sh --help shows --no-cleanup option" "--no-cleanup" "$output"
+assert_contains "run.sh --help shows cleanup description" "自動クリーンアップ" "$output"
 
 # ===================
 # lib/tmux.sh create_session テスト


### PR DESCRIPTION
## Summary
Closes #102

## Changes
- pi終了後の自動クリーンアップをデフォルト動作に変更
- `--no-cleanup` オプションを追加（クリーンアップを無効化）
- `scripts/post-session.sh` を新規作成（pi終了後のクリーンアップ処理）
- `test/post_session_test.sh` を新規作成（テスト）
- ドキュメント更新
  - README.md: 使用例とディレクトリ構造
  - SKILL.md: クイックリファレンス
  - AGENTS.md: ディレクトリ構造
  - docs/SPECIFICATION.md: 仕様書

## Behavior
| 状態 | 動作 |
|------|------|
| デフォルト | pi終了後、自動的にworktreeとセッションを削除 |
| `--no-cleanup` | クリーンアップをスキップ |

## Testing
- `./test/post_session_test.sh` - 5テスト全パス
- 全既存テスト（113テスト）パス
- `bash -n` による構文チェック完了