### PR TITLE
docs: configuration.mdの.ymlを.yamlに統一

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ Pi Issue Runnerの動作は設定ファイルでカスタマイズできます�
 
 1. `--config` オプションで指定されたパス
 2. プロジェクトルート: `./.pi-runner.yaml`
-3. ホームディレクトリ: `~/.pi-runner/config.yml`
+3. ホームディレクトリ: `~/.pi-runner/config.yaml`
 4. デフォルト設定（ファイルなし）
 
 ## 設定フォーマット
@@ -342,7 +342,7 @@ class ConfigManager {
       './.pi-runner.yaml',
       './.pi-runner.yaml',
       './.pi-runner.json',
-      path.join(os.homedir(), '.pi-runner/config.yml'),
+      path.join(os.homedir(), '.pi-runner/config.yaml'),
       path.join(os.homedir(), '.pi-runner/config.yaml'),
       path.join(os.homedir(), '.pi-runner/config.json')
     ];
@@ -479,7 +479,7 @@ class ConfigManager {
 
 ```bash
 # 設定ファイルを指定
-pi-run --config ./custom-config.yml run --issue 42
+pi-run --config ./custom-config.yaml run --issue 42
 
 # 最大同時実行数を上書き
 pi-run run --issues 42,43,44 --max-concurrent 10
@@ -572,7 +572,7 @@ notifications:
 
 ## 設定のベストプラクティス
 
-1. **環境ごとに設定ファイルを分ける**: `.pi-runner.dev.yml`, `.pi-runner.prod.yml`
+1. **環境ごとに設定ファイルを分ける**: `.pi-runner.dev.yaml`, `.pi-runner.prod.yaml`
 2. **機密情報は環境変数で**: GitHubトークン等は設定ファイルに含めない
 3. **リソース制限を適切に設定**: マシンスペックに応じて調整
 4. **ログレベルは環境で変える**: 開発=debug、本番=info

--- a/docs/plans/issue-132-plan.md
+++ b/docs/plans/issue-132-plan.md
@@ -1,0 +1,38 @@
+# Issue #132 実装計画書
+
+## 概要
+docs/configuration.mdに残っている`.yml`拡張子を`.yaml`に統一する。
+
+## 影響範囲
+- `docs/configuration.md` のみ
+
+## 発見した`.yml`箇所
+
+| 行番号 | 内容 | 対応 |
+|--------|------|------|
+| 13 | `~/.pi-runner/config.yml` | `.yaml`に変更 |
+| 345 | `path.join(os.homedir(), '.pi-runner/config.yml')` | `.yaml`に変更 |
+| 364 | `ext === '.yml' \|\| ext === '.yaml'` | **維持**（両拡張子サポートのロジック） |
+| 482 | `./custom-config.yml` | `.yaml`に変更 |
+| 575 | `.pi-runner.dev.yml`, `.pi-runner.prod.yml` | `.yaml`に変更 |
+
+## 実装ステップ
+
+1. Line 13: `~/.pi-runner/config.yml` → `~/.pi-runner/config.yaml`
+2. Line 345: `'.pi-runner/config.yml'` → `'.pi-runner/config.yaml'`
+3. Line 482: `custom-config.yml` → `custom-config.yaml`
+4. Line 575: `.pi-runner.dev.yml`, `.pi-runner.prod.yml` → `.pi-runner.dev.yaml`, `.pi-runner.prod.yaml`
+
+**注意**: Line 364は両拡張子をサポートするコードなので変更しない。
+
+## テスト方針
+
+```bash
+# 変更後、.ymlがドキュメント中に残っていないか確認
+# （ただしコード例の拡張子チェックロジックを除く）
+grep '\.yml' docs/configuration.md | grep -v "ext === '\\.yml'"
+```
+
+## リスク
+
+- リスク: なし（ドキュメントのみの変更）


### PR DESCRIPTION
## Summary
Closes #132

## Changes
- `~/.pi-runner/config.yml` → `~/.pi-runner/config.yaml`
- `path.join(os.homedir(), '.pi-runner/config.yml')` → `.yaml`
- `./custom-config.yml` → `./custom-config.yaml`
- `.pi-runner.dev.yml`, `.pi-runner.prod.yml` → `.yaml`

Note: Kept `.yml` check in code example (line 364) as it's part of the logic to support both file extensions.

## Testing
- Verified with `grep` that no unexpected `.yml` references remain
- All 4 specified lines were updated correctly