### PR TITLE
docs: SKILL.md と README.md のオプション記載を統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ INSTALL_DIR=/usr/local/bin ./install.sh
 # pi終了後、自動的にworktreeとセッションがクリーンアップされます
 scripts/run.sh 42
 
-# ワークフローを指定して起動
-scripts/run.sh 42 --workflow simple    # 簡易ワークフロー（実装・マージのみ）
+# ワークフローを指定して起動（-w は --workflow の短縮形）
+scripts/run.sh 42 -w simple            # 簡易ワークフロー（実装・マージのみ）
 scripts/run.sh 42 --workflow default   # 完全ワークフロー（デフォルト）
 
 # 利用可能なワークフロー一覧を表示
@@ -96,8 +96,8 @@ scripts/run.sh 42 --no-attach
 # pi終了後の自動クリーンアップを無効化
 scripts/run.sh 42 --no-cleanup
 
-# カスタムブランチ名で作成
-scripts/run.sh 42 --branch custom-feature
+# カスタムブランチ名で作成（-b は --branch の短縮形）
+scripts/run.sh 42 -b custom-feature
 
 # 特定のベースブランチから作成
 scripts/run.sh 42 --base develop

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,16 +15,15 @@ GitHub Issueを入力として、Git worktreeを作成し、tmuxセッション�
 scripts/run.sh <issue-number> [options]
 
 Options:
-  --workflow <name> ワークフロー名（デフォルト: default）
-  -w <name>         --workflowの短縮形
-  --list-workflows  利用可能なワークフロー一覧を表示
-  --no-attach       バックグラウンドで起動
-  --no-cleanup      自動クリーンアップを無効化
-  --reattach        既存セッションにアタッチ
-  --force           強制再作成
-  --branch <name>   カスタムブランチ名
-  --base <branch>   ベースブランチ
-  --pi-args <args>  piへの追加引数
+  -w, --workflow <name>  ワークフロー名（デフォルト: default）
+  --list-workflows       利用可能なワークフロー一覧を表示
+  --no-attach            バックグラウンドで起動
+  --no-cleanup           自動クリーンアップを無効化
+  --reattach             既存セッションにアタッチ
+  --force                強制再作成
+  -b, --branch <name>    カスタムブランチ名
+  --base <branch>        ベースブランチ
+  --pi-args <args>       piへの追加引数
 
 # セッション管理
 scripts/list.sh              # セッション一覧

--- a/docs/plans/issue-163-plan.md
+++ b/docs/plans/issue-163-plan.md
@@ -1,0 +1,84 @@
+# Issue #163 実装計画
+
+## 概要
+
+SKILL.md と README.md のオプション記載を統一し、run.sh --help との整合性を確保する。
+
+## 現状分析
+
+### 短縮形オプションの実装状況（scripts/run.sh）
+
+| 短縮形 | 正式名 | 実装 |
+|--------|--------|------|
+| `-i` | `--issue` | ✅ |
+| `-b` | `--branch` | ✅ |
+| `-w` | `--workflow` | ✅ |
+
+### ドキュメントの差異
+
+| オプション | run.sh 実装 | run.sh --help | SKILL.md | README.md |
+|------------|-------------|---------------|----------|-----------|
+| `-i` (--issue短縮形) | ✅ | ❌ | ❌ | ❌ |
+| `-b` (--branch短縮形) | ✅ | ❌ | ❌ | ❌ |
+| `-w` (--workflow短縮形) | ✅ | ❌ | ✅ | ❌ |
+
+## 影響範囲
+
+- `scripts/run.sh` - ヘルプ出力の更新（2箇所）
+- `README.md` - 使い方セクションに短縮形追記
+- `SKILL.md` - クイックリファレンスに短縮形追記（一貫性のため）
+
+## 実装ステップ
+
+### Step 1: run.sh --help 出力の更新
+
+2箇所のヘルプテキストに短縮形オプションを追記：
+
+```diff
+-    --branch NAME     カスタムブランチ名（デフォルト: issue-<num>-<title>）
++    -b, --branch NAME カスタムブランチ名（デフォルト: issue-<num>-<title>）
+
+-    --workflow NAME   ワークフロー名（デフォルト: default）
++    -w, --workflow NAME ワークフロー名（デフォルト: default）
+```
+
+注: `-i` (--issue) は位置引数として使うのが一般的なため、ヘルプには追記しない
+
+### Step 2: README.md の更新
+
+使い方セクションに短縮形オプションを追記：
+
+```diff
+-scripts/run.sh 42 --workflow simple
++scripts/run.sh 42 --workflow simple    # または -w simple
+```
+
+### Step 3: SKILL.md の確認・調整
+
+既に `-w` が記載されているが、`-b` も追記して一貫性を保つ
+
+## テスト方針
+
+1. `scripts/run.sh --help` の出力を確認
+2. 各短縮形オプションの動作確認：
+   - `scripts/run.sh 999 -w simple --no-attach` のパース確認
+   - `scripts/run.sh 999 -b custom-branch --no-attach` のパース確認
+3. ドキュメント間の記載が一致することを確認
+
+## リスクと対策
+
+- **リスク**: ドキュメント修正漏れ
+  - **対策**: 全ファイルをgrepで確認
+
+- **リスク**: ヘルプ出力のフォーマット崩れ
+  - **対策**: 修正後に `--help` を実行して視覚的に確認
+
+## 見積もり
+
+| 作業 | 時間 |
+|------|------|
+| run.sh ヘルプ更新 | 5分 |
+| README.md 更新 | 10分 |
+| SKILL.md 確認・調整 | 5分 |
+| テスト・確認 | 5分 |
+| **合計** | **25分** |

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -16,26 +16,26 @@ Arguments:
     issue-number    GitHub Issue番号
 
 Options:
