### PR TITLE
docs: ドキュメントと実装の乖離を修正

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,20 +2,21 @@
 
 ## 概要
 
-Pi Issue Runnerの動作は設定ファイルでカスタマイズできます。設定ファイルはプロジェクトルートまたはホームディレクトリに配置します。
+Pi Issue Runnerの動作は設定ファイルでカスタマイズできます。設定ファイルはプロジェクトルートに配置します。
 
 ## 設定ファイルの場所
 
 設定ファイルは以下の順序で検索され、最初に見つかったものが使用されます：
 
-1. `--config` オプションで指定されたパス
-2. プロジェクトルート: `./.pi-runner.yaml`
-3. ホームディレクトリ: `~/.pi-runner/config.yaml`
-4. デフォルト設定（ファイルなし）
+1. プロジェクトルート: `./.pi-runner.yaml`
+2. 親ディレクトリを再帰的に検索
+3. デフォルト設定（ファイルなし）
+
+> **Note**: 現在、コマンドラインオプションで設定ファイルを指定する機能は未実装です。
 
 ## 設定フォーマット
 
-### YAML形式（推奨）
+### YAML形式
 
 ```yaml
 # .pi-runner.yaml
@@ -26,92 +27,22 @@ worktree:
   copy_files:                   # Worktreeに自動コピーするファイル
     - ".env"
     - ".env.local"
-    - "config/local.json"
-  symlink_node_modules: false   # node_modulesをシンボリックリンクで共有
+    - ".envrc"
 
 # Tmux設定
 tmux:
-  session_prefix: "pi-issue"    # セッション名のプレフィックス
+  session_prefix: "pi"          # セッション名のプレフィックス
   start_in_session: true        # 作成後に自動アタッチ
-  log_output: true              # 出力をファイルにログ
-  capture_interval: 1000        # 出力キャプチャ間隔（ミリ秒）
 
 # Pi設定
 pi:
   command: "pi"                 # piコマンドのパス
-  args: []                      # デフォルトで渡す引数
-  timeout: 0                    # タイムアウト（0=無制限、ミリ秒）
+  args:                         # デフォルトで渡す引数
+    - "--verbose"
 
 # 並列実行設定
 parallel:
-  max_concurrent: 5             # 最大同時実行数
-  queue_strategy: "fifo"        # キュー戦略（fifo | priority）
-  auto_cleanup: true            # 完了後に自動クリーンアップ
-  resolve_dependencies: false   # Issue間の依存関係を解決
-
-# GitHub設定
-github:
-  token: ""                     # GitHubトークン（未指定時はgh CLIを使用）
-  api_url: "https://api.github.com"  # GitHub API URL（Enterprise用）
-
-# ログ設定
-logging:
-  level: "info"                 # ログレベル（debug | info | warn | error）
-  file: ".pi-runner/system.log" # システムログファイルのパス
-  max_size: 104857600           # ログファイルの最大サイズ（バイト）
-  rotate: true                  # ログローテーション有効化
-
-# データディレクトリ設定
-data:
-  dir: ".pi-runner"             # データディレクトリ
-  backup_dir: ".pi-runner/backups"  # バックアップディレクトリ
-  auto_backup: true             # 自動バックアップ有効化
-  backup_interval: 3600000      # バックアップ間隔（ミリ秒、1時間）
-
-# リソース管理
-resources:
-  max_cpu: 80                   # CPU使用率の上限（%）
-  max_memory: 80                # メモリ使用率の上限（%）
-  min_disk_space: 1073741824    # 最小ディスク空き容量（バイト、1GB）
-
-# エラーハンドリング
-error:
-  strategy: "continue"          # 失敗戦略（continue | stop-all | retry）
-  max_retries: 3                # 最大リトライ回数
-  retry_delay: 5000             # リトライ間隔（ミリ秒）
-
-# 通知設定（将来実装）
-notifications:
-  enabled: false
-  slack_webhook: ""
-  email: ""
-```
-
-### JSON形式
-
-```json
-{
-  "worktree": {
-    "base_dir": ".worktrees",
-    "copy_files": [".env", ".env.local"],
-    "symlink_node_modules": false
-  },
-  "tmux": {
-    "session_prefix": "pi-issue",
-    "start_in_session": true,
-    "log_output": true
-  },
-  "pi": {
-    "command": "pi",
-    "args": [],
-    "timeout": 0
-  },
-  "parallel": {
-    "max_concurrent": 5,
-    "queue_strategy": "fifo",
-    "auto_cleanup": true
-  }
-}
+  max_concurrent: 5             # 最大同時実行数（0=無制限）
 ```
 
 ## 設定項目の詳細
