### PR TITLE
docs: AGENTS.mdのディレクトリ構造にlib/github.shを追加

### DIFF
--- a/docs/plans/issue-203-plan.md
+++ b/docs/plans/issue-203-plan.md
@@ -1,0 +1,38 @@
+# Issue #203 実装計画
+
+## 概要
+
+AGENTS.mdのディレクトリ構造セクションに`lib/github.sh`を追加する。
+
+## 分析結果
+
+**Issue状態: 既に解決済み**
+
+現在のAGENTS.mdを確認したところ、`lib/github.sh # GitHub CLI操作`は既にディレクトリ構造に記載されていました。
+
+```markdown
+├── lib/               # 共通ライブラリ
+│   ├── config.sh      # 設定読み込み
+│   ├── github.sh      # GitHub CLI操作  ← 既に記載済み
+│   ├── log.sh         # ログ出力
+│   ├── notify.sh      # 通知機能
+│   ├── status.sh      # 状態管理
+│   ├── tmux.sh        # tmux操作
+│   ├── workflow.sh    # ワークフローエンジン
+│   └── worktree.sh    # Git worktree操作
+```
+
+また、実際のファイル`lib/github.sh`も存在することを確認しました。
+
+## 受け入れ条件の確認
+
+- [x] AGENTS.mdに`lib/github.sh`の記載がある
+- [x] 実際のファイル構造とドキュメントが一致している
+
+## 結論
+
+この問題は既に解決されているため、コード変更は不要です。
+Issueをクローズするためのコミット（ドキュメント確認のみ）を作成します。
+
+## 作成日時
+2026-01-31


### PR DESCRIPTION
## Summary
Closes #203

## 調査結果

Issue #203では、AGENTS.mdのディレクトリ構造から`lib/github.sh`が欠落していると報告されましたが、
確認の結果、**既に正しく記載されていました**。

### 確認事項
- [x] AGENTS.mdに`lib/github.sh # GitHub CLI操作`が記載済み
- [x] 実際のファイル`lib/github.sh`も存在

## Changes
- 確認結果を`docs/plans/issue-203-plan.md`に記録

## Testing
ドキュメント確認のみのため、コード変更なし。