### PR TITLE
feat: 継続的改善スクリプト (improve.sh) の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,40 @@ piセッション内で `###TASK_COMPLETE_42###` を出力すると、外部プ�
 scripts/cleanup.sh 42
 ```
 
+### 継続的改善（improve.sh）
+
+プロジェクトのレビュー→Issue作成→並列実行→完了待ちを自動化:
+
+```bash
+# 基本的な使い方（最大3イテレーション）
+scripts/improve.sh
+
+# オプション指定
+scripts/improve.sh --max-iterations 2 --max-issues 3
+
+# ドライラン（レビューのみ、Issue作成・実行しない）
+scripts/improve.sh --dry-run
+
+# 自動継続（承認ゲートをスキップ）
+scripts/improve.sh --auto-continue
+
+# レビューのみ表示
+scripts/improve.sh --review-only
+```
+
+### 複数セッションの完了待機
+
+```bash
+# 複数のIssueセッションが完了するまで待機
+scripts/wait-for-sessions.sh 140 141 144
+
+# タイムアウト指定
+scripts/wait-for-sessions.sh 140 141 --timeout 1800
+
+# エラー発生時に即座に終了
+scripts/wait-for-sessions.sh 140 141 --fail-fast
+```
+
 ## ワークフロー
 
 ### ビルトインワークフロー
@@ -192,11 +226,15 @@ pi-issue-runner/
 │   ├── attach.sh           # セッションアタッチ
 │   ├── stop.sh             # セッション停止
 │   ├── cleanup.sh          # クリーンアップ
-│   └── watch-session.sh    # セッション監視と自動クリーンアップ
+│   ├── watch-session.sh    # セッション監視と自動クリーンアップ
+│   ├── wait-for-sessions.sh # 複数セッション完了待機
+│   └── improve.sh          # 継続的改善スクリプト
 ├── lib/
 │   ├── config.sh           # 設定読み込み
 │   ├── github.sh           # GitHub API操作
 │   ├── log.sh              # ログ出力
+│   ├── notify.sh           # 通知機能
+│   ├── status.sh           # ステータスファイル管理
 │   ├── tmux.sh             # tmux操作
 │   ├── workflow.sh         # ワークフローエンジン
 │   └── worktree.sh         # Git worktree操作

--- a/docs/plans/issue-146-plan.md
+++ b/docs/plans/issue-146-plan.md
@@ -1,0 +1,83 @@
+# Issue #146 実装計画: 継続的改善スクリプト (improve.sh) の追加
+
+## 概要
+
+プロジェクトレビュー→Issue作成→並列実行→完了待ち→再レビューのループを自動化するスクリプトを追加する。
+
+## 影響範囲
+
+### 新規ファイル
+- `lib/status.sh` - ステータス管理機能（notify.shから抽出・拡張）
+- `scripts/wait-for-sessions.sh` - 複数セッション完了待機
+- `scripts/improve.sh` - 継続的改善メインスクリプト
+- `test/status_test.sh` - ステータス機能テスト
+- `test/wait_for_sessions_test.sh` - 待機機能テスト
+
+### 既存ファイル変更
+- `lib/notify.sh` - status.shをsourceするように変更（互換性維持）
+- `scripts/watch-session.sh` - 既にステータス機能使用中（変更不要）
+
+## 設計判断
+
+### ステータス管理について
+既存の`lib/notify.sh`に既にステータス管理機能が存在:
+- `save_status()`, `load_status()`, `get_status_value()`, `get_error_message()`
+
+Issue要件では`lib/status.sh`として分離を求めているため:
+1. `lib/status.sh`に純粋なステータス管理機能を配置
+2. `lib/notify.sh`は`status.sh`をsourceして通知機能に専念
+3. 後方互換性を維持
+
+## 実装ステップ
+
+### Step 1: lib/status.sh 作成
+- notify.shからステータス関連関数を抽出
+- `set_status()`エイリアス追加（Issue仕様に合わせる）
+- `get_status()`エイリアス追加
+
+### Step 2: lib/notify.sh 修正
+- status.shをsource
+- 既存関数を維持（互換性）
+- 重複コードを削減
+
+### Step 3: scripts/wait-for-sessions.sh 作成
+- 複数Issue番号を引数で受け取り
+- ポーリングで全セッション完了を待機
+- `--timeout`オプション
+- エラー発生時は即座にエラー通知
+
+### Step 4: scripts/improve.sh 作成
+- メインループ実装
+- `--max-iterations`, `--max-issues`, `--auto-continue`, `--dry-run`オプション
+- piを呼び出してproject-reviewを実行
+- 作成されたIssue番号の抽出
+
+### Step 5: テスト作成
+- `test/status_test.sh` - ステータス機能の単体テスト
+- `test/wait_for_sessions_test.sh` - 待機機能のテスト（モック使用）
+
+## テスト方針
+
+1. **単体テスト**: 個別関数のテスト
+2. **統合テスト**: モック環境での動作確認
+3. **手動テスト**: 実際のIssueを使った動作確認
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| piコマンドの出力形式変更 | マーカー形式を明確に定義 |
+| 無限ループ | --max-iterations で制限 |
+| 並列実行数超過 | 既存のcheck_concurrent_limitを活用 |
+| 通知の重複 | ステータスファイルで状態管理 |
+
+## 完了条件チェックリスト
+
+- [ ] `lib/status.sh` でステータスファイルを管理できる
+- [ ] `watch-session.sh` がステータスファイルを更新する（既存）
+- [ ] `wait-for-sessions.sh` で複数セッションの完了を待機できる
+- [ ] `improve.sh` でレビュー→実行→待機のループが動作する
+- [ ] `--max-iterations` で最大回数を制限できる
+- [ ] `--dry-run` でレビューのみ実行できる
+- [ ] 承認ゲートで次のイテレーションを制御できる
+- [ ] テストがパスする

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -6,142 +6,20 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 source "$SCRIPT_DIR/log.sh"
+source "$SCRIPT_DIR/status.sh"
 
-# ステータスディレクトリを取得
-get_status_dir() {
-    load_config
-    local worktree_base
-    worktree_base="$(get_config worktree_base_dir)"
-    echo "${worktree_base}/.status"
-}
-
-# ステータスディレクトリを初期化
-init_status_dir() {
-    local status_dir
-    status_dir="$(get_status_dir)"
-    if [[ ! -d "$status_dir" ]]; then
-        mkdir -p "$status_dir"
-        log_debug "Created status directory: $status_dir"
-    fi
-}
-
-# ステータスを保存
-# 引数:
-#   $1 - issue_number: Issue番号
-#   $2 - status: ステータス (running, error, complete)
-#   $3 - session_name: セッション名
-#   $4 - error_message: エラーメッセージ (オプション)
-save_status() {
-    local issue_number="$1"
-    local status="$2"
-    local session_name="$3"
-    local error_message="${4:-}"
-    
-    init_status_dir
-    
-    local status_dir
-    status_dir="$(get_status_dir)"
-    local status_file="${status_dir}/${issue_number}.json"
-    local timestamp
-    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-    
-    # JSONを手動で構築（jqがない環境でも動作するように）
-    local json
-    if [[ -n "$error_message" ]]; then
-        # エラーメッセージをJSONエスケープ
-        local escaped_message
-        escaped_message="$(echo "$error_message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | tr '\n' ' ')"
-        json=$(cat << EOF
-{
-  "issue": $issue_number,
-  "status": "$status",
-  "session": "$session_name",
-  "error_message": "$escaped_message",
-  "timestamp": "$timestamp"
-}
-EOF
-)
-    else
-        json=$(cat << EOF
-{
-  "issue": $issue_number,
-  "status": "$status",
-  "session": "$session_name",
-  "timestamp": "$timestamp"
-}
-EOF
-)
-    fi
-    
-    echo "$json" > "$status_file"
-    log_debug "Saved status for issue #$issue_number: $status"
-}
-
-# ステータスを読み込み
-# 引数:
-#   $1 - issue_number: Issue番号
-# 出力: JSONの内容、またはファイルがなければ空
-load_status() {
-    local issue_number="$1"
-    
-    local status_dir
-    status_dir="$(get_status_dir)"
-    local status_file="${status_dir}/${issue_number}.json"
-    
-    if [[ -f "$status_file" ]]; then
-        cat "$status_file"
-    fi
-}
-
-# ステータス値のみを取得
-# 引数:
-#   $1 - issue_number: Issue番号
-# 出力: ステータス文字列 (running, error, complete) または "unknown"
-get_status_value() {
-    local issue_number="$1"
-    
-    local json
-    json="$(load_status "$issue_number")"
-    
-    if [[ -n "$json" ]]; then
-        # "status": "value" からvalueを抽出
-        echo "$json" | grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || echo "unknown"
-    else
-        echo "unknown"
-    fi
-}
-
-# エラーメッセージを取得
-# 引数:
-#   $1 - issue_number: Issue番号
-# 出力: エラーメッセージまたは空
-get_error_message() {
-    local issue_number="$1"
-    
-    local json
-    json="$(load_status "$issue_number")"
-    
-    if [[ -n "$json" ]]; then
-        # "error_message": "value" からvalueを抽出
-        echo "$json" | grep -o '"error_message"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || true
-    fi
-}
-
-# ステータスファイルを削除
-# 引数:
-#   $1 - issue_number: Issue番号
-remove_status() {
-    local issue_number="$1"
-    
-    local status_dir
-    status_dir="$(get_status_dir)"
-    local status_file="${status_dir}/${issue_number}.json"
-    
-    if [[ -f "$status_file" ]]; then
-        rm -f "$status_file"
-        log_debug "Removed status file for issue #$issue_number"
-    fi
-}
+# 後方互換性のために以下の関数はstatus.shで定義済み:
+# - get_status_dir()
+# - init_status_dir()
+# - save_status()
+# - load_status()
+# - get_status_value()
+# - get_error_message()
+# - remove_status()
+# - set_status()     (新規)
+# - get_status()     (新規)
+# - list_all_statuses()  (新規)
+# - list_issues_by_status()  (新規)
 
 # macOSかどうかチェック
 is_macos() {

--- a/lib/status.sh
+++ b/lib/status.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# status.sh - ステータスファイル管理
+
+# Note: set -euo pipefail はsource先の環境に影響するため、
+# このファイルでは設定しない（呼び出し元で設定）
+
+# 自身のディレクトリを取得（SCRIPT_DIRとは別に保存）
+_STATUS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# config.shがまだロードされていなければロード
+if ! declare -f get_config > /dev/null 2>&1; then
+    source "$_STATUS_LIB_DIR/config.sh"
+fi
+
+# ログ関数（log.shがロードされていなければダミー）
+if ! declare -f log_debug > /dev/null 2>&1; then
+    log_debug() { :; }
+    log_info() { echo "[INFO] $*" >&2; }
+    log_warn() { echo "[WARN] $*" >&2; }
+    log_error() { echo "[ERROR] $*" >&2; }
+fi
+
+# ステータスディレクトリを取得
+get_status_dir() {
+    load_config
+    local worktree_base
+    worktree_base="$(get_config worktree_base_dir)"
+    echo "${worktree_base}/.status"
+}
+
+# ステータスディレクトリを初期化
+init_status_dir() {
+    local status_dir
+    status_dir="$(get_status_dir)"
+    if [[ ! -d "$status_dir" ]]; then
+        mkdir -p "$status_dir"
+        log_debug "Created status directory: $status_dir"
+    fi
+}
+
+# ステータスを保存
+# 引数:
+#   $1 - issue_number: Issue番号
+#   $2 - status: ステータス (running, error, complete)
+#   $3 - session_name: セッション名
+#   $4 - error_message: エラーメッセージ (オプション)
+save_status() {
+    local issue_number="$1"
+    local status="$2"
+    local session_name="${3:-}"
+    local error_message="${4:-}"
+    
+    init_status_dir
+    
+    local status_dir
+    status_dir="$(get_status_dir)"
+    local status_file="${status_dir}/${issue_number}.json"
+    local timestamp
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    
+    # JSONを手動で構築（jqがない環境でも動作するように）
+    local json
+    if [[ -n "$error_message" ]]; then
+        # エラーメッセージをJSONエスケープ
+        local escaped_message
+        escaped_message="$(echo "$error_message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | tr '\n' ' ')"
+        json=$(cat << EOF
+{
+  "issue": $issue_number,
+  "status": "$status",
+  "session": "$session_name",
+  "error_message": "$escaped_message",
+  "timestamp": "$timestamp"
+}
+EOF
+)
+    else
+        json=$(cat << EOF
+{
+  "issue": $issue_number,
+  "status": "$status",
+  "session": "$session_name",
+  "timestamp": "$timestamp"
+}
+EOF
+)
+    fi
+    
+    echo "$json" > "$status_file"
+    log_debug "Saved status for issue #$issue_number: $status"
+}
+
+# ステータスを設定（Issue仕様に合わせたエイリアス）
+# 引数:
+#   $1 - issue: Issue番号
+#   $2 - status: ステータス (running, error, complete)
+#   $3 - message: メッセージ (オプション、エラー時のみ使用)
+set_status() {
+    local issue="$1"
+    local status="$2"
+    local message="${3:-}"
+    
+    # セッション名を生成
+    local session_name
+    if declare -f generate_session_name > /dev/null 2>&1; then
+        session_name="$(generate_session_name "$issue")"
+    else
+        session_name="pi-issue-${issue}"
+    fi
+    
+    if [[ "$status" == "error" ]]; then
+        save_status "$issue" "$status" "$session_name" "$message"
+    else
+        save_status "$issue" "$status" "$session_name"
+    fi
+}
+
+# ステータスを読み込み
+# 引数:
+#   $1 - issue_number: Issue番号
+# 出力: JSONの内容、またはファイルがなければ空
+load_status() {
+    local issue_number="$1"
+    
+    local status_dir
+    status_dir="$(get_status_dir)"
+    local status_file="${status_dir}/${issue_number}.json"
+    
+    if [[ -f "$status_file" ]]; then
+        cat "$status_file"
+    fi
+}
+
+# ステータス値のみを取得
+# 引数:
+#   $1 - issue_number: Issue番号
+# 出力: ステータス文字列 (running, error, complete) または "unknown"
+get_status_value() {
+    local issue_number="$1"
+    
+    local json
+    json="$(load_status "$issue_number")"
+    
+    if [[ -n "$json" ]]; then
+        # "status": "value" からvalueを抽出
+        echo "$json" | grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || echo "unknown"
+    else
+        echo "unknown"
+    fi
+}
+
+# ステータスを取得（Issue仕様に合わせたエイリアス）
+# 引数:
+#   $1 - issue: Issue番号
+# 出力: ステータス文字列 (running, error, complete) または "unknown"
+get_status() {
+    get_status_value "$1"
+}
+
+# エラーメッセージを取得
+# 引数:
+#   $1 - issue_number: Issue番号
+# 出力: エラーメッセージまたは空
+get_error_message() {
+    local issue_number="$1"
+    
+    local json
+    json="$(load_status "$issue_number")"
+    
+    if [[ -n "$json" ]]; then
+        # "error_message": "value" からvalueを抽出
+        echo "$json" | grep -o '"error_message"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || true
+    fi
+}
+
+# ステータスファイルを削除
+# 引数:
+#   $1 - issue_number: Issue番号
+remove_status() {
+    local issue_number="$1"
+    
+    local status_dir
+    status_dir="$(get_status_dir)"
+    local status_file="${status_dir}/${issue_number}.json"
+    
+    if [[ -f "$status_file" ]]; then
+        rm -f "$status_file"
+        log_debug "Removed status file for issue #$issue_number"
+    fi
+}
+
+# 全てのステータスを一覧取得
+# 出力: Issue番号とステータスのペア（タブ区切り）
+list_all_statuses() {
+    local status_dir
+    status_dir="$(get_status_dir)"
+    
+    if [[ ! -d "$status_dir" ]]; then
+        return 0
+    fi
+    
+    for status_file in "$status_dir"/*.json; do
+        [[ -f "$status_file" ]] || continue
+        local issue_number
+        issue_number="$(basename "$status_file" .json)"
+        local status
+        status="$(get_status_value "$issue_number")"
+        echo -e "${issue_number}\t${status}"
+    done
+}
+
+# 指定ステータスのIssue一覧を取得
+# 引数:
+#   $1 - status: フィルタするステータス
+# 出力: Issue番号（1行に1つ）
+list_issues_by_status() {
+    local filter_status="$1"
+    
+    list_all_statuses | while IFS=$'\t' read -r issue status; do
+        if [[ "$status" == "$filter_status" ]]; then
+            echo "$issue"
+        fi
+    done
+}

--- a/scripts/improve.sh
+++ b/scripts/improve.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# improve.sh - 継続的改善スクリプト
+# プロジェクトレビュー→Issue作成→並列実行→完了待ち→再レビューのループを自動化
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/status.sh"
+
+# グローバル変数
+CREATED_ISSUES=()
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [options]
+
+Options:
+    --max-iterations N   最大イテレーション数（デフォルト: 3）
+    --max-issues N       1回あたりの最大Issue数（デフォルト: 5）
+    --auto-continue      承認ゲートをスキップ（自動継続）
+    --dry-run            レビューのみ実行（Issue作成・実行しない）
+    --timeout <sec>      各イテレーションのタイムアウト（デフォルト: 3600）
+    --review-only        project-reviewスキルで問題を表示するのみ
+    -v, --verbose        詳細ログを表示
+    -h, --help           このヘルプを表示
+
+Description:
+    プロジェクトの継続的改善を自動化します:
+    1. プロジェクトをレビューして問題を発見
+    2. 発見した問題からGitHub Issueを作成
+    3. 各Issueに対してpi-issue-runnerを並列実行
+    4. すべての実行が完了するまで待機
+    5. 問題がなくなるか最大回数に達するまで繰り返し
+
+Examples:
+    $(basename "$0")
+    $(basename "$0") --max-iterations 2 --max-issues 3
+    $(basename "$0") --dry-run
+    $(basename "$0") --auto-continue
+
+Environment Variables:
+    PI_COMMAND           piコマンドのパス（デフォルト: pi）
+    LOG_LEVEL            ログレベル（DEBUG, INFO, WARN, ERROR）
+EOF
+}
+
+main() {
+    local max_iterations=3
+    local max_issues=5
+    local auto_continue=false
+    local dry_run=false
+    local review_only=false
+    local timeout=3600
+
+    # 引数のパース
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --max-iterations)
+                max_iterations="$2"
+                shift 2
+                ;;
+            --max-issues)
+                max_issues="$2"
+                shift 2
+                ;;
+            --auto-continue)
+                auto_continue=true
+                shift
+                ;;
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --review-only)
+                review_only=true
+                shift
+                ;;
+            --timeout)
+                timeout="$2"
+                shift 2
+                ;;
+            -v|--verbose)
+                LOG_LEVEL="DEBUG"
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage >&2
+                exit 1
+                ;;
+            *)
+                log_error "Unexpected argument: $1"
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    load_config
+
+    # 依存関係チェック
+    check_dependencies || exit 1
+
+    local iteration=1
+
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════╗"
+    echo "║             🔧 継続的改善スクリプト (improve.sh)            ║"
+    echo "╠════════════════════════════════════════════════════════════╣"
+    echo "║  max-iterations: $max_iterations"
+    echo "║  max-issues:     $max_issues"
+    echo "║  auto-continue:  $auto_continue"
+    echo "║  dry-run:        $dry_run"
+    echo "║  timeout:        ${timeout}s"
+    echo "╚════════════════════════════════════════════════════════════╝"
+    echo ""
+
+    while [[ $iteration -le $max_iterations ]]; do
+        echo ""
+        echo "🔍 ════════════════════════════════════════════════════════"
+        echo "   Iteration $iteration/$max_iterations"
+        echo "════════════════════════════════════════════════════════════"
+        echo ""
+
+        # Phase 1: レビュー
+        echo "[REVIEW] プロジェクトをレビュー中..."
+        CREATED_ISSUES=()
+        
+        if ! review_and_create_issues "$max_issues" "$dry_run" "$review_only"; then
+            log_error "Review failed"
+            exit 1
+        fi
+
+        # Issue が0件なら完了
+        if [[ ${#CREATED_ISSUES[@]} -eq 0 ]]; then
+            echo ""
+            echo "✅ 改善完了！問題は見つかりませんでした。"
+            echo ""
+            exit 0
+        fi
+
+        echo "[pi] ${#CREATED_ISSUES[@]}件の問題を発見/Issue作成"
+        for issue in "${CREATED_ISSUES[@]}"; do
+            echo "  - Issue #$issue"
+        done
+
+        # --review-only モードの場合はここで終了
+        if [[ "$review_only" == "true" ]]; then
+            echo ""
+            echo "[INFO] --review-only モードのため、実行をスキップします"
+            break
+        fi
+
+        # --dry-run モードの場合はPhase 2-3をスキップ
+        if [[ "$dry_run" == "true" ]]; then
+            echo ""
+            echo "[INFO] --dry-run モードのため、実行をスキップします"
+        else
+            # Phase 2: 並列実行
+            echo ""
+            echo "[RUN] ${#CREATED_ISSUES[@]} Issueを並列実行中..."
+            for issue in "${CREATED_ISSUES[@]}"; do
+                echo "  Starting Issue #$issue..."
+                "$SCRIPT_DIR/run.sh" "$issue" --no-attach || {
+                    log_warn "Failed to start session for Issue #$issue"
+                }
+            done
+
+            # Phase 3: 完了待機
+            echo ""
+            echo "[WAIT] 完了を待機中..."
+            if ! "$SCRIPT_DIR/wait-for-sessions.sh" "${CREATED_ISSUES[@]}" --timeout "$timeout"; then
+                log_warn "Some sessions failed or timed out"
+            fi
+        fi
+
+        # Phase 4: 承認ゲート
+        if [[ $iteration -lt $max_iterations ]]; then
+            if [[ "$auto_continue" != "true" ]]; then
+                echo ""
+                read -r -p "次のイテレーションを実行しますか？ [Y/n]: " answer
+                if [[ "$answer" =~ ^[Nn] ]]; then
+                    echo "[INFO] ユーザーにより中断されました"
+                    break
+                fi
+            fi
+        fi
+
+        ((iteration++)) || true
+    done
+
+    if [[ $iteration -gt $max_iterations ]]; then
+        echo ""
+        echo "[INFO] 最大イテレーション数 ($max_iterations) に達しました"
+    fi
+
+    echo ""
+    echo "🏁 改善プロセス終了"
+}
+
+# 依存関係チェック
+check_dependencies() {
+    local missing=()
+
+    # piコマンド
+    local pi_command
+    pi_command="$(get_config pi_command)"
+    if ! command -v "$pi_command" &> /dev/null; then
+        missing+=("$pi_command (pi)")
+    fi
+
+    # gh (GitHub CLI)
+    if ! command -v gh &> /dev/null; then
+        missing+=("gh (GitHub CLI)")
+    fi
+
+    # tmux
+    if ! command -v tmux &> /dev/null; then
+        missing+=("tmux")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing dependencies:"
+        for dep in "${missing[@]}"; do
+            echo "  - $dep" >&2
+        done
+        return 1
+    fi
+
+    return 0
+}
+
+# プロジェクトをレビューしてIssueを作成
+# 引数:
+#   $1 - max_issues: 最大Issue数
+#   $2 - dry_run: ドライランモード
+#   $3 - review_only: レビューのみモード
+review_and_create_issues() {
+    local max_issues="$1"
+    local dry_run="$2"
+    local review_only="$3"
+    
+    local output_file
+    output_file="$(mktemp)"
+    trap "rm -f '$output_file'" RETURN
+    
+    local pi_command
+    pi_command="$(get_config pi_command)"
+    
+    # プロンプトの構築
+    local review_prompt
+    if [[ "$review_only" == "true" ]]; then
+        review_prompt="project-reviewスキルを使用してプロジェクト全体をレビューし、発見した問題を一覧で表示してください。Issue作成は行わないでください。"
+    elif [[ "$dry_run" == "true" ]]; then
+        review_prompt="project-reviewスキルを使用してプロジェクト全体をレビューし、発見した問題を一覧で表示してください。
+発見した問題のうち、作成するべきIssueがあれば、以下の形式で番号を出力してください（実際にはIssue作成しないでください）:
+
+###WOULD_CREATE_ISSUES###
+<仮のIssue番号または説明を1行ずつ>
+###END_ISSUES###"
+    else
+        review_prompt="project-reviewスキルを使用してプロジェクト全体を厳格にレビューし、発見した問題からGitHub Issueを作成してください。
+最大${max_issues}件までのIssueを作成してください。
+
+作成したIssue番号を以下の形式で最後に必ず出力してください:
+###CREATED_ISSUES###
+<Issue番号を1行ずつ、数字のみ>
+###END_ISSUES###
+
+例:
+###CREATED_ISSUES###
+147
+148
+###END_ISSUES###"
+    fi
+
+    echo "[pi] レビュー実行中..."
+    
+    # piを実行
+    if ! "$pi_command" --message "$review_prompt" 2>&1 | tee "$output_file"; then
+        log_error "pi command failed"
+        return 1
+    fi
+
+    # Issue番号を抽出
+    if [[ "$dry_run" == "true" ]]; then
+        # ドライランモードでは仮のIssue番号を表示するのみ
+        echo "[dry-run] 以下のIssueが作成される予定でした:"
+        sed -n '/###WOULD_CREATE_ISSUES###/,/###END_ISSUES###/p' "$output_file" \
+            | grep -v '###' \
+            | head -n "$max_issues" \
+            || true
+        CREATED_ISSUES=()
+    elif [[ "$review_only" == "true" ]]; then
+        # レビューのみモードではIssue番号を抽出しない
+        CREATED_ISSUES=()
+    else
+        # Issue番号を抽出（数字のみの行）
+        local issues_text
+        issues_text=$(sed -n '/###CREATED_ISSUES###/,/###END_ISSUES###/p' "$output_file" \
+            | grep -E '^[0-9]+$' \
+            | head -n "$max_issues") || true
+        
+        if [[ -n "$issues_text" ]]; then
+            while IFS= read -r issue; do
+                if [[ -n "$issue" && "$issue" =~ ^[0-9]+$ ]]; then
+                    CREATED_ISSUES+=("$issue")
+                fi
+            done <<< "$issues_text"
+        fi
+    fi
+
+    return 0
+}
+
+main "$@"

--- a/scripts/wait-for-sessions.sh
+++ b/scripts/wait-for-sessions.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# wait-for-sessions.sh - 複数セッションの完了を待機
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/status.sh"
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") <issue-number>... [options]
+
+Arguments:
+    issue-number...   待機するIssue番号（複数指定可）
+
+Options:
+    --timeout <sec>   タイムアウト秒数（デフォルト: 3600 = 1時間）
+    --interval <sec>  チェック間隔（デフォルト: 5秒）
+    --fail-fast       1つでもエラーになったら即座に終了
+    --quiet           進捗表示を抑制
+    -h, --help        このヘルプを表示
+
+Description:
+    指定したIssue番号のセッションがすべて完了するまで待機します。
+    ステータスファイル (.worktrees/.status/<issue>.json) を監視し、
+    全セッションが complete になったら正常終了します。
+
+Examples:
+    $(basename "$0") 140 141 144
+    $(basename "$0") 140 141 --timeout 1800
+    $(basename "$0") 140 141 --fail-fast
+
+Exit codes:
+    0 - 全セッションが正常完了
+    1 - 1つ以上のセッションがエラー
+    2 - タイムアウト
+    3 - 引数エラー
+EOF
+}
+
+main() {
+    local -a issues=()
+    local timeout=3600
+    local interval=5
+    local fail_fast=false
+    local quiet=false
+
+    # 引数のパース
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --timeout)
+                timeout="$2"
+                shift 2
+                ;;
+            --interval)
+                interval="$2"
+                shift 2
+                ;;
+            --fail-fast)
+                fail_fast=true
+                shift
+                ;;
+            --quiet|-q)
+                quiet=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage >&2
+                exit 3
+                ;;
+            *)
+                # 数字のみ許可
+                if [[ "$1" =~ ^[0-9]+$ ]]; then
+                    issues+=("$1")
+                else
+                    log_error "Invalid issue number: $1"
+                    exit 3
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ ${#issues[@]} -eq 0 ]]; then
+        log_error "At least one issue number is required"
+        usage >&2
+        exit 3
+    fi
+
+    load_config
+
+    if [[ "$quiet" != "true" ]]; then
+        log_info "Waiting for ${#issues[@]} session(s): ${issues[*]}"
+        log_info "Timeout: ${timeout}s, Check interval: ${interval}s"
+    fi
+
+    wait_for_sessions "${issues[@]}"
+}
+
+# セッション完了を待機
+# 引数: Issue番号の配列
+# 戻り値: 0=全完了, 1=エラー発生, 2=タイムアウト
+wait_for_sessions() {
+    local issues_str="$*"
+    local start_time
+    start_time=$(date +%s)
+    
+    # 完了/エラー済みのIssueをスペース区切りで保持（Bash 3.x互換）
+    local completed_list=""
+    local errored_list=""
+    
+    while true; do
+        local all_done=true
+        local has_error=false
+        
+        for issue in $issues_str; do
+            # 既に完了/エラー判定済みはスキップ
+            if echo " $completed_list " | grep -q " $issue "; then
+                continue
+            fi
+            if echo " $errored_list " | grep -q " $issue "; then
+                continue
+            fi
+            
+            local status
+            status="$(get_status "$issue")"
+            
+            case "$status" in
+                complete)
+                    completed_list="$completed_list $issue"
+                    if [[ "$quiet" != "true" ]]; then
+                        echo "[✓] Issue #$issue 完了"
+                    fi
+                    ;;
+                error)
+                    errored_list="$errored_list $issue"
+                    has_error=true
+                    local error_msg
+                    error_msg="$(get_error_message "$issue")"
+                    if [[ "$quiet" != "true" ]]; then
+                        echo "[✗] Issue #$issue エラー: $error_msg"
+                    fi
+                    if [[ "$fail_fast" == "true" ]]; then
+                        log_error "Fail-fast enabled. Exiting due to error in issue #$issue"
+                        return 1
+                    fi
+                    ;;
+                running)
+                    all_done=false
+                    ;;
+                unknown)
+                    # セッションがまだ開始されていないか、既にクリーンアップ済み
+                    all_done=false
+                    ;;
+            esac
+        done
+        
+        # 全て完了判定
+        if [[ "$all_done" == "true" ]]; then
+            if [[ "$has_error" == "true" ]]; then
+                # エラー数をカウント
+                local error_count
+                error_count=$(echo "$errored_list" | wc -w | tr -d ' ')
+                if [[ "$quiet" != "true" ]]; then
+                    log_error "$error_count session(s) failed"
+                fi
+                return 1
+            fi
+            # 完了数をカウント
+            local total_count
+            total_count=$(echo "$issues_str" | wc -w | tr -d ' ')
+            if [[ "$quiet" != "true" ]]; then
+                log_info "All $total_count session(s) completed successfully"
+            fi
+            return 0
+        fi
+        
+        # タイムアウトチェック
+        local current_time
+        current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+        
+        if [[ $elapsed -ge $timeout ]]; then
+            local running_count=0
+            for issue in $issues_str; do
+                if ! echo " $completed_list " | grep -q " $issue " && ! echo " $errored_list " | grep -q " $issue "; then
+                    ((running_count++)) || true
+                fi
+            done
+            if [[ "$quiet" != "true" ]]; then
+                log_error "Timeout after ${elapsed}s. $running_count session(s) still running."
+            fi
+            return 2
+        fi
+        
+        # 進捗表示（verboseモード）
+        if [[ "$quiet" != "true" ]] && [[ "${LOG_LEVEL:-INFO}" == "DEBUG" ]]; then
+            local completed_count
+            local errored_count
+            local total
+            completed_count=$(echo "$completed_list" | wc -w | tr -d ' ')
+            errored_count=$(echo "$errored_list" | wc -w | tr -d ' ')
+            total=$(echo "$issues_str" | wc -w | tr -d ' ')
+            log_debug "Progress: $completed_count/$total complete, $errored_count errors, ${elapsed}s elapsed"
+        fi
+        
+        sleep "$interval"
+    done
+}
+
+main "$@"

--- a/test/status_test.sh
+++ b/test/status_test.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# status_test.sh - status.sh のテスト
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# テスト用のテンポラリディレクトリ
+TEST_TMP_DIR=""
+
+setup() {
+    TEST_TMP_DIR="$(mktemp -d)"
+    
+    # ライブラリを読み込み
+    source "$SCRIPT_DIR/../lib/config.sh"
+    source "$SCRIPT_DIR/../lib/status.sh"
+    
+    # テスト用の設定を上書き
+    get_config() {
+        case "$1" in
+            worktree_base_dir) echo "$TEST_TMP_DIR/.worktrees" ;;
+            *) echo "" ;;
+        esac
+    }
+    
+    mkdir -p "$TEST_TMP_DIR/.worktrees"
+    
+    # ログを抑制
+    LOG_LEVEL="ERROR"
+}
+
+teardown() {
+    if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" ]]; then
+        rm -rf "$TEST_TMP_DIR"
+    fi
+}
+
+# テスト結果カウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_file_exists() {
+    local description="$1"
+    local filepath="$2"
+    
+    if [[ -f "$filepath" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  File does not exist: $filepath"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_dir_exists() {
+    local description="$1"
+    local dirpath="$2"
+    
+    if [[ -d "$dirpath" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Directory does not exist: $dirpath"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_file_contains() {
+    local description="$1"
+    local filepath="$2"
+    local pattern="$3"
+    
+    if grep -q "$pattern" "$filepath" 2>/dev/null; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Pattern '$pattern' not found in $filepath"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# テスト実行
+echo "=== status.sh tests ==="
+echo ""
+
+# セットアップ
+setup
+
+# --- get_status_dir テスト ---
+echo "--- get_status_dir ---"
+status_dir="$(get_status_dir)"
+expected_status_dir="$TEST_TMP_DIR/.worktrees/.status"
+assert_equals "get_status_dir returns correct path" "$expected_status_dir" "$status_dir"
+
+# --- init_status_dir テスト ---
+echo ""
+echo "--- init_status_dir ---"
+init_status_dir
+assert_dir_exists "init_status_dir creates directory" "$status_dir"
+
+# --- save_status テスト ---
+echo ""
+echo "--- save_status ---"
+save_status "42" "running" "pi-issue-42"
+assert_file_exists "save_status creates status file" "$status_dir/42.json"
+assert_file_contains "save_status writes issue number" "$status_dir/42.json" '"issue": 42'
+assert_file_contains "save_status writes status" "$status_dir/42.json" '"status": "running"'
+assert_file_contains "save_status writes session" "$status_dir/42.json" '"session": "pi-issue-42"'
+
+# --- set_status テスト（エイリアス） ---
+echo ""
+echo "--- set_status (alias) ---"
+set_status "50" "running"
+assert_file_exists "set_status creates status file" "$status_dir/50.json"
+status="$(get_status "50")"
+assert_equals "set_status sets running status" "running" "$status"
+
+set_status "51" "complete"
+status="$(get_status "51")"
+assert_equals "set_status sets complete status" "complete" "$status"
+
+set_status "52" "error" "Something went wrong"
+status="$(get_status "52")"
+assert_equals "set_status sets error status" "error" "$status"
+
+# --- save_status with error ---
+echo ""
+echo "--- save_status with error ---"
+save_status "43" "error" "pi-issue-43" "Test error message"
+assert_file_exists "save_status creates error status file" "$status_dir/43.json"
+assert_file_contains "save_status writes error_message" "$status_dir/43.json" '"error_message":'
+assert_file_contains "save_status writes error message content" "$status_dir/43.json" 'Test error message'
+assert_file_contains "save_status writes error status" "$status_dir/43.json" '"status": "error"'
+
+# --- load_status テスト ---
+echo ""
+echo "--- load_status ---"
+json="$(load_status "42")"
+assert_file_contains "load_status returns valid JSON" <(echo "$json") '"issue": 42'
+
+# --- get_status_value テスト ---
+echo ""
+echo "--- get_status_value ---"
+status_value="$(get_status_value "42")"
+assert_equals "get_status_value returns running" "running" "$status_value"
+
+status_value="$(get_status_value "43")"
+assert_equals "get_status_value returns error" "error" "$status_value"
+
+status_value="$(get_status_value "999")"
+assert_equals "get_status_value returns unknown for non-existent" "unknown" "$status_value"
+
+# --- get_status テスト（エイリアス）---
+echo ""
+echo "--- get_status (alias) ---"
+status="$(get_status "42")"
+assert_equals "get_status returns running" "running" "$status"
+
+status="$(get_status "999")"
+assert_equals "get_status returns unknown for non-existent" "unknown" "$status"
+
+# --- get_error_message テスト ---
+echo ""
+echo "--- get_error_message ---"
+error_msg="$(get_error_message "43")"
+# トリムして比較
+error_msg_trimmed="${error_msg%% }"
+assert_equals "get_error_message returns error message" "Test error message" "$error_msg_trimmed"
+
+error_msg="$(get_error_message "42")"
+assert_equals "get_error_message returns empty for non-error" "" "$error_msg"
+
+# --- remove_status テスト ---
+echo ""
+echo "--- remove_status ---"
+remove_status "42"
+status_value="$(get_status_value "42")"
+assert_equals "remove_status removes file" "unknown" "$status_value"
+
+# --- list_all_statuses テスト ---
+echo ""
+echo "--- list_all_statuses ---"
+# 新しいステータスを追加
+save_status "100" "running" "pi-issue-100"
+save_status "101" "complete" "pi-issue-101"
+save_status "102" "error" "pi-issue-102" "test error"
+
+all_statuses="$(list_all_statuses)"
+if echo "$all_statuses" | grep -q "100"; then
+    echo "✓ list_all_statuses includes issue 100"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ list_all_statuses should include issue 100"
+    ((TESTS_FAILED++)) || true
+fi
+
+if echo "$all_statuses" | grep -q "101"; then
+    echo "✓ list_all_statuses includes issue 101"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ list_all_statuses should include issue 101"
+    ((TESTS_FAILED++)) || true
+fi
+
+# --- list_issues_by_status テスト ---
+echo ""
+echo "--- list_issues_by_status ---"
+running_issues="$(list_issues_by_status "running")"
+if echo "$running_issues" | grep -q "100"; then
+    echo "✓ list_issues_by_status(running) includes issue 100"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ list_issues_by_status(running) should include issue 100"
+    ((TESTS_FAILED++)) || true
+fi
+
+complete_issues="$(list_issues_by_status "complete")"
+if echo "$complete_issues" | grep -q "101"; then
+    echo "✓ list_issues_by_status(complete) includes issue 101"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ list_issues_by_status(complete) should include issue 101"
+    ((TESTS_FAILED++)) || true
+fi
+
+# --- JSON escape テスト ---
+echo ""
+echo "--- JSON escape in save_status ---"
+save_status "44" "error" "pi-issue-44" 'Error with "quotes" and \backslash'
+json_content="$(cat "$status_dir/44.json")"
+# JSONが有効かチェック（jqがあれば）
+if command -v jq &>/dev/null; then
+    if echo "$json_content" | jq . > /dev/null 2>&1; then
+        echo "✓ JSON with special chars is valid"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ JSON with special chars is invalid"
+        ((TESTS_FAILED++)) || true
+    fi
+else
+    echo "⚠ Skipping JSON validation (jq not installed)"
+fi
+
+# クリーンアップ
+teardown
+
+# 結果表示
+echo ""
+echo "=== Results ==="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+
+exit $TESTS_FAILED

--- a/test/wait_for_sessions_test.sh
+++ b/test/wait_for_sessions_test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# wait_for_sessions_test.sh - wait-for-sessions.sh のテスト
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/.."
+
+# テスト用のテンポラリディレクトリ
+TEST_TMP_DIR=""
+
+setup() {
+    TEST_TMP_DIR="$(mktemp -d)"
+    
+    # ライブラリを読み込み
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    # テスト用の設定を上書き
+    get_config() {
+        case "$1" in
+            worktree_base_dir) echo "$TEST_TMP_DIR/.worktrees" ;;
+            *) echo "" ;;
+        esac
+    }
+    
+    mkdir -p "$TEST_TMP_DIR/.worktrees/.status"
+    
+    # ログを抑制
+    LOG_LEVEL="ERROR"
+}
+
+teardown() {
+    if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" ]]; then
+        rm -rf "$TEST_TMP_DIR"
+    fi
+}
+
+# テスト結果カウンター
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_exit_code() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected exit code: $expected"
+        echo "  Actual exit code:   $actual"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# テスト実行
+echo "=== wait-for-sessions.sh tests ==="
+echo ""
+
+# セットアップ
+setup
+
+# --- ヘルプ表示テスト ---
+echo "--- help display ---"
+help_output=$("$PROJECT_ROOT/scripts/wait-for-sessions.sh" --help 2>&1) || true
+if echo "$help_output" | grep -q "Usage:"; then
+    echo "✓ --help shows usage"
+    ((TESTS_PASSED++)) || true
+else
+    echo "✗ --help should show usage"
+    ((TESTS_FAILED++)) || true
+fi
+
+# --- 引数なしエラーテスト ---
+echo ""
+echo "--- no arguments error ---"
+set +e
+"$PROJECT_ROOT/scripts/wait-for-sessions.sh" 2>/dev/null
+exit_code=$?
+set -e
+assert_exit_code "No arguments returns exit code 3" "3" "$exit_code"
+
+# --- 不正なIssue番号エラーテスト ---
+echo ""
+echo "--- invalid issue number error ---"
+set +e
+"$PROJECT_ROOT/scripts/wait-for-sessions.sh" "abc" 2>/dev/null
+exit_code=$?
+set -e
+assert_exit_code "Invalid issue number returns exit code 3" "3" "$exit_code"
+
+# --- すべて完了済みのテスト ---
+echo ""
+echo "--- all sessions complete ---"
+
+# テスト用ステータスディレクトリを設定
+export PI_RUNNER_WORKTREE_BASE_DIR="$TEST_TMP_DIR/.worktrees"
+
+# 完了ステータスを作成
+mkdir -p "$TEST_TMP_DIR/.worktrees/.status"
+cat > "$TEST_TMP_DIR/.worktrees/.status/200.json" << 'EOF'
+{
+  "issue": 200,
+  "status": "complete",
+  "session": "pi-issue-200",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+cat > "$TEST_TMP_DIR/.worktrees/.status/201.json" << 'EOF'
+{
+  "issue": 201,
+  "status": "complete",
+  "session": "pi-issue-201",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+set +e
+output=$("$PROJECT_ROOT/scripts/wait-for-sessions.sh" 200 201 --interval 1 --timeout 5 --quiet 2>&1)
+exit_code=$?
+set -e
+assert_exit_code "All complete returns exit code 0" "0" "$exit_code"
+
+# --- エラーセッションのテスト ---
+echo ""
+echo "--- session with error ---"
+
+cat > "$TEST_TMP_DIR/.worktrees/.status/300.json" << 'EOF'
+{
+  "issue": 300,
+  "status": "error",
+  "session": "pi-issue-300",
+  "error_message": "Test error",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+set +e
+output=$("$PROJECT_ROOT/scripts/wait-for-sessions.sh" 300 --interval 1 --timeout 5 --quiet 2>&1)
+exit_code=$?
+set -e
+assert_exit_code "Error session returns exit code 1" "1" "$exit_code"
+
+# --- タイムアウトテスト ---
+echo ""
+echo "--- timeout test ---"
+
+# 実行中のままのステータス
+cat > "$TEST_TMP_DIR/.worktrees/.status/400.json" << 'EOF'
+{
+  "issue": 400,
+  "status": "running",
+  "session": "pi-issue-400",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+set +e
+output=$("$PROJECT_ROOT/scripts/wait-for-sessions.sh" 400 --interval 1 --timeout 2 --quiet 2>&1)
+exit_code=$?
+set -e
+assert_exit_code "Timeout returns exit code 2" "2" "$exit_code"
+
+# --- fail-fast テスト ---
+echo ""
+echo "--- fail-fast test ---"
+
+cat > "$TEST_TMP_DIR/.worktrees/.status/500.json" << 'EOF'
+{
+  "issue": 500,
+  "status": "running",
+  "session": "pi-issue-500",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+cat > "$TEST_TMP_DIR/.worktrees/.status/501.json" << 'EOF'
+{
+  "issue": 501,
+  "status": "error",
+  "session": "pi-issue-501",
+  "error_message": "Immediate failure",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+set +e
+output=$("$PROJECT_ROOT/scripts/wait-for-sessions.sh" 500 501 --interval 1 --timeout 10 --fail-fast --quiet 2>&1)
+exit_code=$?
+set -e
+assert_exit_code "Fail-fast returns exit code 1 immediately" "1" "$exit_code"
+
+# --- 混合ステータステスト ---
+echo ""
+echo "--- mixed status (complete + error) ---"
+
+cat > "$TEST_TMP_DIR/.worktrees/.status/600.json" << 'EOF'
+{
+  "issue": 600,
+  "status": "complete",
+  "session": "pi-issue-600",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+cat > "$TEST_TMP_DIR/.worktrees/.status/601.json" << 'EOF'
+{
+  "issue": 601,
+  "status": "error",
+  "session": "pi-issue-601",
+  "error_message": "Failed",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+EOF
+
+set +e
+output=$("$PROJECT_ROOT/scripts/wait-for-sessions.sh" 600 601 --interval 1 --timeout 5 --quiet 2>&1)
+exit_code=$?
+set -e
+assert_exit_code "Mixed status (complete + error) returns exit code 1" "1" "$exit_code"
+
+# クリーンアップ
+unset PI_RUNNER_WORKTREE_BASE_DIR
+teardown
+
+# 結果表示
+echo ""
+echo "=== Results ==="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+
+exit $TESTS_FAILED


### PR DESCRIPTION
## Summary
Closes #146

## Changes
- **lib/status.sh**: ステータスファイル管理機能を新規追加
  - `set_status()`, `get_status()` エイリアス追加
  - `list_all_statuses()`, `list_issues_by_status()` 追加
- **lib/notify.sh**: status.sh をsourceするようにリファクタリング（後方互換性維持）
- **scripts/wait-for-sessions.sh**: 複数セッション完了待機スクリプト
  - `--timeout`, `--interval`, `--fail-fast`, `--quiet` オプション
  - Bash 3.x互換（associative array不使用）
- **scripts/improve.sh**: 継続的改善メインスクリプト
  - `--max-iterations`, `--max-issues`, `--auto-continue`, `--dry-run`
  - `--review-only`, `--timeout` オプション
- **README.md**: 新機能のドキュメント追加
- **test/status_test.sh**: ステータス機能テスト（28項目）
- **test/wait_for_sessions_test.sh**: 待機機能テスト（8項目）

## Testing
- 全テストパス（`for f in test/*_test.sh; do bash "$f"; done`）
- Bash 3.x互換性確認済み
- 既存のnotify_test.shも引き続きパス

## Usage
```bash
# 継続的改善を実行
./scripts/improve.sh

# オプション指定
./scripts/improve.sh --max-iterations 2 --max-issues 3 --auto-continue

# 複数セッション完了待機
./scripts/wait-for-sessions.sh 140 141 144 --timeout 1800
```