@@ -125,35 +56,20 @@ notifications:
 
 #### copy_files
 - **型**: `string[]`
-- **デフォルト**: `[".env"]`
+- **デフォルト**: `.env .env.local .envrc`
 - **説明**: Worktree作成時にコピーするファイルのリスト（プロジェクトルートからの相対パス）
-
-#### symlink_node_modules
-- **型**: `boolean`
-- **デフォルト**: `false`
-- **説明**: `node_modules`をシンボリックリンクで共有（ディスク容量節約）
 
 ### tmux
 
 #### session_prefix
 - **型**: `string`
-- **デフォルト**: `pi-issue`
+- **デフォルト**: `pi`
 - **説明**: Tmuxセッション名のプレフィックス（実際のセッション名: `{prefix}-{issue番号}`）
 
 #### start_in_session
 - **型**: `boolean`
 - **デフォルト**: `true`
 - **説明**: タスク作成後、自動的にセッションにアタッチ
-
-#### log_output
-- **型**: `boolean`
-- **デフォルト**: `true`
-- **説明**: セッションの出力をファイルに記録
-
-#### capture_interval
-- **型**: `number`
-- **デフォルト**: `1000`
-- **説明**: 出力をキャプチャする間隔（ミリ秒）
 
 ### pi
 
@@ -164,7 +80,7 @@ notifications:
 
 #### args
 - **型**: `string[]`
-- **デフォルト**: `[]`
+- **デフォルト**: `[]`（空）
 - **説明**: piコマンドに常に渡す追加引数
 
 **例**:
