### PR TITLE
docs: SKILL.mdとAGENTS.mdに新機能を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,15 @@ pi-issue-runner/
 │   ├── status.sh      # 状態確認
 │   ├── attach.sh      # セッションアタッチ
 │   ├── stop.sh        # セッション停止
-│   └── cleanup.sh     # クリーンアップ
+│   ├── cleanup.sh     # クリーンアップ
+│   ├── improve.sh     # 継続的改善スクリプト
+│   └── wait-for-sessions.sh  # 複数セッション完了待機
 ├── lib/               # 共通ライブラリ
 │   ├── config.sh      # 設定読み込み
 │   ├── github.sh      # GitHub CLI操作
 │   ├── log.sh         # ログ出力
+│   ├── notify.sh      # 通知機能
+│   ├── status.sh      # 状態管理
 │   ├── tmux.sh        # tmux操作
 │   ├── workflow.sh    # ワークフローエンジン
 │   └── worktree.sh    # Git worktree操作
@@ -62,6 +66,12 @@ shellcheck scripts/*.sh lib/*.sh
 # 手動テスト
 ./scripts/list.sh -v
 ./scripts/status.sh 42
+
+# 継続的改善
+./scripts/improve.sh --dry-run
+
+# 複数セッション待機
+./scripts/wait-for-sessions.sh 42 43
 ```
 
 ## コーディング規約

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,11 @@ scripts/attach.sh <session>  # セッションにアタッチ
 scripts/status.sh <session>  # 状態確認
 scripts/stop.sh <session>    # セッション停止
 scripts/cleanup.sh <session> # 手動クリーンアップ
+
+# 継続的改善
+scripts/improve.sh                    # レビュー→Issue作成→実行→待機のループ
+scripts/improve.sh --dry-run          # レビューのみ
+scripts/wait-for-sessions.sh 42 43    # 複数セッション完了待機
 ```
 
 ## 前提条件

--- a/docs/plans/issue-150-plan.md
+++ b/docs/plans/issue-150-plan.md
@@ -1,0 +1,35 @@
+# Issue #150 実装計画
+
+## 概要
+
+#146で追加された新機能（improve.sh, wait-for-sessions.sh, notify.sh, status.sh）のドキュメントをSKILL.mdとAGENTS.mdに追加する。
+
+## 影響範囲
+
+- `SKILL.md` - クイックリファレンスに継続的改善セクション追加
+- `AGENTS.md` - ディレクトリ構造と開発コマンド更新
+
+## 実装ステップ
+
+### 1. SKILL.md更新
+- クイックリファレンスに「継続的改善」セクションを追加
+- `scripts/improve.sh` の使用方法を記載
+- `scripts/wait-for-sessions.sh` の使用方法を記載
+
+### 2. AGENTS.md更新
+- ディレクトリ構造に以下を追加:
+  - `scripts/improve.sh`
+  - `scripts/wait-for-sessions.sh`
+  - `lib/notify.sh`
+  - `lib/status.sh`
+- 開発コマンドに継続的改善と複数セッション待機のコマンドを追加
+
+## テスト方針
+
+- ドキュメントの変更のみなので、構文チェックは不要
+- 目視確認で正しく追加されていることを確認
+
+## リスクと対策
+
+- リスク: マークダウンのフォーマット崩れ
+- 対策: 既存のスタイルに合わせて追加


### PR DESCRIPTION
## Summary
Closes #150

## Changes
- SKILL.mdのクイックリファレンスに「継続的改善」セクションを追加
  - scripts/improve.sh の使用方法
  - scripts/wait-for-sessions.sh の使用方法
- AGENTS.mdのディレクトリ構造を更新
  - scripts/improve.sh
  - scripts/wait-for-sessions.sh
  - lib/notify.sh
  - lib/status.sh
- AGENTS.mdの開発コマンドセクションに継続的改善コマンドを追加

## Testing
- ドキュメントの変更のみ
- マークダウンのフォーマットを目視確認済み