### PR TITLE
feat: グローバルインストール用のinstall.shを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,47 @@ which yq
 
 ## インストール
 
+### スキルとしてインストール（piから使用）
+
 piのスキルディレクトリにクローン:
 
 ```bash
 git clone https://github.com/takemo101/pi-issue-runner ~/.pi/agent/skills/pi-issue-runner
+```
+
+### グローバルインストール（コマンドラインから使用）
+
+任意のディレクトリで `pi-run 42` のようにコマンドを実行できるようにします:
+
+```bash
+cd ~/.pi/agent/skills/pi-issue-runner
+./install.sh
+```
+
+インストールされるコマンド:
+
+| コマンド | 説明 |
+|----------|------|
+| `pi-run` | Issue実行 |
+| `pi-list` | セッション一覧 |
+| `pi-attach` | セッションアタッチ |
+| `pi-status` | 状態確認 |
+| `pi-stop` | セッション停止 |
+| `pi-cleanup` | クリーンアップ |
+| `pi-improve` | 継続的改善 |
+| `pi-wait` | 完了待機 |
+| `pi-watch` | セッション監視 |
+
+カスタムインストール先を指定する場合:
+
+```bash
+INSTALL_DIR=/usr/local/bin ./install.sh
+```
+
+アンインストール:
+
+```bash
+./uninstall.sh
 ```
 
 ## 使い方

