### PR TITLE
feat: ワークフローエンジン（lib/workflow.sh）の実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 ## 技術スタック
 
 - **言語**: Bash 4.0以上
-- **依存ツール**: `gh` (GitHub CLI), `tmux`, `git`, `jq`
+- **依存ツール**: `gh` (GitHub CLI), `tmux`, `git`, `jq`, `yq` (YAMLパーサー、オプション)
 - **テストフレームワーク**: Bats (Bash Automated Testing System)
 
 ## ディレクトリ構造
@@ -29,6 +29,7 @@ pi-issue-runner/
 │   ├── github.sh      # GitHub CLI操作
 │   ├── log.sh         # ログ出力
 │   ├── tmux.sh        # tmux操作
+│   ├── workflow.sh    # ワークフローエンジン
 │   └── worktree.sh    # Git worktree操作
 ├── docs/              # ドキュメント
 ├── test/              # 単体テスト（*_test.sh形式）

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ which pi
 
 # jq (JSON処理)
 which jq
+
+# yq (YAML処理、オプション - ワークフローのカスタマイズに必要)
+which yq
 ```
 
 ## インストール
@@ -142,6 +145,7 @@ pi-issue-runner/
 │   ├── github.sh           # GitHub API操作
 │   ├── log.sh              # ログ出力
 │   ├── tmux.sh             # tmux操作
+│   ├── workflow.sh         # ワークフローエンジン
 │   └── worktree.sh         # Git worktree操作
 ├── docs/                    # ドキュメント
 ├── test/                    # 単体テスト

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -90,6 +90,7 @@ project-root/
 │   ├── github.sh            # GitHub CLI操作
 │   ├── log.sh               # ログ出力
 │   ├── tmux.sh              # tmux操作
+│   ├── workflow.sh          # ワークフローエンジン
 │   └── worktree.sh          # Git worktree操作
 └── scripts/                 # 実行スクリプト
     ├── run.sh               # タスク起動
@@ -230,7 +231,7 @@ Options:
 
 ### オプション
 
-- **yq** (YAML設定ファイルの高度な処理)
+- **yq** (YAMLパーサー、ワークフローカスタマイズに必要)
 
 ## 非機能要件
 

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# workflow.sh - ワークフローエンジン（YAMLワークフロー定義の読み込みと実行）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/log.sh"
+
+# ビルトインワークフロー定義
+# workflows/ ディレクトリが存在しない場合に使用
+_BUILTIN_WORKFLOW_DEFAULT="plan implement review merge"
+_BUILTIN_WORKFLOW_SIMPLE="implement merge"
+
+# ビルトインエージェントプロンプト（最小限）
+_BUILTIN_AGENT_PLAN='Plan the implementation for issue #{{issue_number}}.
+Read the issue description and create an implementation plan.'
+
+_BUILTIN_AGENT_IMPLEMENT='Implement the changes for issue #{{issue_number}}.
+Follow the plan and make the necessary code changes.'
+
+_BUILTIN_AGENT_REVIEW='Review the implementation for issue #{{issue_number}}.
+Check code quality, tests, and documentation.'
+
+_BUILTIN_AGENT_MERGE='Create a PR and merge for issue #{{issue_number}}.
+Push changes and create a pull request.'
+
+# ===================
+# 依存チェック
+# ===================
+
+# yq の存在確認
+check_yq() {
+    if command -v yq &> /dev/null; then
+        return 0
+    else
+        log_debug "yq not found, using builtin workflow"
+        return 1
+    fi
+}
+
+# ===================
+# ファイル検索
+# ===================
+
+# ワークフローファイル検索（優先順位順）
+# 優先順位:
+#   1. .pi-runner.yaml（プロジェクトルート）の workflow セクション
+#   2. .pi/workflow.yaml
+#   3. workflows/default.yaml
+#   4. ビルトイン default
+find_workflow_file() {
+    local workflow_name="${1:-default}"
+    local project_root="${2:-.}"
+    
+    # 1. .pi-runner.yaml の存在確認
+    if [[ -f "$project_root/.pi-runner.yaml" ]]; then
+        if check_yq && yq -e '.workflow' "$project_root/.pi-runner.yaml" &>/dev/null; then
+            echo "$project_root/.pi-runner.yaml"
+            return 0
+        fi
+    fi
+    
+    # 2. .pi/workflow.yaml
+    if [[ -f "$project_root/.pi/workflow.yaml" ]]; then
+        echo "$project_root/.pi/workflow.yaml"
+        return 0
+    fi
+    
+    # 3. workflows/{name}.yaml
+    if [[ -f "$project_root/workflows/${workflow_name}.yaml" ]]; then
+        echo "$project_root/workflows/${workflow_name}.yaml"
+        return 0
+    fi
+    
+    # 4. ビルトイン（特殊な値で返す）
+    echo "builtin:${workflow_name}"
+    return 0
+}
+
+# エージェントファイル検索
+# 優先順位:
+#   1. agents/{step}.md
+#   2. .pi/agents/{step}.md
+#   3. ビルトイン
+find_agent_file() {
+    local step_name="$1"
+    local project_root="${2:-.}"
+    
+    # 1. agents/{step}.md
+    if [[ -f "$project_root/agents/${step_name}.md" ]]; then
+        echo "$project_root/agents/${step_name}.md"
+        return 0
+    fi
+    
+    # 2. .pi/agents/{step}.md
+    if [[ -f "$project_root/.pi/agents/${step_name}.md" ]]; then
+        echo "$project_root/.pi/agents/${step_name}.md"
+        return 0
+    fi
+    
+    # 3. ビルトイン
+    echo "builtin:${step_name}"
+    return 0
+}
+
+# ===================
+# ワークフロー読み込み
+# ===================
+
+# ワークフローからステップ一覧を取得
+get_workflow_steps() {
+    local workflow_file="$1"
+    
+    # ビルトインの場合
+    if [[ "$workflow_file" == builtin:* ]]; then
+        local workflow_name="${workflow_file#builtin:}"
+        case "$workflow_name" in
+            simple)
+                echo "$_BUILTIN_WORKFLOW_SIMPLE"
+                ;;
+            *)
+                echo "$_BUILTIN_WORKFLOW_DEFAULT"
+                ;;
+        esac
+        return 0
+    fi
+    
+    # ファイルが存在しない場合
+    if [[ ! -f "$workflow_file" ]]; then
+        log_error "Workflow file not found: $workflow_file"
+        return 1
+    fi
+    
+    # yq が利用可能か確認
+    if ! check_yq; then
+        log_warn "yq not available, using builtin workflow"
+        echo "$_BUILTIN_WORKFLOW_DEFAULT"
+        return 0
+    fi
+    
+    # YAMLからstepsを読み込む
+    # .pi-runner.yaml の場合は .workflow.steps を参照
+    local steps
+    if [[ "$workflow_file" == *".pi-runner.yaml" ]]; then
+        steps=$(yq -r '.workflow.steps[]' "$workflow_file" 2>/dev/null | tr '\n' ' ' || echo "")
+    else
+        steps=$(yq -r '.steps[]' "$workflow_file" 2>/dev/null | tr '\n' ' ' || echo "")
+    fi
+    
+    # 末尾のスペースを削除
+    steps="${steps% }"
+    
+    if [[ -z "$steps" ]]; then
+        log_warn "No steps found in workflow, using builtin"
+        echo "$_BUILTIN_WORKFLOW_DEFAULT"
+        return 0
+    fi
+    
+    echo "$steps"
+}
+
+# ===================
+# テンプレート処理
+# ===================
+
+# テンプレート変数展開
+# 対応変数:
+#   {{issue_number}} - Issue番号
+#   {{branch_name}} - ブランチ名
+#   {{worktree_path}} - ワークツリーパス
+#   {{step_name}} - 現在のステップ名
+#   {{workflow_name}} - ワークフロー名
+render_template() {
+    local template="$1"
+    local issue_number="${2:-}"
+    local branch_name="${3:-}"
+    local worktree_path="${4:-}"
+    local step_name="${5:-}"
+    local workflow_name="${6:-default}"
+    
+    local result="$template"
+    
+    # 変数展開
+    result="${result//\{\{issue_number\}\}/$issue_number}"
+    result="${result//\{\{branch_name\}\}/$branch_name}"
+    result="${result//\{\{worktree_path\}\}/$worktree_path}"
+    result="${result//\{\{step_name\}\}/$step_name}"
+    result="${result//\{\{workflow_name\}\}/$workflow_name}"
+    
+    echo "$result"
+}
+
+# エージェントプロンプトを取得
+get_agent_prompt() {
+    local agent_file="$1"
+    local issue_number="${2:-}"
+    local branch_name="${3:-}"
+    local worktree_path="${4:-}"
+    local step_name="${5:-}"
+    
+    local prompt
+    
+    # ビルトインの場合
+    if [[ "$agent_file" == builtin:* ]]; then
+        local agent_name="${agent_file#builtin:}"
+        case "$agent_name" in
+            plan)
+                prompt="$_BUILTIN_AGENT_PLAN"
+                ;;
+            implement)
+                prompt="$_BUILTIN_AGENT_IMPLEMENT"
+                ;;
+            review)
+                prompt="$_BUILTIN_AGENT_REVIEW"
+                ;;
+            merge)
+                prompt="$_BUILTIN_AGENT_MERGE"
+                ;;
+            *)
+                log_warn "Unknown builtin agent: $agent_name, using implement"
+                prompt="$_BUILTIN_AGENT_IMPLEMENT"
+                ;;
+        esac
+    else
+        # ファイルから読み込み
+        if [[ ! -f "$agent_file" ]]; then
+            log_error "Agent file not found: $agent_file"
+            return 1
+        fi
+        prompt=$(cat "$agent_file")
+    fi
+    
+    # テンプレート変数展開
+    render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name"
+}
+
+# ===================
+# ステップ実行
+# ===================
+
+# ステップ結果の定数
+STEP_RESULT_DONE="DONE"
+STEP_RESULT_BLOCKED="BLOCKED"
+STEP_RESULT_FIX_NEEDED="FIX_NEEDED"
+STEP_RESULT_UNKNOWN="UNKNOWN"
+
+# エージェント出力から結果を判定
+parse_step_result() {
+    local output="$1"
+    
+    # 出力から結果マーカーを検出
+    if echo "$output" | grep -q '\[DONE\]'; then
+        echo "$STEP_RESULT_DONE"
+    elif echo "$output" | grep -q '\[BLOCKED\]'; then
+        echo "$STEP_RESULT_BLOCKED"
+    elif echo "$output" | grep -q '\[FIX_NEEDED\]'; then
+        echo "$STEP_RESULT_FIX_NEEDED"
+    else
+        # マーカーがない場合はDONEとみなす（後方互換性）
+        echo "$STEP_RESULT_DONE"
+    fi
+}
+
+# 単一ステップ実行
+# 注: この関数はエージェントプロンプトを返す（実際の実行は呼び出し元で行う）
+run_step() {
+    local step_name="$1"
+    local issue_number="${2:-}"
+    local branch_name="${3:-}"
+    local worktree_path="${4:-}"
+    local project_root="${5:-.}"
+    
+    log_info "Running step: $step_name"
+    
+    # エージェントファイル検索
+    local agent_file
+    agent_file=$(find_agent_file "$step_name" "$project_root")
+    log_debug "Agent file: $agent_file"
+    
+    # プロンプト取得
+    local prompt
+    prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step_name")
+    
+    echo "$prompt"
+}
+
+# ===================
+# ワークフロー実行
+# ===================
+
+# ワークフロー全体実行
+# この関数は実行計画を出力する（実際の実行は呼び出し元で行う）
+run_workflow() {
+    local workflow_name="${1:-default}"
+    local issue_number="${2:-}"
+    local branch_name="${3:-}"
+    local worktree_path="${4:-}"
+    local project_root="${5:-.}"
+    
+    log_info "Starting workflow: $workflow_name"
+    
+    # ワークフローファイル検索
+    local workflow_file
+    workflow_file=$(find_workflow_file "$workflow_name" "$project_root")
+    log_debug "Workflow file: $workflow_file"
+    
+    # ステップ一覧取得
+    local steps
+    steps=$(get_workflow_steps "$workflow_file")
+    log_info "Steps: $steps"
+    
+    # 各ステップの情報を出力
+    local step_index=0
+    for step in $steps; do
+        echo "step:$step_index:$step"
+        ((step_index++)) || true
+    done
+    
+    echo "total:$step_index"
+}
+
+# ワークフローステップを配列として取得
+get_workflow_steps_array() {
+    local workflow_name="${1:-default}"
+    local project_root="${2:-.}"
+    
+    local workflow_file
+    workflow_file=$(find_workflow_file "$workflow_name" "$project_root")
+    
+    get_workflow_steps "$workflow_file"
+}

--- a/test/workflow_test.sh
+++ b/test/workflow_test.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# workflow.sh のテスト
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/workflow.sh"
+
+# テストカウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# テスト用一時ディレクトリ
+TEST_DIR=""
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_contains() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == *"$expected"* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected to contain: '$expected'"
+        echo "  Actual: '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_not_empty() {
+    local description="$1"
+    local actual="$2"
+    if [[ -n "$actual" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description (value is empty)"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_file_exists() {
+    local description="$1"
+    local file_path="$2"
+    if [[ -f "$file_path" ]] || [[ "$file_path" == builtin:* ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description (file not found: $file_path)"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# テスト用ディレクトリのセットアップ
+setup_test_dir() {
+    TEST_DIR=$(mktemp -d)
+    mkdir -p "$TEST_DIR/workflows"
+    mkdir -p "$TEST_DIR/agents"
+    mkdir -p "$TEST_DIR/.pi/agents"
+}
+
+# テスト用ディレクトリのクリーンアップ
+cleanup_test_dir() {
+    if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+# テスト終了時にクリーンアップ
+trap cleanup_test_dir EXIT
+
+# ===================
+# check_yq テスト
+# ===================
+echo "=== check_yq tests ==="
+
+if command -v yq &>/dev/null; then
+    check_yq
+    assert_equals "check_yq returns 0 when yq is available" "0" "$?"
+else
+    ! check_yq
+    assert_equals "check_yq returns 1 when yq is not available" "0" "$?"
+fi
+
+# ===================
+# find_workflow_file テスト
+# ===================
+echo ""
+echo "=== find_workflow_file tests ==="
+
+setup_test_dir
+
+# ビルトインへのフォールバック
+result=$(find_workflow_file "default" "$TEST_DIR")
+assert_equals "Returns builtin when no file exists" "builtin:default" "$result"
+
+# workflows/default.yaml が存在する場合
+cat > "$TEST_DIR/workflows/default.yaml" << 'EOF'
+name: default
+steps:
+  - plan
+  - implement
+EOF
+
+result=$(find_workflow_file "default" "$TEST_DIR")
+assert_equals "Returns workflows/default.yaml when exists" "$TEST_DIR/workflows/default.yaml" "$result"
+
+# .pi/workflow.yaml が優先される
+cat > "$TEST_DIR/.pi/workflow.yaml" << 'EOF'
+name: custom
+steps:
+  - implement
+  - merge
+EOF
+
+result=$(find_workflow_file "default" "$TEST_DIR")
+assert_equals ".pi/workflow.yaml takes priority" "$TEST_DIR/.pi/workflow.yaml" "$result"
+
+cleanup_test_dir
+
+# ===================
+# find_agent_file テスト
+# ===================
+echo ""
+echo "=== find_agent_file tests ==="
+
+setup_test_dir
+
+# ビルトインへのフォールバック
+result=$(find_agent_file "plan" "$TEST_DIR")
+assert_equals "Returns builtin when no agent file exists" "builtin:plan" "$result"
+
+# agents/plan.md が存在する場合
+echo "Custom plan agent" > "$TEST_DIR/agents/plan.md"
+result=$(find_agent_file "plan" "$TEST_DIR")
+assert_equals "Returns agents/plan.md when exists" "$TEST_DIR/agents/plan.md" "$result"
+
+# .pi/agents/plan.md は agents/ より低優先度
+mkdir -p "$TEST_DIR/.pi/agents"
+echo "Pi plan agent" > "$TEST_DIR/.pi/agents/plan.md"
+result=$(find_agent_file "plan" "$TEST_DIR")
+assert_equals "agents/ takes priority over .pi/agents/" "$TEST_DIR/agents/plan.md" "$result"
+
+# agents/がない場合は .pi/agents/ を使用
+rm "$TEST_DIR/agents/plan.md"
+result=$(find_agent_file "plan" "$TEST_DIR")
+assert_equals "Falls back to .pi/agents/ when agents/ not found" "$TEST_DIR/.pi/agents/plan.md" "$result"
+
+cleanup_test_dir
+
+# ===================
+# get_workflow_steps テスト
+# ===================
+echo ""
+echo "=== get_workflow_steps tests ==="
+
+# ビルトイン default
+result=$(get_workflow_steps "builtin:default")
+assert_equals "Builtin default workflow" "plan implement review merge" "$result"
+
+# ビルトイン simple
+result=$(get_workflow_steps "builtin:simple")
+assert_equals "Builtin simple workflow" "implement merge" "$result"
+
+# YAMLファイルからの読み込み（yqがある場合のみ）
+if command -v yq &>/dev/null; then
+    setup_test_dir
+    
+    cat > "$TEST_DIR/workflows/test.yaml" << 'EOF'
+name: test
+steps:
+  - step1
+  - step2
+  - step3
+EOF
+
+    result=$(get_workflow_steps "$TEST_DIR/workflows/test.yaml")
+    assert_equals "Steps from YAML file" "step1 step2 step3" "$result"
+    
+    cleanup_test_dir
+else
+    echo "(skipping YAML parsing test - yq not available)"
+fi
+
+# ===================
+# render_template テスト
+# ===================
+echo ""
+echo "=== render_template tests ==="
+
+template="Issue #{{issue_number}} on branch {{branch_name}}"
+result=$(render_template "$template" "42" "feature/test")
+assert_equals "Basic template rendering" "Issue #42 on branch feature/test" "$result"
+
+template="Step: {{step_name}}, Workflow: {{workflow_name}}"
+result=$(render_template "$template" "" "" "" "implement" "default")
+assert_equals "Step and workflow rendering" "Step: implement, Workflow: default" "$result"
+
+template="Path: {{worktree_path}}"
+result=$(render_template "$template" "" "" "/path/to/worktree")
+assert_equals "Worktree path rendering" "Path: /path/to/worktree" "$result"
+
+# 変数がない場合は空文字に置換
+template="Issue #{{issue_number}}"
+result=$(render_template "$template")
+assert_equals "Empty variable becomes empty string" "Issue #" "$result"
+
+# ===================
+# get_agent_prompt テスト
+# ===================
+echo ""
+echo "=== get_agent_prompt tests ==="
+
+# ビルトインエージェント
+result=$(get_agent_prompt "builtin:plan" "42")
+assert_contains "Builtin plan agent contains issue number" "issue #42" "$result"
+
+result=$(get_agent_prompt "builtin:implement" "99")
+assert_contains "Builtin implement agent contains issue number" "issue #99" "$result"
+
+# カスタムエージェントファイル
+setup_test_dir
+echo "Custom agent for issue #{{issue_number}}" > "$TEST_DIR/agents/custom.md"
+result=$(get_agent_prompt "$TEST_DIR/agents/custom.md" "123")
+assert_equals "Custom agent file with template" "Custom agent for issue #123" "$result"
+cleanup_test_dir
+
+# ===================
+# parse_step_result テスト
+# ===================
+echo ""
+echo "=== parse_step_result tests ==="
+
+result=$(parse_step_result "Task completed [DONE]")
+assert_equals "Detects [DONE] marker" "DONE" "$result"
+
+result=$(parse_step_result "Cannot proceed [BLOCKED] due to missing info")
+assert_equals "Detects [BLOCKED] marker" "BLOCKED" "$result"
+
+result=$(parse_step_result "Found issues [FIX_NEEDED]")
+assert_equals "Detects [FIX_NEEDED] marker" "FIX_NEEDED" "$result"
+
+result=$(parse_step_result "Some output without marker")
+assert_equals "No marker defaults to DONE" "DONE" "$result"
+
+# ===================
+# run_step テスト
+# ===================
+echo ""
+echo "=== run_step tests ==="
+
+setup_test_dir
+
+# ビルトインエージェントでの実行
+result=$(run_step "plan" "42" "feature/test" "/path/worktree" "$TEST_DIR")
+assert_contains "run_step returns prompt" "issue #42" "$result"
+
+# カスタムエージェントでの実行
+echo "Custom step for #{{issue_number}} on {{branch_name}}" > "$TEST_DIR/agents/custom.md"
+result=$(run_step "custom" "55" "feature/custom" "/path" "$TEST_DIR")
+assert_equals "run_step with custom agent" "Custom step for #55 on feature/custom" "$result"
+
+cleanup_test_dir
+
+# ===================
+# run_workflow テスト
+# ===================
+echo ""
+echo "=== run_workflow tests ==="
+
+setup_test_dir
+
+result=$(run_workflow "default" "42" "feature/test" "/path" "$TEST_DIR")
+assert_contains "run_workflow outputs step:0" "step:0:plan" "$result"
+assert_contains "run_workflow outputs step:1" "step:1:implement" "$result"
+assert_contains "run_workflow outputs step:2" "step:2:review" "$result"
+assert_contains "run_workflow outputs step:3" "step:3:merge" "$result"
+assert_contains "run_workflow outputs total" "total:4" "$result"
+
+result=$(run_workflow "simple" "42" "" "" "$TEST_DIR")
+assert_contains "simple workflow step:0" "step:0:implement" "$result"
+assert_contains "simple workflow step:1" "step:1:merge" "$result"
+assert_contains "simple workflow total" "total:2" "$result"
+
+cleanup_test_dir
+
+# ===================
+# get_workflow_steps_array テスト
+# ===================
+echo ""
+echo "=== get_workflow_steps_array tests ==="
+
+result=$(get_workflow_steps_array "default" "/nonexistent")
+assert_equals "get_workflow_steps_array returns steps" "plan implement review merge" "$result"
+
+# ===================
+# 結果サマリー
+# ===================
+echo ""
+echo "===================="
+echo "Tests: $((TESTS_PASSED + TESTS_FAILED))"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "===================="
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Closes #97

## Changes
- **lib/workflow.sh**: ワークフローエンジンの実装
  - `find_workflow_file()`: ワークフローファイル検索（優先順位順）
  - `find_agent_file()`: エージェントファイル検索
  - `render_template()`: テンプレート変数展開
  - `run_step()`: 単一ステップ実行
  - `run_workflow()`: ワークフロー全体実行
  - `parse_step_result()`: 結果判定（[DONE]/[BLOCKED]/[FIX_NEEDED]）
- ビルトインワークフロー定義（default, simple）
- ビルトインエージェントプロンプト（plan, implement, review, merge）
- `yq` 依存チェックとビルトインフォールバック

- **test/workflow_test.sh**: 単体テスト（33テストケース）

- **AGENTS.md, README.md, docs/SPECIFICATION.md**: ドキュメント更新
  - lib/workflow.sh の追加
  - yq 依存の明記

## Testing
- `./test/workflow_test.sh`: 33/33 passed
- 既存テスト全て通過（151テスト）
- 構文チェック: `bash -n lib/workflow.sh` OK