@@ -176,289 +92,14 @@ pi:
     - "claude-sonnet-4"
 ```
 
-#### timeout
-- **型**: `number`
-- **デフォルト**: `0`
-- **説明**: タスクのタイムアウト（ミリ秒、0は無制限）
-
 ### parallel
 
 #### max_concurrent
 - **型**: `number`
-- **デフォルト**: `5`
+- **デフォルト**: `0`（無制限）
 - **説明**: 同時に実行できるタスクの最大数
 
 **推奨値**: CPUコア数の50-75%
-
-#### queue_strategy
-- **型**: `"fifo" | "priority"`
-- **デフォルト**: `"fifo"`
-- **説明**: タスクキューの処理戦略
-  - `fifo`: 先入れ先出し
-  - `priority`: 優先度ベース（Issueラベルから計算）
-
-#### auto_cleanup
-- **型**: `boolean`
-- **デフォルト**: `true`
-- **説明**: タスク完了後に自動的にworktreeとセッションをクリーンアップ
-
-#### resolve_dependencies
-- **型**: `boolean`
-- **デフォルト**: `false`
-- **説明**: Issue本文から依存関係を解析し、順序を調整
-
-### github
-
-#### token
-- **型**: `string`
-- **デフォルト**: `""`
-- **説明**: GitHub APIトークン（未指定時は `gh` CLIを使用）
-
-**取得方法**:
-```bash
-# gh CLIで取得
-gh auth token
-```
-
-#### api_url
-- **型**: `string`
-- **デフォルト**: `"https://api.github.com"`
-- **説明**: GitHub API URL（GitHub Enterprise Server用）
-
-### logging
-
-#### level
-- **型**: `"debug" | "info" | "warn" | "error"`
-- **デフォルト**: `"info"`
-- **説明**: ログレベル
-
-#### file
-- **型**: `string`
-- **デフォルト**: `".pi-runner/system.log"`
-- **説明**: システムログファイルのパス
-
-#### max_size
-- **型**: `number`
-- **デフォルト**: `104857600` (100MB)
-- **説明**: ログファイルの最大サイズ（バイト）
-
-#### rotate
-- **型**: `boolean`
-- **デフォルト**: `true`
-- **説明**: ログローテーション有効化
-
-### data
-
-#### dir
-- **型**: `string`
-- **デフォルト**: `".pi-runner"`
-- **説明**: タスク状態やメタデータを保存するディレクトリ
-
-#### backup_dir
-- **型**: `string`
-- **デフォルト**: `".pi-runner/backups"`
-- **説明**: バックアップファイルの保存先
-
-#### auto_backup
-- **型**: `boolean`
-- **デフォルト**: `true`
-- **説明**: 自動バックアップ有効化
-
-#### backup_interval
-- **型**: `number`
-- **デフォルト**: `3600000` (1時間)
-- **説明**: バックアップ作成間隔（ミリ秒）
-
-### resources
-
-#### max_cpu
-- **型**: `number`
-- **デフォルト**: `80`
-- **説明**: CPU使用率の上限（%）
-
-#### max_memory
-- **型**: `number`
-- **デフォルト**: `80`
-- **説明**: メモリ使用率の上限（%）
-
-#### min_disk_space
-- **型**: `number`
-- **デフォルト**: `1073741824` (1GB)
-- **説明**: 最小ディスク空き容量（バイト）
-
-### error
-
-#### strategy
-- **型**: `"continue" | "stop-all" | "retry"`
-- **デフォルト**: `"continue"`
-- **説明**: タスク失敗時の動作
-  - `continue`: 他のタスクは継続
-  - `stop-all`: 全タスクを停止
-  - `retry`: 失敗したタスクを自動リトライ
-
-#### max_retries
-- **型**: `number`
-- **デフォルト**: `3`
-- **説明**: 最大リトライ回数（`retry`戦略時のみ）
-
-#### retry_delay
-- **型**: `number`
-- **デフォルト**: `5000`
-- **説明**: リトライ間隔（ミリ秒）
-
-## 設定の読み込み
-
-### ConfigManager実装
-
-```typescript
-class ConfigManager {
-  private config: Config | null = null;
-  
-  async load(): Promise<Config> {
-    if (this.config) {
-      return this.config;
-    }
-    
-    // 設定ファイルを検索
-    const configPath = await this.findConfigFile();
-    
-    if (configPath) {
-      this.config = await this.loadFromFile(configPath);
-    } else {
-      this.config = this.getDefaults();
-    }
-    
-    // 環境変数で上書き
-    this.applyEnvironmentOverrides(this.config);
-    
-    // 検証
-    this.validate(this.config);
-    
-    return this.config;
-  }
-  
-  private async findConfigFile(): Promise<string | null> {
-    const candidates = [
-      './.pi-runner.yaml',
-      './.pi-runner.yaml',
-      './.pi-runner.json',
-      path.join(os.homedir(), '.pi-runner/config.yaml'),
-      path.join(os.homedir(), '.pi-runner/config.yaml'),
-      path.join(os.homedir(), '.pi-runner/config.json')
-    ];
-    
-    for (const candidate of candidates) {
-      if (await Bun.file(candidate).exists()) {
-        return candidate;
-      }
-    }
-    
-    return null;
-  }
-  
-  private async loadFromFile(filePath: string): Promise<Config> {
-    const ext = path.extname(filePath);
-    
-    if (ext === '.json') {
-      return await Bun.file(filePath).json();
-    } else if (ext === '.yml' || ext === '.yaml') {
-      // YAML解析（yaml パッケージを使用）
-      const content = await Bun.file(filePath).text();
-      return YAML.parse(content);
-    }
-    
-    throw new UnsupportedConfigFormatError(`Unsupported config format: ${ext}`);
-  }
-  
-  private applyEnvironmentOverrides(config: Config): void {
-    // 環境変数から設定を上書き
-    if (process.env.PI_RUNNER_MAX_CONCURRENT) {
-      config.parallel.max_concurrent = parseInt(
-        process.env.PI_RUNNER_MAX_CONCURRENT
-      );
-    }
-    
-    if (process.env.PI_RUNNER_AUTO_CLEANUP) {
-      config.parallel.auto_cleanup = 
-        process.env.PI_RUNNER_AUTO_CLEANUP === 'true';
-    }
-    
-    if (process.env.GITHUB_TOKEN) {
-      config.github.token = process.env.GITHUB_TOKEN;
-    }
-  }
-  
-  private validate(config: Config): void {
-    // 設定値の検証
-    if (config.parallel.max_concurrent < 1) {
-      throw new ConfigValidationError(
-        'parallel.max_concurrent must be at least 1'
-      );
-    }
-    
-    if (config.resources.max_cpu < 1 || config.resources.max_cpu > 100) {
-      throw new ConfigValidationError(
-        'resources.max_cpu must be between 1 and 100'
-      );
-    }
-    
-    // ... その他の検証
-  }
-  
-  getDefaults(): Config {
-    return {
-      worktree: {
-        base_dir: '.worktrees',
-        copy_files: ['.env'],
-        symlink_node_modules: false
-      },
-      tmux: {
-        session_prefix: 'pi-issue',
-        start_in_session: true,
-        log_output: true,
-        capture_interval: 1000
-      },
-      pi: {
-        command: 'pi',
-        args: [],
-        timeout: 0
-      },
-      parallel: {
-        max_concurrent: 5,
-        queue_strategy: 'fifo',
-        auto_cleanup: true,
-        resolve_dependencies: false
-      },
-      github: {
-        token: '',
-        api_url: 'https://api.github.com'
-      },
-      logging: {
-        level: 'info',
-        file: '.pi-runner/system.log',
-        max_size: 104857600,
-        rotate: true
-      },
-      data: {
-        dir: '.pi-runner',
-        backup_dir: '.pi-runner/backups',
-        auto_backup: true,
-        backup_interval: 3600000
-      },
-      resources: {
-        max_cpu: 80,
-        max_memory: 80,
-        min_disk_space: 1073741824
-      },
-      error: {
-        strategy: 'continue',
-        max_retries: 3,
-        retry_delay: 5000
-      }
-    };
-  }
-}
-```
 
 ## 環境変数
 
@@ -466,34 +107,19 @@ class ConfigManager {
 
 | 環境変数 | 説明 | 例 |
 |---------|------|-----|
-| `PI_RUNNER_MAX_CONCURRENT` | 最大同時実行数 | `10` |
-| `PI_RUNNER_AUTO_CLEANUP` | 自動クリーンアップ | `true` |
-| `PI_RUNNER_LOG_LEVEL` | ログレベル | `debug` |
-| `PI_RUNNER_DATA_DIR` | データディレクトリ | `/var/pi-runner` |
-| `GITHUB_TOKEN` | GitHubトークン | `ghp_xxxxx` |
-| `TMUX_SESSION_PREFIX` | Tmuxセッションプレフィックス | `dev-issue` |
-
-## CLIオプションによる上書き
-
-コマンドライン引数は設定ファイルと環境変数を上書きします：
-
-```bash
-# 設定ファイルを指定
-pi-run --config ./custom-config.yaml run --issue 42
-
-# 最大同時実行数を上書き
-pi-run run --issues 42,43,44 --max-concurrent 10
-
-# 自動クリーンアップを無効化
-pi-run run --issue 42 --no-auto-cleanup
-```
+| `PI_RUNNER_WORKTREE_BASE_DIR` | Worktreeのベースディレクトリ | `.worktrees` |
+| `PI_RUNNER_WORKTREE_COPY_FILES` | コピーするファイル（スペース区切り） | `.env .env.local` |
+| `PI_RUNNER_TMUX_SESSION_PREFIX` | Tmuxセッションプレフィックス | `pi` |
+| `PI_RUNNER_TMUX_START_IN_SESSION` | 自動アタッチ | `true` |
+| `PI_RUNNER_PI_COMMAND` | piコマンドのパス | `pi` |
+| `PI_RUNNER_PI_ARGS` | piコマンドの引数（スペース区切り） | `--verbose` |
+| `PI_RUNNER_PARALLEL_MAX_CONCURRENT` | 最大同時実行数 | `5` |
 
 ## 設定の優先順位
 
-1. **CLIオプション** (最優先)
-2. **環境変数**
-3. **設定ファイル**
-4. **デフォルト値** (最低優先)
+1. **環境変数** (最優先)
+2. **設定ファイル**
+3. **デフォルト値** (最低優先)
 
 ## 設定例
 
@@ -505,7 +131,7 @@ worktree:
   base_dir: ".worktrees"
   copy_files:
     - ".env.local"
-    - "config/development.json"
+    - ".envrc"
 
 tmux:
   start_in_session: true
@@ -516,10 +142,6 @@ pi:
 
 parallel:
   max_concurrent: 3
-  auto_cleanup: false  # デバッグのため無効
-
-logging:
-  level: "debug"
 ```
 
 ### 本番環境（CI/CD）
