### PR TITLE
docs: watch-session.shと自動クリーンアップのドキュメント追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ pi-issue-runner/
 │   ├── attach.sh           # セッションアタッチ
 │   ├── stop.sh             # セッション停止
 │   ├── cleanup.sh          # クリーンアップ
-│   └── post-session.sh     # セッション終了後処理
+│   ├── post-session.sh     # セッション終了後処理
+│   └── watch-session.sh    # セッション監視と自動クリーンアップ
 ├── lib/
 │   ├── config.sh           # 設定読み込み
 │   ├── github.sh           # GitHub API操作

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,25 @@ scripts/cleanup.sh <session> # 手動クリーンアップ
 - `pi`
 - `jq` (JSON処理)
 
+## 自動クリーンアップ
+
+タスク完了時にAIが `###TASK_COMPLETE_<issue_number>###` マーカーを出力すると、
+`watch-session.sh` が検出して自動的にクリーンアップを実行します。
+
+### 動作フロー
+
+1. `run.sh` がバックグラウンドで `watch-session.sh` を起動
+2. `watch-session.sh` がtmuxセッションの出力を監視
+3. 完了マーカー（例: `###TASK_COMPLETE_42###`）を検出
+4. 自動的に `cleanup.sh` を実行してworktreeとセッションを削除
+
+### 自動クリーンアップの無効化
+
+```bash
+# 自動クリーンアップを無効化
+scripts/run.sh 42 --no-cleanup
+```
+
 ## 詳細ドキュメント
 
 詳しい使い方、設定、トラブルシューティングは [README.md](README.md) を参照してください。

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -109,7 +109,8 @@ project-root/
     ├── attach.sh            # セッションアタッチ
     ├── stop.sh              # セッション停止
     ├── cleanup.sh           # クリーンアップ
-    └── post-session.sh      # セッション終了後処理
+    ├── post-session.sh      # セッション終了後処理
+    └── watch-session.sh     # セッション監視と自動クリーンアップ
 ```
 
 ## 設定
@@ -249,6 +250,44 @@ Options:
     --keep-session    セッションを維持
     --keep-worktree   worktreeを維持
 ```
+
+### watch-session.sh - セッション監視と自動クリーンアップ
+
+```bash
+./scripts/watch-session.sh <session-name> [options]
+
+Arguments:
+    session-name    監視するtmuxセッション名
+
+Options:
+    --marker <text>   完了マーカー（デフォルト: ###TASK_COMPLETE_<issue>###）
+    --interval <sec>  監視間隔（デフォルト: 2秒）
+    --cleanup-args    cleanup.shに渡す追加引数
+    -h, --help        このヘルプを表示
+```
+
+#### 動作概要
+
+1. tmuxセッションの出力を定期的にキャプチャ
+2. 完了マーカー（`###TASK_COMPLETE_<issue_number>###`）を検出
+3. マーカー検出時に `cleanup.sh` を自動実行
+4. セッションが終了した場合は監視を停止
+
+#### 使用例
+
+```bash
+# run.shから自動的に起動される（通常は直接呼び出さない）
+./scripts/watch-session.sh pi-issue-42
+
+# カスタムマーカーを指定
+./scripts/watch-session.sh pi-issue-42 --marker "###DONE###"
+
+# 監視間隔を変更
+./scripts/watch-session.sh pi-issue-42 --interval 5
+```
+
+※ このスクリプトは通常、`run.sh` がバックグラウンドで自動的に起動します。
+直接呼び出す必要はありません。
 
 ## 依存関係
 

--- a/docs/plans/issue-133-plan.md
+++ b/docs/plans/issue-133-plan.md
@@ -1,0 +1,42 @@
+# Issue #133 実装計画書
+
+## 概要
+
+`watch-session.sh` と自動クリーンアップ機能のドキュメントを追加する。
+
+## 影響範囲
+
+- `README.md` - ディレクトリ構造セクション
+- `SKILL.md` - 自動クリーンアップの詳細説明
+- `docs/SPECIFICATION.md` - watch-session.shの仕様
+
+## 実装ステップ
+
+### 1. README.md 更新
+- ディレクトリ構造に `watch-session.sh` を追加
+- 説明: 「セッション監視と自動クリーンアップ」
+
+### 2. SKILL.md 更新
+- 自動クリーンアップの詳細説明を追加
+- `###TASK_COMPLETE_<issue_number>###` マーカーの説明
+
+### 3. docs/SPECIFICATION.md 更新
+- ディレクトリ構造に `watch-session.sh` を追加
+- watch-session.sh のCLIコマンド仕様を追加
+
+## テスト方針
+
+- ドキュメントの構文チェック（リンクの有効性など）
+- 変更内容のレビュー
+
+## リスクと対策
+
+- リスク: ドキュメントの一貫性が失われる可能性
+- 対策: 既存のスタイルに従って記述する
+
+## 推定工数
+
+- README.md: 10行程度
+- SKILL.md: 20行程度
+- docs/SPECIFICATION.md: 50行程度
+- 合計: 約80行


### PR DESCRIPTION
## Summary
Closes #133

## Changes
- README.mdにwatch-session.shをディレクトリ構造に追加
- SKILL.mdに自動クリーンアップの詳細説明を追加
- docs/SPECIFICATION.mdにwatch-session.shの仕様を追加

## Testing
- ドキュメントの構文を確認
- 変更内容のレビュー完了