### PR TITLE
fix: 設定ファイル拡張子を .yaml に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ scripts/cleanup.sh pi-issue-42
 
 ## 設定
 
-プロジェクトルートに `.pi-runner.yml` を作成して動作をカスタマイズできます：
+プロジェクトルートに `.pi-runner.yaml` を作成して動作をカスタマイズできます：
 
 ```yaml
 # Git worktree設定
@@ -221,7 +221,7 @@ your-project/
 │   │   └── ...
 │   └── issue-43/           # Issue #43 のworktree
 │       └── ...
-└── .pi-runner.yml          # 設定ファイル（オプション）
+└── .pi-runner.yaml         # 設定ファイル（オプション）
 ```
 
 ## トラブルシューティング

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -19,7 +19,7 @@ CONFIG_PARALLEL_MAX_CONCURRENT="${CONFIG_PARALLEL_MAX_CONCURRENT:-0}"  # 0 = unl
 # 設定ファイルを探す
 find_config_file() {
     local start_dir="${1:-.}"
-    local config_name=".pi-runner.yml"
+    local config_name=".pi-runner.yaml"
     local current_dir
     current_dir="$(cd "$start_dir" && pwd)"
 


### PR DESCRIPTION
## Summary
Closes #108

## Changes
- `lib/config.sh`: `.pi-runner.yml` → `.pi-runner.yaml`
- `README.md`: `.pi-runner.yml` → `.pi-runner.yaml` (2箇所)

## Background
設定ファイル拡張子に不整合があったため、YAML公式推奨の `.yaml` に統一

## Testing
- 単体テスト: `./test/config_test.sh` 全パス (11/11)
- grep確認: すべてのファイルで `.yaml` に統一されていることを確認