### PR TITLE
refactor: rename detect_dangerous_patterns to has_dangerous_patterns

### DIFF
--- a/docs/plans/issue-171-plan.md
+++ b/docs/plans/issue-171-plan.md
@@ -1,0 +1,106 @@
+# Issue #171 Implementation Plan
+
+## 概要
+
+`lib/github.sh` の `detect_dangerous_patterns` 関数の戻り値ロジックを改善し、Bashの標準的な規約に従った直感的な実装に変更する。
+
+## 問題点の詳細
+
+### 現在の実装
+
+```bash
+detect_dangerous_patterns() {
+    # ...
+    return $found  # 危険パターンあり: 1, なし: 0
+}
+
+# 呼び出し側
+if ! detect_dangerous_patterns "$body" 2>/dev/null; then
+    log_info "sanitizing..."
+fi
+```
+
+### 問題
+
+- Bashでは戻り値0=true/成功、非0=false/失敗が規約
+- 関数名「detect」は検出成功時に0を返すべき
+- `if !` を使った条件分岐が分かりにくい
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `lib/github.sh` | 関数リネーム、戻り値ロジック変更 |
+| `test/github_test.sh` | テストケースの更新 |
+
+## 実装ステップ
+
+### Step 1: 関数のリネームと戻り値変更
+
+`detect_dangerous_patterns` → `has_dangerous_patterns`
+
+```bash
+# has_dangerous_patterns - 危険なパターンが含まれているかチェック
+# 戻り値: 0=危険なパターンあり(true), 1=安全(false)
+has_dangerous_patterns() {
+    local text="$1"
+    
+    # コマンド置換 $(...)
+    if echo "$text" | grep -qE '\$\([^)]+\)'; then
+        log_warn "Dangerous pattern detected: command substitution \$(...)  "
+        return 0  # 危険あり = true
+    fi
+    
+    # バッククォート `...`
+    if echo "$text" | grep -q '`[^`]*`'; then
+        log_warn "Dangerous pattern detected: backtick command \`...\`"
+        return 0  # 危険あり = true
+    fi
+    
+    # 変数展開 ${...}
+    if echo "$text" | grep -qE '\$\{[^}]+\}'; then
+        log_warn "Dangerous pattern detected: variable expansion \${...}"
+        return 0  # 危険あり = true
+    fi
+    
+    return 1  # 安全 = false
+}
+```
+
+### Step 2: 呼び出し側の更新
+
+```bash
+# Before
+if ! detect_dangerous_patterns "$body" 2>/dev/null; then
+    log_info "sanitizing..."
+fi
+
+# After
+if has_dangerous_patterns "$body" 2>/dev/null; then
+    log_info "Issue body contains potentially dangerous patterns, sanitizing..."
+fi
+```
+
+### Step 3: テストの更新
+
+テストコードも新しい関数名と戻り値に合わせて更新する。
+
+## テスト方針
+
+1. 既存の `test/github_test.sh` のテストを更新
+2. 安全なテキスト → `has_dangerous_patterns` は 1 (false) を返す
+3. 危険なテキスト → `has_dangerous_patterns` は 0 (true) を返す
+4. サニタイズ処理が正常に動作することを確認
+
+## リスクと対策
+
+| リスク | 対策 |
+|-------|------|
+| 関数名変更による互換性問題 | 外部から呼ばれる関数ではないため影響は限定的 |
+| テストの見落とし | 全テストを実行して確認 |
+
+## 完了条件
+
+- [x] 関数の動作とコメントが一致している
+- [x] 呼び出し側のコードが直感的に理解できる
+- [x] 既存のテストがパスする

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -114,31 +114,31 @@ _DANGEROUS_PATTERNS=(
     '\$\{[^}]+\}'           # 変数展開 ${...}
 )
 
-# 危険なパターンを検出
-# 戻り値: 0=安全, 1=危険なパターン検出
-detect_dangerous_patterns() {
+# 危険なパターンが含まれているかチェック
+# 戻り値: 0=危険なパターンあり(true), 1=安全(false)
+# Bashの規約に従い、条件が真の場合に0を返す
+has_dangerous_patterns() {
     local text="$1"
-    local found=0
     
     # コマンド置換 $(...) - grepを使用して安全に検出
     if echo "$text" | grep -qE '\$\([^)]+\)'; then
         log_warn "Dangerous pattern detected: command substitution \$(...)  "
-        found=1
+        return 0  # 危険あり = true
     fi
     
     # バッククォート `...`
     if echo "$text" | grep -q '`[^`]*`'; then
         log_warn "Dangerous pattern detected: backtick command \`...\`"
-        found=1
+        return 0  # 危険あり = true
     fi
     
     # 変数展開 ${...}
     if echo "$text" | grep -qE '\$\{[^}]+\}'; then
         log_warn "Dangerous pattern detected: variable expansion \${...}"
-        found=1
+        return 0  # 危険あり = true
     fi
     
-    return $found
+    return 1  # 安全 = false
 }
 
 # Issue本文のサニタイズ