@@ -536,14 +158,6 @@ tmux:
 
 parallel:
   max_concurrent: 10
-  auto_cleanup: true
-
-logging:
-  level: "info"
-  file: "/var/log/pi-runner/system.log"
-
-error:
-  strategy: "stop-all"  # 本番では失敗時に全停止
 ```
 
 ### チーム開発
@@ -558,27 +172,53 @@ worktree:
 
 parallel:
   max_concurrent: 5
-  queue_strategy: "priority"  # 優先度ベース
-  resolve_dependencies: true  # 依存関係解決
-
-github:
-  # チームのGitHub Enterprise Server
-  api_url: "https://github.company.com/api/v3"
-
-notifications:
-  enabled: true
-  slack_webhook: "https://hooks.slack.com/services/xxx"
 ```
 
 ## 設定のベストプラクティス
 
-1. **環境ごとに設定ファイルを分ける**: `.pi-runner.dev.yaml`, `.pi-runner.prod.yaml`
-2. **機密情報は環境変数で**: GitHubトークン等は設定ファイルに含めない
-3. **リソース制限を適切に設定**: マシンスペックに応じて調整
-4. **ログレベルは環境で変える**: 開発=debug、本番=info
-5. **自動クリーンアップ**: 本番では有効、開発では無効にしてデバッグしやすく
-6. **バックアップ設定**: 本番環境では必ず有効化
-7. **設定のバージョン管理**: `.pi-runner.yaml`はGitで管理、`.env`は除外
+1. **環境ごとに設定ファイルを分ける**: 開発/本番で異なる設定を使用
+2. **機密情報は環境変数で**: `.env`ファイル等は設定ファイルに含めずコピー対象として指定
+3. **リソース制限を適切に設定**: マシンスペックに応じて`max_concurrent`を調整
+4. **設定のバージョン管理**: `.pi-runner.yaml`はGitで管理
+
+## 設定の実装詳細
+
+設定は `lib/config.sh` でBashスクリプトとして実装されています。
+
+### 主要な関数
+
+```bash
+# 設定ファイルを探す
+find_config_file [start_dir]
+
+# 設定を読み込む
+load_config [config_file]
+
+# 設定値を取得
+get_config <key>
+
+# 設定を再読み込み（テスト用）
+reload_config [config_file]
+
+# 設定を表示（デバッグ用）
+show_config
+```
+
+### 使用例
+
+```bash
+source lib/config.sh
+
+# 設定を読み込む
+load_config
+
+# 設定値を取得
+base_dir=$(get_config worktree_base_dir)
+echo "Worktree directory: $base_dir"
+
+# デバッグ: 全設定を表示
+show_config
+```
 
 ## トラブルシューティング
 
