### PR TITLE
fix: improve.shがIssue番号を抽出できないバグを修正

### DIFF
--- a/docs/plans/issue-155-plan.md
+++ b/docs/plans/issue-155-plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Issue #155
+
+## 概要
+
+`improve.sh`の`review_and_create_issues`関数がIssue番号を抽出する際、先頭スペースがある行を正しく処理できないバグを修正する。
+
+## 原因分析
+
+問題のコード（233-235行目）:
+```bash
+issues_text=$(sed -n '/###CREATED_ISSUES###/,/###END_ISSUES###/p' "$output_file" \
+    | grep -E '^[0-9]+$' \
+    | head -n "$max_issues") || true
+```
+
+`grep -E '^[0-9]+$'` は行頭が数字で始まることを要求するため、以下のような入力で失敗する:
+```
+ ###CREATED_ISSUES###
+ 152
+ 153
+ ###END_ISSUES###
+```
+
+## 影響範囲
+
+- `scripts/improve.sh` - `review_and_create_issues`関数のIssue番号抽出部分
+- 影響を受けるモード: 通常モード（`dry_run=false`, `review_only=false`）のみ
+
+## 実装ステップ
+
+### Step 1: Issue番号抽出ロジックの修正
+
+修正案: `grep -oE '[0-9]+'` を使用して、行内の数字のみを抽出する。
+
+**修正前:**
+```bash
+issues_text=$(sed -n '/###CREATED_ISSUES###/,/###END_ISSUES###/p' "$output_file" \
+    | grep -E '^[0-9]+$' \
+    | head -n "$max_issues") || true
+```
+
+**修正後:**
+```bash
+issues_text=$(sed -n '/###CREATED_ISSUES###/,/###END_ISSUES###/p' "$output_file" \
+    | grep -oE '[0-9]+' \
+    | head -n "$max_issues") || true
+```
+
+### Step 2: テストの追加
+
+`test/improve_test.sh` を新規作成し、Issue番号抽出のテストケースを追加:
+- 空白なしの正常ケース
+- 先頭スペースありのケース
+- 末尾スペースありのケース
+- マーカーが見つからないケース
+- Issue番号がないケース
+
+## テスト方針
+
+1. **単体テスト**: `test/improve_test.sh` でIssue番号抽出ロジックをテスト
+2. **手動テスト**: 実際にスペースを含む出力ファイルを作成してテスト
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| `grep -oE` が複数の数字を1行から抽出する | マーカー間の行のみを対象とするため問題なし |
+| テキスト中の数字を誤抽出 | マーカーで囲まれた範囲のみを処理するため安全 |
+
+## 見積もり
+
+- 修正: 10分
+- テスト追加: 15分
+- レビュー: 5分
+- **合計: 30分**

