### PR TITLE
perf: yqチェック結果のキャッシュ

### DIFF
--- a/docs/plans/issue-113-plan.md
+++ b/docs/plans/issue-113-plan.md
@@ -1,0 +1,50 @@
+# Issue #113 実装計画: yqチェック結果のキャッシュ
+
+## 概要
+
+`lib/workflow.sh` の `check_yq()` 関数が毎回 `command -v yq` を実行しているため、
+結果をグローバル変数にキャッシュして2回目以降の呼び出しを高速化する。
+
+## 影響範囲
+
+- `lib/workflow.sh` - `check_yq()` 関数のみ
+
+## 現状分析
+
+現在の `check_yq()` 関数:
+```bash
+check_yq() {
+    if command -v yq &> /dev/null; then
+        return 0
+    else
+        log_debug "yq not found, using builtin workflow"
+        return 1
+    fi
+}
+```
+
+呼び出し箇所:
+- L58: `find_workflow_file()` 内
+- L136: `get_workflow_steps()` 内
+
+## 実装ステップ
+
+1. グローバルキャッシュ変数 `_YQ_CHECK_RESULT` を追加（未チェック: 空、存在: "1"、不在: "0"）
+2. `check_yq()` を修正:
+   - キャッシュが存在する場合はそれを返す
+   - キャッシュがない場合のみ `command -v` を実行
+   - 結果をキャッシュに保存
+
+## テスト方針
+
+- 既存の `test/workflow_test.sh` でテストが存在するか確認
+- 新しいテストケース追加: キャッシュが効いていることの確認
+
+## リスクと対策
+
+- **リスク**: シェルスクリプトのサブシェルでキャッシュが効かない
+  - **対策**: 通常の関数呼び出しではキャッシュが効くので問題なし
+
+## 推定作業量
+
+約10行の変更、20分以内に完了予定

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -29,11 +29,23 @@ Push changes and create a pull request.'
 # 依存チェック
 # ===================
 
-# yq の存在確認
+# yq チェック結果のキャッシュ（空: 未チェック、"1": 存在、"0": 不在）
+_YQ_CHECK_RESULT=""
+
+# yq の存在確認（結果をキャッシュ）
 check_yq() {
+    # キャッシュがある場合はそれを返す
+    if [[ -n "$_YQ_CHECK_RESULT" ]]; then
+        [[ "$_YQ_CHECK_RESULT" == "1" ]]
+        return
+    fi
+    
+    # 初回のみ実際にチェック
     if command -v yq &> /dev/null; then
+        _YQ_CHECK_RESULT="1"
         return 0
     else
+        _YQ_CHECK_RESULT="0"
         log_debug "yq not found, using builtin workflow"
         return 1
     fi

--- a/test/workflow_test.sh
+++ b/test/workflow_test.sh
@@ -98,6 +98,27 @@ else
     assert_equals "check_yq returns 1 when yq is not available" "0" "$?"
 fi
 
+# キャッシュのテスト
+# キャッシュをリセット
+_YQ_CHECK_RESULT=""
+
+# 1回目の呼び出し
+check_yq || true
+cache_after_first="$_YQ_CHECK_RESULT"
+assert_not_empty "Cache is set after first check_yq call" "$cache_after_first"
+
+# 2回目の呼び出し（キャッシュから返るはず）
+check_yq || true
+cache_after_second="$_YQ_CHECK_RESULT"
+assert_equals "Cache remains same after second call" "$cache_after_first" "$cache_after_second"
+
+# キャッシュ値の検証
+if command -v yq &>/dev/null; then
+    assert_equals "Cache value is '1' when yq exists" "1" "$_YQ_CHECK_RESULT"
+else
+    assert_equals "Cache value is '0' when yq not found" "0" "$_YQ_CHECK_RESULT"
+fi
+
 # ===================
 # find_workflow_file テスト
 # ===================


### PR DESCRIPTION
## Summary
Closes #113

## Changes
- `check_yq()` 関数の結果をグローバル変数 `_YQ_CHECK_RESULT` にキャッシュ
- 2回目以降の呼び出しではキャッシュを返すため、コマンド確認のオーバーヘッドを削減
- キャッシュ動作のテストを3件追加

## Testing
- 全39件のテストがパス（新規3件）
- 手動テストでキャッシュ動作を確認