-    --branch NAME     カスタムブランチ名（デフォルト: issue-<num>-<title>）
-    --base BRANCH     ベースブランチ（デフォルト: HEAD）
-    --workflow NAME   ワークフロー名（デフォルト: default）
-                      利用可能: default, simple
-    --no-attach       セッション作成後にアタッチしない
-    --no-cleanup      pi終了後の自動クリーンアップを無効化
-    --reattach        既存セッションがあればアタッチ
-    --force           既存セッション/worktreeを削除して再作成
-    --pi-args ARGS    piに渡す追加の引数
-    --list-workflows  利用可能なワークフロー一覧を表示
-    -h, --help        このヘルプを表示
+    -b, --branch NAME   カスタムブランチ名（デフォルト: issue-<num>-<title>）
+    --base BRANCH       ベースブランチ（デフォルト: HEAD）
+    -w, --workflow NAME ワークフロー名（デフォルト: default）
+                        利用可能: default, simple
+    --no-attach         セッション作成後にアタッチしない
+    --no-cleanup        pi終了後の自動クリーンアップを無効化
+    --reattach          既存セッションがあればアタッチ
+    --force             既存セッション/worktreeを削除して再作成
+    --pi-args ARGS      piに渡す追加の引数
+    --list-workflows    利用可能なワークフロー一覧を表示
+    -h, --help          このヘルプを表示
 
 Examples:
     run.sh 42
-    run.sh 42 --workflow simple
+    run.sh 42 -w simple
     run.sh 42 --no-attach
     run.sh 42 --no-cleanup
     run.sh 42 --reattach
     run.sh 42 --force
-    run.sh 42 --branch custom-feature
+    run.sh 42 -b custom-feature
     run.sh 42 --base develop
 HELP_EOF
             exit 0
@@ -64,26 +64,26 @@ Arguments:
     issue-number    GitHub Issue番号
 
 Options:
-    --branch NAME     カスタムブランチ名（デフォルト: issue-<num>-<title>）
-    --base BRANCH     ベースブランチ（デフォルト: HEAD）
-    --workflow NAME   ワークフロー名（デフォルト: default）
-                      利用可能: default, simple
-    --no-attach       セッション作成後にアタッチしない
-    --no-cleanup      pi終了後の自動クリーンアップを無効化
-    --reattach        既存セッションがあればアタッチ
-    --force           既存セッション/worktreeを削除して再作成
-    --pi-args ARGS    piに渡す追加の引数
-    --list-workflows  利用可能なワークフロー一覧を表示
-    -h, --help        このヘルプを表示
+    -b, --branch NAME   カスタムブランチ名（デフォルト: issue-<num>-<title>）
+    --base BRANCH       ベースブランチ（デフォルト: HEAD）
+    -w, --workflow NAME ワークフロー名（デフォルト: default）
+                        利用可能: default, simple
+    --no-attach         セッション作成後にアタッチしない
+    --no-cleanup        pi終了後の自動クリーンアップを無効化
+    --reattach          既存セッションがあればアタッチ
+    --force             既存セッション/worktreeを削除して再作成
+    --pi-args ARGS      piに渡す追加の引数
+    --list-workflows    利用可能なワークフロー一覧を表示
+    -h, --help          このヘルプを表示
 
 Examples:
     $(basename "$0") 42
-    $(basename "$0") 42 --workflow simple
+    $(basename "$0") 42 -w simple
     $(basename "$0") 42 --no-attach
     $(basename "$0") 42 --no-cleanup
     $(basename "$0") 42 --reattach
     $(basename "$0") 42 --force
-    $(basename "$0") 42 --branch custom-feature
+    $(basename "$0") 42 -b custom-feature
     $(basename "$0") 42 --base develop
 EOF
 }


### PR DESCRIPTION
## Summary
Closes #163

## Changes
- run.sh --help に短縮形オプション (-b, -w) を追記
- README.md に短縮形オプションの説明を追加
- SKILL.md のオプション記載を --help と一致させる
- Examples で短縮形オプションを使用

## Testing
- `scripts/run.sh --help` で正しく短縮形オプションが表示される
- SKILL.md, README.md, run.sh --help の整合性を確認

## Acceptance Criteria
- [x] README.md に短縮形オプションが記載されている
- [x] SKILL.md と README.md の記載に矛盾がない
- [x] run.sh --help の出力とドキュメントが一致する