--- a/docs/plans/issue-159-plan.md
+++ b/docs/plans/issue-159-plan.md
@@ -1,0 +1,70 @@
+# Issue #159 実装計画
+
+## 概要
+
+pi-issue-runnerをグローバルインストールするためのスクリプト（install.sh、uninstall.sh）を追加し、任意のディレクトリで`pi-run 42`のようなコマンドを実行できるようにする。
+
+## 影響範囲
+
+### 新規作成ファイル
+- `install.sh` - グローバルインストールスクリプト
+- `uninstall.sh` - アンインストールスクリプト
+
+### 更新ファイル
+- `README.md` - インストールセクションの更新
+
+## 実装ステップ
+
+### 1. install.sh の作成
+- シンボリックリンクを `$HOME/.local/bin` に作成
+- 環境変数 `INSTALL_DIR` でカスタマイズ可能
+- コマンドマッピング:
+  - `pi-run` → `scripts/run.sh`
+  - `pi-list` → `scripts/list.sh`
+  - `pi-attach` → `scripts/attach.sh`
+  - `pi-status` → `scripts/status.sh`
+  - `pi-stop` → `scripts/stop.sh`
+  - `pi-cleanup` → `scripts/cleanup.sh`
+  - `pi-improve` → `scripts/improve.sh`
+  - `pi-wait` → `scripts/wait-for-sessions.sh`
+  - `pi-watch` → `scripts/watch-session.sh` （既存スクリプト）
+- PATH未設定の場合に警告を表示
+
+### 2. uninstall.sh の作成
+- シンボリックリンクを削除
+- 存在するリンクのみ削除
+
+### 3. README.md の更新
+- グローバルインストールセクションを追加
+- 使用例を追加
+
+## テスト方針
+
+### 手動テスト
+1. `./install.sh` を実行し、シンボリックリンクが作成されることを確認
+2. 作成されたコマンドが実行可能であることを確認
+3. `./uninstall.sh` を実行し、リンクが削除されることを確認
+
+### テスト内容
+- カスタム `INSTALL_DIR` での動作
+- 既存リンクがある場合の上書き動作
+- PATH警告の表示
+
+## リスクと対策
+
+### リスク1: 既存コマンドとの名前衝突
+- **対策**: `pi-` プレフィックスで衝突を回避
+
+### リスク2: シンボリックリンクの絶対パス依存
+- **対策**: `$SCRIPT_DIR` を使用して相対パスから絶対パスを解決
+
+### リスク3: 権限問題
+- **対策**: ユーザー領域（`$HOME/.local/bin`）をデフォルトに使用
+
+## 見積もり
+
+- install.sh: 30分
+- uninstall.sh: 15分
+- README更新: 15分
+- テスト: 30分
+- **合計: 1.5時間**

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# install.sh - pi-issue-runner をグローバルにインストール
+#
+# 使用方法:
+#   ./install.sh
+#   INSTALL_DIR=/usr/local/bin ./install.sh
+#
+# ラッパースクリプトを INSTALL_DIR に作成します。
+
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# コマンドマッピング（command:script 形式）
+COMMANDS="
+pi-run:scripts/run.sh
+pi-list:scripts/list.sh
+pi-attach:scripts/attach.sh
+pi-status:scripts/status.sh
+pi-stop:scripts/stop.sh
+pi-cleanup:scripts/cleanup.sh
+pi-improve:scripts/improve.sh
+pi-wait:scripts/wait-for-sessions.sh
+pi-watch:scripts/watch-session.sh
+"
+
+echo "Installing pi-issue-runner to $INSTALL_DIR..."
+mkdir -p "$INSTALL_DIR"
+
+for mapping in $COMMANDS; do
+    # 空行をスキップ
+    [[ -z "$mapping" ]] && continue
+    
+    cmd="${mapping%%:*}"
+    script="${mapping#*:}"
+    target="$SCRIPT_DIR/$script"
+    wrapper="$INSTALL_DIR/$cmd"
+    
+    # ターゲットが存在するか確認
+    if [[ ! -f "$target" ]]; then
+        echo "  ⚠️  Skipped $cmd (target not found: $script)"
+        continue
+    fi
+    
+    # ラッパースクリプトを生成
+    cat > "$wrapper" << EOF
+#!/usr/bin/env bash
+# Auto-generated wrapper for pi-issue-runner
+exec "$target" "\$@"
+EOF
+    chmod +x "$wrapper"
+    echo "  ✓ $cmd"
+done
+
+echo ""
+echo "✅ インストール完了！"
+echo ""
+
+# PATH確認
+if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+    echo "⚠️  PATHに追加してください:"
+    echo ""
+    echo "  # bashの場合"
+    echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc"
+    echo ""
+    echo "  # zshの場合"
+    echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc"
+    echo ""
+    echo "  # 現在のセッションに適用"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# uninstall.sh - pi-issue-runner をアンインストール
+#
+# 使用方法:
+#   ./uninstall.sh
+#   INSTALL_DIR=/usr/local/bin ./uninstall.sh
+#
+# install.sh で作成したラッパースクリプトを削除します。
+
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+# コマンド一覧
+COMMANDS="
+pi-run
+pi-list
+pi-attach
+pi-status
+pi-stop
+pi-cleanup
+pi-improve
+pi-wait
+pi-watch
+"
+
+echo "Uninstalling pi-issue-runner from $INSTALL_DIR..."
+
+removed_count=0
+for cmd in $COMMANDS; do
+    # 空行をスキップ
+    [[ -z "$cmd" ]] && continue
+    
+    wrapper="$INSTALL_DIR/$cmd"
+    
+    # ラッパースクリプトが存在し、pi-issue-runnerのものであるか確認
+    if [[ -f "$wrapper" ]] && grep -q "pi-issue-runner" "$wrapper" 2>/dev/null; then
+        rm "$wrapper"
+        echo "  ✓ Removed $cmd"
+        ((removed_count++)) || true
+    fi
+done
+
+echo ""
+if [[ $removed_count -eq 0 ]]; then
+    echo "ℹ️  削除するコマンドがありませんでした"
+else
+    echo "✅ アンインストール完了！ ($removed_count コマンドを削除)"
+fi


### PR DESCRIPTION
## Summary
Closes #159

## Changes
- `install.sh`: ラッパースクリプトを生成してグローバルインストール
- `uninstall.sh`: 生成したラッパースクリプトを削除
- `README.md`: グローバルインストールの手順を追記

## インストールされるコマンド
| コマンド | 説明 |
|----------|------|
| `pi-run` | Issue実行 |
| `pi-list` | セッション一覧 |
| `pi-attach` | セッションアタッチ |
| `pi-status` | 状態確認 |
| `pi-stop` | セッション停止 |
| `pi-cleanup` | クリーンアップ |
| `pi-improve` | 継続的改善 |
| `pi-wait` | 完了待機 |
| `pi-watch` | セッション監視 |

## Testing
- `./install.sh` でコマンドがインストールされることを確認
- インストール後、`pi-list --help` などが実行可能であることを確認
- `./uninstall.sh` でコマンドが削除されることを確認
- PATH未設定時に警告が表示されることを確認