--- a/scripts/improve.sh
+++ b/scripts/improve.sh
@@ -301,10 +301,10 @@ review_and_create_issues() {
         # レビューのみモードではIssue番号を抽出しない
         CREATED_ISSUES=()
     else
-        # Issue番号を抽出（数字のみの行）
+        # Issue番号を抽出（数字のみ、先頭・末尾の空白を許容）
         local issues_text
         issues_text=$(sed -n '/###CREATED_ISSUES###/,/###END_ISSUES###/p' "$output_file" \
-            | grep -E '^[0-9]+$' \
+            | grep -oE '[0-9]+' \
             | head -n "$max_issues") || true
         
         if [[ -n "$issues_text" ]]; then

--- a/test/improve_test.sh
+++ b/test/improve_test.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# improve_test.sh - Tests for improve.sh issue number extraction
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Test helper functions
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+assert_array_equals() {
+    local description="$1"
+    shift
+    local -a expected=()
+    local -a actual=()
+    
+    # Parse expected and actual arrays
+    local parsing_expected=true
+    for arg in "$@"; do
+        if [[ "$arg" == "--" ]]; then
+            parsing_expected=false
+            continue
+        fi
+        if $parsing_expected; then
+            expected+=("$arg")
+        else
+            actual+=("$arg")
+        fi
+    done
+    
+    if [[ "${expected[*]:-}" == "${actual[*]:-}" ]]; then
+        echo "✓ $description"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "✗ $description"
+        echo "  Expected: (${expected[*]:-})"
+        echo "  Actual:   (${actual[*]:-})"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# Function to extract issue numbers (same logic as improve.sh)
+extract_issue_numbers() {
+    local input_file="$1"
+    local max_issues="${2:-5}"
+    
+    sed -n '/###CREATED_ISSUES###/,/###END_ISSUES###/p' "$input_file" \
+        | grep -oE '[0-9]+' \
+        | head -n "$max_issues"
+}
+
+# ==================== Tests ====================
+
+echo "=== improve.sh issue extraction tests ==="
+echo ""
+
+# Test 1: Normal case - no leading spaces
+test_normal_case() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+Some output from pi...
+###CREATED_ISSUES###
+152
+153
+154
+###END_ISSUES###
+Done.
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file")
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "Normal case: extracts issue numbers without spaces" \
+        "152" "153" "154" -- "${result[@]}"
+}
+
+# Test 2: Leading spaces - the bug case
+test_leading_spaces() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+Some output from pi...
+ ###CREATED_ISSUES###
+ 152
+ 153
+ 154
+ ###END_ISSUES###
+Done.
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file")
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "Leading spaces: extracts issue numbers with leading spaces" \
+        "152" "153" "154" -- "${result[@]}"
+}
+
+# Test 3: Trailing spaces
+test_trailing_spaces() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+###CREATED_ISSUES###
+152  
+153	
+154   
+###END_ISSUES###
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file")
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "Trailing spaces: extracts issue numbers with trailing spaces" \
+        "152" "153" "154" -- "${result[@]}"
+}
+
+# Test 4: Mixed spaces (leading and trailing)
+test_mixed_spaces() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+   ###CREATED_ISSUES###
+   152   
+   153   
+   ###END_ISSUES###
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file")
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "Mixed spaces: extracts issue numbers with mixed spaces" \
+        "152" "153" -- "${result[@]}"
+}
+
+# Test 5: No markers found
+test_no_markers() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+Some output without markers
+152
+153
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file")
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "No markers: returns empty array" \
+        -- "${result[@]:-}"
+}
+
+# Test 6: Empty between markers
+test_empty_between_markers() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+###CREATED_ISSUES###
+###END_ISSUES###
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file")
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "Empty between markers: returns empty array" \
+        -- "${result[@]:-}"
+}
+
+# Test 7: Max issues limit
+test_max_issues_limit() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+###CREATED_ISSUES###
+1
+2
+3
+4
+5
+6
+7
+###END_ISSUES###
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file" 3)
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "Max issues limit: respects limit of 3" \
+        "1" "2" "3" -- "${result[@]}"
+}
+
+# Test 8: Single issue number
+test_single_issue() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+    cat > "$tmp_file" << 'EOF'
+###CREATED_ISSUES###
+ 999
+###END_ISSUES###
+EOF
+    
+    local -a result=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && result+=("$line")
+    done < <(extract_issue_numbers "$tmp_file")
+    
+    rm -f "$tmp_file"
+    
+    assert_array_equals "Single issue: extracts single issue number" \
+        "999" -- "${result[@]}"
+}
+
+# Run all tests
+test_normal_case
+test_leading_spaces
+test_trailing_spaces
+test_mixed_spaces
+test_no_markers
+test_empty_between_markers
+test_max_issues_limit
+test_single_issue
+
+# Summary
+echo ""
+echo "=========================================="
+echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+echo "=========================================="
+
+exit $TESTS_FAILED


### PR DESCRIPTION
## Summary
Closes #155

## Changes
- `scripts/improve.sh`: Issue番号抽出ロジックを `grep -E '^[0-9]+$'` から `grep -oE '[0-9]+'` に変更し、先頭・末尾の空白を許容
- `test/improve_test.sh`: 8つのテストケースを追加（正常系、空白あり、マーカーなし、上限テストなど）
- `docs/plans/issue-155-plan.md`: 実装計画書を追加

## Testing
- 全8テストケースがパス
- 既存の230+テストに影響なし

## Root Cause
`grep -E '^[0-9]+$'` は行頭が数字で始まることを要求するため、piが先頭スペース付きで出力した場合にマッチしなかった。