@@ -155,7 +155,7 @@ sanitize_issue_body() {
     fi
     
     # 危険なパターンを検出して警告
-    if ! detect_dangerous_patterns "$body" 2>/dev/null; then
+    if has_dangerous_patterns "$body" 2>/dev/null; then
         log_info "Issue body contains potentially dangerous patterns, sanitizing..."
     fi
     

--- a/test/github_test.sh
+++ b/test/github_test.sh
@@ -190,52 +190,52 @@ else
 fi
 
 # ===================
-# detect_dangerous_patterns テスト
+# has_dangerous_patterns テスト
 # ===================
 echo ""
-echo "=== detect_dangerous_patterns tests ==="
+echo "=== has_dangerous_patterns tests ==="
 
-if declare -f detect_dangerous_patterns > /dev/null 2>&1; then
-    echo "✓ detect_dangerous_patterns function exists"
+if declare -f has_dangerous_patterns > /dev/null 2>&1; then
+    echo "✓ has_dangerous_patterns function exists"
     ((TESTS_PASSED++)) || true
     
-    # 安全なテキスト
-    if detect_dangerous_patterns "Safe text" 2>/dev/null; then
-        echo "✓ detect_dangerous_patterns returns success for safe text"
+    # 安全なテキスト（危険なパターンがない場合は1=falseを返す）
+    if ! has_dangerous_patterns "Safe text" 2>/dev/null; then
+        echo "✓ has_dangerous_patterns returns false for safe text"
         ((TESTS_PASSED++)) || true
     else
-        echo "✗ detect_dangerous_patterns should return success for safe text"
+        echo "✗ has_dangerous_patterns should return false for safe text"
         ((TESTS_FAILED++)) || true
     fi
     
-    # 危険なパターン（コマンド置換）
-    if ! detect_dangerous_patterns 'Dangerous $(rm -rf /)' 2>/dev/null; then
-        echo "✓ detect_dangerous_patterns detects command substitution"
+    # 危険なパターン（コマンド置換）- 0=trueを返す
+    if has_dangerous_patterns 'Dangerous $(rm -rf /)' 2>/dev/null; then
+        echo "✓ has_dangerous_patterns detects command substitution"
         ((TESTS_PASSED++)) || true
     else
-        echo "✗ detect_dangerous_patterns should detect command substitution"
+        echo "✗ has_dangerous_patterns should detect command substitution"
         ((TESTS_FAILED++)) || true
     fi
     
-    # 危険なパターン（バッククォート）
-    if ! detect_dangerous_patterns 'Dangerous `rm -rf /`' 2>/dev/null; then
-        echo "✓ detect_dangerous_patterns detects backticks"
+    # 危険なパターン（バッククォート）- 0=trueを返す
+    if has_dangerous_patterns 'Dangerous `rm -rf /`' 2>/dev/null; then
+        echo "✓ has_dangerous_patterns detects backticks"
         ((TESTS_PASSED++)) || true
     else
-        echo "✗ detect_dangerous_patterns should detect backticks"
+        echo "✗ has_dangerous_patterns should detect backticks"
         ((TESTS_FAILED++)) || true
     fi
     
-    # 危険なパターン（変数展開）
-    if ! detect_dangerous_patterns 'Dangerous ${PATH}' 2>/dev/null; then
-        echo "✓ detect_dangerous_patterns detects variable expansion"
+    # 危険なパターン（変数展開）- 0=trueを返す
+    if has_dangerous_patterns 'Dangerous ${PATH}' 2>/dev/null; then
+        echo "✓ has_dangerous_patterns detects variable expansion"
         ((TESTS_PASSED++)) || true
     else
-        echo "✗ detect_dangerous_patterns should detect variable expansion"
+        echo "✗ has_dangerous_patterns should detect variable expansion"
         ((TESTS_FAILED++)) || true
     fi
 else
-    echo "✗ detect_dangerous_patterns function does not exist"
+    echo "✗ has_dangerous_patterns function does not exist"
     ((TESTS_FAILED++)) || true
 fi
 


### PR DESCRIPTION
## Summary
Closes #171

## Changes
- Renamed `detect_dangerous_patterns` to `has_dangerous_patterns` for clearer semantics
- Changed return value logic: 0 = dangerous patterns found (true), 1 = safe (false)
- Follows Bash convention where 0 means success/true
- Updated calling code in `sanitize_issue_body` to use simpler if-statement
- Updated tests to reflect new function name and semantics

## Before
```bash
# Confusing: returns 1 when dangerous, 0 when safe
if ! detect_dangerous_patterns "$body"; then
    log_info "sanitizing..."
fi
```

## After
```bash
# Clear: returns 0 (true) when dangerous, 1 (false) when safe
if has_dangerous_patterns "$body"; then
    log_info "sanitizing..."
fi
```

## Testing
- All existing tests updated and passing
- Ran full test suite: all 19 github tests pass
- All other tests (400+) continue to pass