@@ -586,17 +226,12 @@ notifications:
 
 ```bash
 # 設定ファイルの場所を確認
-pi-run config --show-path
+find .pi-runner.yaml
 
-# 設定内容を表示
-pi-run config --show
-```
-
-### 設定の検証エラー
-
-```bash
-# 設定ファイルを検証
-pi-run config --validate
+# 設定内容を確認（lib/config.shのshow_config関数を使用）
+source lib/config.sh
+load_config
+show_config
 ```
 
 ### デフォルト設定に戻す
@@ -604,41 +239,20 @@ pi-run config --validate
 ```bash
 # 設定ファイルを削除
 rm .pi-runner.yaml
-
-# または、デフォルト設定を出力
-pi-run config --init
 ```
 
-## 設定スキーマ
+## 将来の拡張予定
 
-JSON Schemaで設定を検証：
+以下の機能は将来のバージョンで実装予定です：
 
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "worktree": {
-      "type": "object",
-      "properties": {
-        "base_dir": { "type": "string" },
-        "copy_files": {
-          "type": "array",
-          "items": { "type": "string" }
-        }
-      }
-    },
-    "parallel": {
-      "type": "object",
-      "properties": {
-        "max_concurrent": {
-          "type": "number",
-          "minimum": 1
-        }
-      }
-    }
-  }
-}
-```
-
-このスキーマをVS Codeで使用すると、設定ファイル編集時に補完と検証が効きます。
+- `--config` オプションによる設定ファイル指定
+- `tmux.log_output`: セッション出力のファイル記録
+- `pi.timeout`: タスクのタイムアウト設定
+- `parallel.queue_strategy`: キュー戦略（fifo/priority）
+- `parallel.auto_cleanup`: 完了後の自動クリーンアップ
+- `github`: GitHub API設定
+- `logging`: ログ設定
+- `notifications`: 通知設定（Slack等）
+- `error`: エラーハンドリング設定
+- `resources`: リソース制限設定
+- JSON形式の設定ファイルサポート

--- a/docs/plans/issue-152-plan.md
+++ b/docs/plans/issue-152-plan.md
@@ -1,0 +1,122 @@
+# 実装計画書: Issue #152
+
+## 概要
+
+`docs/configuration.md` の内容を実際の `lib/config.sh` 実装に合わせて修正します。
+
+## 影響範囲
+
+- **変更ファイル**: `docs/configuration.md`
+- **参照ファイル**: `lib/config.sh`（変更なし、参照のみ）
+
+## 問題点の詳細
+
+### 1. TypeScript実装コード（L280-L370付近）
+- `ConfigManager` クラスのTypeScriptコードが記載されている
+- 実際は `lib/config.sh` でBashスクリプトとして実装
+
+### 2. 未実装の設定項目
+ドキュメントに記載されているが、`lib/config.sh` に実装されていない設定：
+
+| 設定項目 | ドキュメント | 実装 |
+|---------|------------|------|
+| `worktree.base_dir` | ✅ | ✅ |
+| `worktree.copy_files` | ✅ | ✅ |
+| `worktree.symlink_node_modules` | ✅ | ❌ |
+| `tmux.session_prefix` | ✅ | ✅ |
+| `tmux.start_in_session` | ✅ | ✅ |
+| `tmux.log_output` | ✅ | ❌ |
+| `tmux.capture_interval` | ✅ | ❌ |
+| `pi.command` | ✅ | ✅ |
+| `pi.args` | ✅ | ✅ |
+| `pi.timeout` | ✅ | ❌ |
+| `parallel.max_concurrent` | ✅ | ✅ |
+| `parallel.queue_strategy` | ✅ | ❌ |
+| `parallel.auto_cleanup` | ✅ | ❌ |
+| `parallel.resolve_dependencies` | ✅ | ❌ |
+| `github` セクション | ✅ | ❌ |
+| `logging` セクション | ✅ | ❌ |
+| `data` セクション | ✅ | ❌ |
+| `resources` セクション | ✅ | ❌ |
+| `error` セクション | ✅ | ❌ |
+| `notifications` セクション | ✅ | ❌ |
+
+### 3. 環境変数の不一致
+実装されている環境変数（`lib/config.sh`）:
+- `PI_RUNNER_WORKTREE_BASE_DIR`
+- `PI_RUNNER_WORKTREE_COPY_FILES`
+- `PI_RUNNER_TMUX_SESSION_PREFIX`
+- `PI_RUNNER_TMUX_START_IN_SESSION`
+- `PI_RUNNER_PI_COMMAND`
+- `PI_RUNNER_PI_ARGS`
+- `PI_RUNNER_PARALLEL_MAX_CONCURRENT`
+
+ドキュメントに記載されているが未実装の環境変数:
+- `PI_RUNNER_MAX_CONCURRENT`（実装は `PI_RUNNER_PARALLEL_MAX_CONCURRENT`）
+- `PI_RUNNER_AUTO_CLEANUP`
+- `PI_RUNNER_LOG_LEVEL`
+- `PI_RUNNER_DATA_DIR`
+- `GITHUB_TOKEN`
+- `TMUX_SESSION_PREFIX`（実装は `PI_RUNNER_TMUX_SESSION_PREFIX`）
+
+### 4. 未実装のCLIオプション
+- `--config` オプション
+- `--max-concurrent` オプション
+- `--no-auto-cleanup` オプション
+- `pi-run config --show-path`
+- `pi-run config --show`
+- `pi-run config --validate`
+- `pi-run config --init`
+
+## 実装ステップ
+
+### Step 1: 設定ファイルの場所セクション修正
+- `--config` オプションの記載を削除
+- 検索順序を実装に合わせて修正
+
+### Step 2: YAML形式サンプルの修正
+- 実装されている設定項目のみに絞り込む
+- 未実装項目はコメントで「将来実装予定」と明記
+
+### Step 3: JSON形式サンプルの修正
+- YAML形式と同様に修正
+
+### Step 4: 設定項目の詳細セクション修正
+- 未実装項目を削除またはステータスを明記
+- デフォルト値を実装に合わせて修正
+
+### Step 5: TypeScriptコードの削除
+- `ConfigManager` クラスのコード例を削除
+- Bashでの実装概要に置き換え
+
+### Step 6: 環境変数セクション修正
+- 実装されている環境変数のみに修正
+
+### Step 7: CLIオプションセクション修正
+- `pi-run` を `./scripts/run.sh` に修正
+- 未実装オプションを削除
+
+### Step 8: 設定例セクション修正
+- 実装済み項目のみを使用した例に修正
+
+### Step 9: トラブルシューティングセクション修正
+- 未実装のコマンドを削除
+
+## テスト方針
+
+1. ドキュメントに記載された全設定項目が `lib/config.sh` で動作確認
+2. 環境変数のオーバーライドが正しく動作することを確認
+3. 設定ファイルのサンプルが有効なYAML/JSONであることを確認
+
+## リスクと対策
+
+| リスク | 対策 |
+|-------|------|
+| 将来実装予定の機能を削除してしまう | 「将来実装予定」セクションとして残す |
+| ユーザーが既存のドキュメントを参照している | 変更内容を明確にコミットメッセージに記載 |
+
+## 作業時間見積もり
+
+- ドキュメント修正: 1-2時間
+- レビュー・調整: 30分
+- **合計**: 約2時間


### PR DESCRIPTION
## Summary
Closes #152

## Changes
- TypeScriptコード例を削除し、Bashスクリプト実装の説明に置換
- 未実装の設定項目（symlink_node_modules, log_output, timeout等）を削除
- 環境変数名を実装に合わせて修正（PI_RUNNER_*形式）
- CLIオプション（--config等）の未実装記載を削除
- 「将来の拡張予定」セクションを追加して未実装機能を明記
- 設定例を実装済み項目のみに簡素化

## Testing
- 全245テストがパス
- ドキュメント記載の設定項目がlib/config.shの実装と一致することを確認
- 環境変数名がドキュメントと実装で一致することを確認