### PR TITLE
fix: `{{issue_title}}` テンプレート変数の追加

### DIFF
--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -167,6 +167,7 @@ get_workflow_steps() {
 # テンプレート変数展開
 # 対応変数:
 #   {{issue_number}} - Issue番号
+#   {{issue_title}} - Issueタイトル
 #   {{branch_name}} - ブランチ名
 #   {{worktree_path}} - ワークツリーパス
 #   {{step_name}} - 現在のステップ名
@@ -178,11 +179,13 @@ render_template() {
     local worktree_path="${4:-}"
     local step_name="${5:-}"
     local workflow_name="${6:-default}"
+    local issue_title="${7:-}"
     
     local result="$template"
     
     # 変数展開
     result="${result//\{\{issue_number\}\}/$issue_number}"
+    result="${result//\{\{issue_title\}\}/$issue_title}"
     result="${result//\{\{branch_name\}\}/$branch_name}"
     result="${result//\{\{worktree_path\}\}/$worktree_path}"
     result="${result//\{\{step_name\}\}/$step_name}"
@@ -198,6 +201,7 @@ get_agent_prompt() {
     local branch_name="${3:-}"
     local worktree_path="${4:-}"
     local step_name="${5:-}"
+    local issue_title="${6:-}"
     
     local prompt
     
@@ -232,7 +236,7 @@ get_agent_prompt() {
     fi
     
     # テンプレート変数展開
-    render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name"
+    render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "default" "$issue_title"
 }
 
 # ===================
@@ -270,6 +274,7 @@ run_step() {
     local branch_name="${3:-}"
     local worktree_path="${4:-}"
     local project_root="${5:-.}"
+    local issue_title="${6:-}"
     
     log_info "Running step: $step_name"
     
@@ -280,7 +285,7 @@ run_step() {
     
     # プロンプト取得
     local prompt
-    prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step_name")
+    prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "$issue_title")
     
     echo "$prompt"
 }
@@ -405,7 +410,7 @@ EOF
         agent_file=$(find_agent_file "$step" "$project_root")
         
         local agent_prompt
-        agent_prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step")
+        agent_prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step" "$issue_title")
         
         # ステップ名の最初を大文字に
         local step_name

--- a/test/workflow_test.sh
+++ b/test/workflow_test.sh
@@ -221,6 +221,16 @@ template="Issue #{{issue_number}}"
 result=$(render_template "$template")
 assert_equals "Empty variable becomes empty string" "Issue #" "$result"
 
+# issue_title のテスト
+template="Issue: {{issue_title}}"
+result=$(render_template "$template" "" "" "" "" "default" "Fix bug in parser")
+assert_equals "Issue title rendering" "Issue: Fix bug in parser" "$result"
+
+# 複数変数の組み合わせテスト
+template="Issue #{{issue_number}}: {{issue_title}} on {{branch_name}}"
+result=$(render_template "$template" "42" "feature/test" "" "" "default" "Add new feature")
+assert_equals "Combined issue_number, issue_title, branch_name" "Issue #42: Add new feature on feature/test" "$result"
+
 # ===================
 # get_agent_prompt テスト
 # ===================
@@ -239,6 +249,11 @@ setup_test_dir
 echo "Custom agent for issue #{{issue_number}}" > "$TEST_DIR/agents/custom.md"
 result=$(get_agent_prompt "$TEST_DIR/agents/custom.md" "123")
 assert_equals "Custom agent file with template" "Custom agent for issue #123" "$result"
+
+# issue_title を含むカスタムエージェントファイル
+echo "Issue #{{issue_number}}: {{issue_title}}" > "$TEST_DIR/agents/with_title.md"
+result=$(get_agent_prompt "$TEST_DIR/agents/with_title.md" "42" "" "" "" "My Issue Title")
+assert_equals "Custom agent with issue_title" "Issue #42: My Issue Title" "$result"
 cleanup_test_dir
 
 # ===================


### PR DESCRIPTION
## Summary
Closes #107

## Changes
- `render_template()` 関数に `issue_title` パラメータを追加
- `get_agent_prompt()` で `issue_title` を受け取り `render_template()` に渡すように更新
- `run_step()` と `generate_workflow_prompt()` を更新
- 単体テストを追加（3件）

## Testing
- `./test/workflow_test.sh` で全36テストがパス
- 手動テストで `generate_workflow_prompt()` が `{{issue_title}}` を正しく展開することを確認