### PR TITLE
test: add Bats tests for missing library files

### DIFF
--- a/docs/plans/issue-200-plan.md
+++ b/docs/plans/issue-200-plan.md
@@ -1,0 +1,84 @@
+# Issue #200 実装計画書
+
+## 概要
+
+Batsテストが存在しないライブラリファイル（`notify.sh`, `status.sh`, `tmux.sh`, `workflow.sh`, `worktree.sh`）に対して、Batsテストファイルを作成する。
+
+## 影響範囲
+
+### 新規作成ファイル
+- `test/lib/notify.bats`
+- `test/lib/status.bats`
+- `test/lib/tmux.bats`
+- `test/lib/workflow.bats`
+- `test/lib/worktree.bats`
+
+### 参照するライブラリ
+- `lib/notify.sh` - 通知機能（macOS/Linux対応）
+- `lib/status.sh` - ステータスファイル管理
+- `lib/tmux.sh` - tmux操作
+- `lib/workflow.sh` - ワークフローエンジン
+- `lib/worktree.sh` - Git worktree操作
+
+## 実装ステップ
+
+### 1. test/lib/status.bats
+`status.sh`は基本的なJSON操作とステータス管理を行う。テスト内容：
+- `json_escape()` - JSON文字列エスケープ
+- `get_status_dir()` - ステータスディレクトリパス取得
+- `save_status()` / `load_status()` - ステータス保存・読み込み
+- `set_status()` / `get_status()` - エイリアス関数
+- `list_all_statuses()` - 全ステータス一覧
+
+### 2. test/lib/notify.bats
+`notify.sh`はプラットフォーム検出と通知機能を提供。テスト内容：
+- `is_macos()` / `is_linux()` - プラットフォーム検出
+- `notify_error()` / `notify_success()` - 通知関数（モック使用）
+- `handle_error()` / `handle_complete()` - 統合処理
+
+### 3. test/lib/tmux.bats
+`tmux.sh`はtmuxセッション管理を行う。テスト内容：
+- `generate_session_name()` - セッション名生成
+- `extract_issue_number()` - セッション名からIssue番号抽出
+- `session_exists()` - セッション存在確認（モック使用）
+- `list_sessions()` - セッション一覧（モック使用）
+
+### 4. test/lib/workflow.bats
+`workflow.sh`はワークフロー定義の読み込みと実行を行う。テスト内容：
+- `find_workflow_file()` - ワークフローファイル検索
+- `get_workflow_steps()` - ステップ一覧取得
+- `render_template()` - テンプレート変数展開
+- `generate_workflow_prompt()` - プロンプト生成
+
+### 5. test/lib/worktree.bats
+`worktree.sh`はGit worktree操作を行う。テスト内容：
+- `create_worktree()` - worktree作成（モック使用）
+- `remove_worktree()` - worktree削除（モック使用）
+- `list_worktrees()` - worktree一覧
+- `find_worktree_by_issue()` - Issue番号からworktree検索
+
+## テスト方針
+
+1. 各テストファイルに最低3つのテストケースを含める（受け入れ条件）
+2. 外部コマンド（git, tmux, osascript等）はモックを使用
+3. 既存の `test_helper.bash` のモック関数を活用
+4. テスト用一時ディレクトリ（`BATS_TEST_TMPDIR`）を使用
+5. 既存の `*_test.sh` のテストケースを参考にBats形式に移行
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| モックが複雑になる | 既存のtest_helper.bashのモック関数を拡張 |
+| プラットフォーム依存テスト | 条件分岐でスキップ処理を追加 |
+| config.shの事前読み込み | setup()でconfig.shを明示的に初期化 |
+
+## 受け入れ条件チェックリスト
+
+- [ ] `test/lib/notify.bats` が作成されている
+- [ ] `test/lib/status.bats` が作成されている
+- [ ] `test/lib/tmux.bats` が作成されている
+- [ ] `test/lib/workflow.bats` が作成されている
+- [ ] `test/lib/worktree.bats` が作成されている
+- [ ] `bats test/lib/*.bats` が正常に実行できる
+- [ ] 各テストファイルに最低3つのテストケースが含まれている

--- a/test/lib/notify.bats
+++ b/test/lib/notify.bats
@@ -1,0 +1,249 @@
+#!/usr/bin/env bats
+# notify.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # 設定をリセット
+    unset _CONFIG_LOADED
+    unset CONFIG_WORKTREE_BASE_DIR
+    
+    # worktree_base_dirを一時ディレクトリに設定
+    export PI_RUNNER_WORKTREE_BASE_DIR="${BATS_TEST_TMPDIR}/.worktrees"
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees"
+    
+    # ログレベルを抑制
+    export LOG_LEVEL="ERROR"
+    
+    # モックディレクトリをセットアップ
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    export ORIGINAL_PATH="$PATH"
+}
+
+teardown() {
+    if [[ -n "${ORIGINAL_PATH:-}" ]]; then
+        export PATH="$ORIGINAL_PATH"
+    fi
+    
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# osascriptのモック（macOS通知用）
+mock_osascript() {
+    local mock_script="$MOCK_DIR/osascript"
+    cat > "$mock_script" << 'MOCK_EOF'
+#!/usr/bin/env bash
+echo "osascript called: $*"
+exit 0
+MOCK_EOF
+    chmod +x "$mock_script"
+}
+
+# notify-sendのモック（Linux通知用）
+mock_notify_send() {
+    local mock_script="$MOCK_DIR/notify-send"
+    cat > "$mock_script" << 'MOCK_EOF'
+#!/usr/bin/env bash
+echo "notify-send called: $*"
+exit 0
+MOCK_EOF
+    chmod +x "$mock_script"
+}
+
+# ====================
+# プラットフォーム検出テスト
+# ====================
+
+@test "is_macos returns true on macOS" {
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    if [[ "$(uname)" == "Darwin" ]]; then
+        run is_macos
+        [ "$status" -eq 0 ]
+    else
+        skip "Not running on macOS"
+    fi
+}
+
+@test "is_macos returns false on non-macOS" {
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    if [[ "$(uname)" != "Darwin" ]]; then
+        run is_macos
+        [ "$status" -ne 0 ]
+    else
+        skip "Running on macOS"
+    fi
+}
+
+@test "is_linux returns true on Linux" {
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    if [[ "$(uname)" == "Linux" ]]; then
+        run is_linux
+        [ "$status" -eq 0 ]
+    else
+        skip "Not running on Linux"
+    fi
+}
+
+@test "is_linux returns false on non-Linux" {
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    if [[ "$(uname)" != "Linux" ]]; then
+        run is_linux
+        [ "$status" -ne 0 ]
+    else
+        skip "Running on Linux"
+    fi
+}
+
+# ====================
+# notify_error テスト
+# ====================
+
+@test "notify_error calls osascript on macOS" {
+    if [[ "$(uname)" != "Darwin" ]]; then
+        skip "Only runs on macOS"
+    fi
+    
+    mock_osascript
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    run notify_error "test-session" "42" "Test error"
+    [ "$status" -eq 0 ]
+}
+
+@test "notify_error handles special characters in message" {
+    if [[ "$(uname)" != "Darwin" ]]; then
+        skip "Only runs on macOS"
+    fi
+    
+    mock_osascript
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    # エラーにならないことを確認
+    run notify_error "test-session" "42" 'Error with "quotes"'
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# notify_success テスト
+# ====================
+
+@test "notify_success calls osascript on macOS" {
+    if [[ "$(uname)" != "Darwin" ]]; then
+        skip "Only runs on macOS"
+    fi
+    
+    mock_osascript
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    run notify_success "test-session" "42"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# handle_error テスト
+# ====================
+
+@test "handle_error saves error status" {
+    mock_osascript
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    # auto_attach=falseで実行（Terminal.appを開かない）
+    handle_error "test-session" "42" "Test error" "false"
+    
+    # ステータスがエラーになっていることを確認
+    result="$(get_status_value "42")"
+    [ "$result" = "error" ]
+}
+
+@test "handle_error includes error message in status" {
+    mock_osascript
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    handle_error "test-session" "43" "Custom error message" "false"
+    
+    error_msg="$(get_error_message "43")"
+    [ "$error_msg" = "Custom error message" ]
+}
+
+# ====================
+# handle_complete テスト
+# ====================
+
+@test "handle_complete saves complete status" {
+    mock_osascript
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    handle_complete "test-session" "42"
+    
+    result="$(get_status_value "42")"
+    [ "$result" = "complete" ]
+}
+
+@test "handle_complete sends success notification" {
+    mock_osascript
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    # エラーなしで実行できることを確認
+    run handle_complete "test-session" "42"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# open_terminal_and_attach テスト
+# ====================
+
+@test "open_terminal_and_attach fails on non-macOS" {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        skip "Only runs on non-macOS"
+    fi
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    run open_terminal_and_attach "test-session"
+    [ "$status" -ne 0 ]
+}
+
+# ====================
+# 統合テスト
+# ====================
+
+@test "notify functions work without crashing" {
+    mock_osascript
+    mock_notify_send
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/notify.sh"
+    
+    # 基本的な呼び出しがクラッシュしないことを確認
+    run notify_error "session" "1" "error"
+    run notify_success "session" "2"
+    
+    # どちらの呼び出しもエラーなし
+    [ "$status" -eq 0 ]
+}

--- a/test/lib/status.bats
+++ b/test/lib/status.bats
@@ -1,0 +1,274 @@
+#!/usr/bin/env bats
+# status.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # 設定をリセット
+    unset _CONFIG_LOADED
+    unset CONFIG_WORKTREE_BASE_DIR
+    
+    # テスト用の設定ファイルを作成
+    export TEST_CONFIG_FILE="${BATS_TEST_TMPDIR}/test-config.yaml"
+    cat > "$TEST_CONFIG_FILE" << 'EOF'
+worktree:
+  base_dir: "${BATS_TEST_TMPDIR}/.worktrees"
+EOF
+    
+    # worktree_base_dirを一時ディレクトリに設定
+    export PI_RUNNER_WORKTREE_BASE_DIR="${BATS_TEST_TMPDIR}/.worktrees"
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees"
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# json_escape テスト
+# ====================
+
+@test "json_escape escapes double quotes" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    result="$(json_escape 'Hello "World"')"
+    [ "$result" = 'Hello \"World\"' ]
+}
+
+@test "json_escape escapes backslashes" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    result="$(json_escape 'Path: C:\Users')"
+    [ "$result" = 'Path: C:\\Users' ]
+}
+
+@test "json_escape escapes newlines" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    result="$(json_escape $'Line1\nLine2')"
+    [ "$result" = 'Line1\nLine2' ]
+}
+
+@test "json_escape handles multiple special chars" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    result="$(json_escape $'Quote: " Tab:\t')"
+    [[ "$result" == *'\"'* ]]
+    [[ "$result" == *'\t'* ]]
+}
+
+# ====================
+# get_status_dir テスト
+# ====================
+
+@test "get_status_dir returns correct path" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    result="$(get_status_dir)"
+    [[ "$result" == *".worktrees/.status" ]]
+}
+
+# ====================
+# init_status_dir テスト
+# ====================
+
+@test "init_status_dir creates directory" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    init_status_dir
+    status_dir="$(get_status_dir)"
+    [ -d "$status_dir" ]
+}
+
+# ====================
+# save_status / load_status テスト
+# ====================
+
+@test "save_status creates status file" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "running" "pi-issue-42"
+    
+    status_dir="$(get_status_dir)"
+    [ -f "$status_dir/42.json" ]
+}
+
+@test "save_status writes correct JSON" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "running" "pi-issue-42"
+    
+    status_dir="$(get_status_dir)"
+    json="$(cat "$status_dir/42.json")"
+    
+    [[ "$json" == *'"issue": 42'* ]]
+    [[ "$json" == *'"status": "running"'* ]]
+    [[ "$json" == *'"session": "pi-issue-42"'* ]]
+}
+
+@test "save_status with error message" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "43" "error" "pi-issue-43" "Test error"
+    
+    status_dir="$(get_status_dir)"
+    json="$(cat "$status_dir/43.json")"
+    
+    [[ "$json" == *'"status": "error"'* ]]
+    [[ "$json" == *'"error_message"'* ]]
+    [[ "$json" == *'Test error'* ]]
+}
+
+@test "load_status returns JSON content" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "complete" "pi-issue-42"
+    json="$(load_status "42")"
+    
+    [[ "$json" == *'"issue": 42'* ]]
+}
+
+@test "load_status returns empty for non-existent" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    init_status_dir
+    result="$(load_status "999")"
+    [ -z "$result" ]
+}
+
+# ====================
+# get_status_value / get_status テスト
+# ====================
+
+@test "get_status_value returns status string" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "running" "pi-issue-42"
+    result="$(get_status_value "42")"
+    [ "$result" = "running" ]
+}
+
+@test "get_status_value returns unknown for missing" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    init_status_dir
+    result="$(get_status_value "999")"
+    [ "$result" = "unknown" ]
+}
+
+@test "get_status is alias for get_status_value" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "complete" "pi-issue-42"
+    result="$(get_status "42")"
+    [ "$result" = "complete" ]
+}
+
+# ====================
+# set_status テスト
+# ====================
+
+@test "set_status creates status with generated session name" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    set_status "50" "running"
+    result="$(get_status "50")"
+    [ "$result" = "running" ]
+}
+
+@test "set_status with error message" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    set_status "51" "error" "Something went wrong"
+    
+    result="$(get_status "51")"
+    [ "$result" = "error" ]
+    
+    error_msg="$(get_error_message "51")"
+    [ "$error_msg" = "Something went wrong" ]
+}
+
+# ====================
+# get_error_message テスト
+# ====================
+
+@test "get_error_message returns error message" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "error" "pi-issue-42" "Error occurred"
+    result="$(get_error_message "42")"
+    [ "$result" = "Error occurred" ]
+}
+
+@test "get_error_message returns empty for non-error status" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "running" "pi-issue-42"
+    result="$(get_error_message "42")"
+    [ -z "$result" ]
+}
+
+# ====================
+# remove_status テスト
+# ====================
+
+@test "remove_status deletes status file" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "42" "running" "pi-issue-42"
+    remove_status "42"
+    
+    result="$(get_status_value "42")"
+    [ "$result" = "unknown" ]
+}
+
+# ====================
+# list_all_statuses テスト
+# ====================
+
+@test "list_all_statuses returns all statuses" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "10" "running" "pi-issue-10"
+    save_status "20" "complete" "pi-issue-20"
+    
+    result="$(list_all_statuses)"
+    
+    [[ "$result" == *"10"* ]]
+    [[ "$result" == *"running"* ]]
+    [[ "$result" == *"20"* ]]
+    [[ "$result" == *"complete"* ]]
+}
+
+@test "list_all_statuses returns empty for no statuses" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    init_status_dir
+    result="$(list_all_statuses)"
+    [ -z "$result" ]
+}
+
+# ====================
+# list_issues_by_status テスト
+# ====================
+
+@test "list_issues_by_status filters by status" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    save_status "10" "running" "pi-issue-10"
+    save_status "20" "running" "pi-issue-20"
+    save_status "30" "complete" "pi-issue-30"
+    
+    result="$(list_issues_by_status "running")"
+    
+    [[ "$result" == *"10"* ]]
+    [[ "$result" == *"20"* ]]
+    [[ "$result" != *"30"* ]]
+}

--- a/test/lib/tmux.bats
+++ b/test/lib/tmux.bats
@@ -1,0 +1,292 @@
+#!/usr/bin/env bats
+# tmux.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # 設定をリセット
+    unset _CONFIG_LOADED
+    unset CONFIG_WORKTREE_BASE_DIR
+    unset CONFIG_TMUX_SESSION_PREFIX
+    
+    # デフォルト設定
+    export PI_RUNNER_TMUX_SESSION_PREFIX="pi"
+    
+    # モックディレクトリをセットアップ
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    export ORIGINAL_PATH="$PATH"
+}
+
+teardown() {
+    if [[ -n "${ORIGINAL_PATH:-}" ]]; then
+        export PATH="$ORIGINAL_PATH"
+    fi
+    
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# tmuxのモック
+mock_tmux_exists() {
+    local mock_script="$MOCK_DIR/tmux"
+    cat > "$mock_script" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 0  # セッションが存在する
+        ;;
+    "new-session")
+        exit 0
+        ;;
+    "kill-session")
+        exit 0
+        ;;
+    "attach-session")
+        exit 0
+        ;;
+    "send-keys")
+        exit 0
+        ;;
+    "list-sessions")
+        echo "pi-issue-42: 1 windows (created ...)"
+        echo "pi-issue-43: 1 windows (created ...)"
+        ;;
+    "capture-pane")
+        echo "Mock pane content"
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$mock_script"
+}
+
+mock_tmux_not_exists() {
+    local mock_script="$MOCK_DIR/tmux"
+    cat > "$mock_script" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 1  # セッションが存在しない
+        ;;
+    "list-sessions")
+        echo ""
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$mock_script"
+}
+
+# ====================
+# generate_session_name テスト
+# ====================
+
+@test "generate_session_name creates correct format" {
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(generate_session_name "42")"
+    [ "$result" = "pi-issue-42" ]
+}
+
+@test "generate_session_name uses custom prefix" {
+    export PI_RUNNER_TMUX_SESSION_PREFIX="custom"
+    unset _CONFIG_LOADED
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(generate_session_name "42")"
+    [ "$result" = "custom-issue-42" ]
+}
+
+@test "generate_session_name handles prefix with -issue suffix" {
+    export PI_RUNNER_TMUX_SESSION_PREFIX="test-issue"
+    unset _CONFIG_LOADED
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(generate_session_name "42")"
+    [ "$result" = "test-issue-42" ]
+}
+
+# ====================
+# extract_issue_number テスト
+# ====================
+
+@test "extract_issue_number from standard format" {
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(extract_issue_number "pi-issue-42")"
+    [ "$result" = "42" ]
+}
+
+@test "extract_issue_number from complex format" {
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(extract_issue_number "pi-issue-42-feature")"
+    [ "$result" = "42" ]
+}
+
+@test "extract_issue_number from simple format" {
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(extract_issue_number "session-123")"
+    [ "$result" = "123" ]
+}
+
+@test "extract_issue_number returns empty for no number" {
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run extract_issue_number "no-number-here"
+    [ "$status" -ne 0 ]
+}
+
+# ====================
+# session_exists テスト
+# ====================
+
+@test "session_exists returns true when session exists" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run session_exists "pi-issue-42"
+    [ "$status" -eq 0 ]
+}
+
+@test "session_exists returns false when session not exists" {
+    mock_tmux_not_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run session_exists "nonexistent"
+    [ "$status" -ne 0 ]
+}
+
+# ====================
+# create_session テスト
+# ====================
+
+@test "create_session fails when session already exists" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run create_session "pi-issue-42" "/tmp" "echo test"
+    [ "$status" -ne 0 ]
+}
+
+@test "create_session succeeds when session does not exist" {
+    mock_tmux_not_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run create_session "pi-issue-42" "$BATS_TEST_TMPDIR" "echo test"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# list_sessions テスト
+# ====================
+
+@test "list_sessions returns matching sessions" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(list_sessions)"
+    [[ "$result" == *"pi-issue-42"* ]]
+}
+
+# ====================
+# kill_session テスト
+# ====================
+
+@test "kill_session succeeds for existing session" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run kill_session "pi-issue-42"
+    [ "$status" -eq 0 ]
+}
+
+@test "kill_session succeeds even for non-existent session" {
+    mock_tmux_not_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run kill_session "nonexistent"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# get_session_output テスト
+# ====================
+
+@test "get_session_output returns pane content" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(get_session_output "pi-issue-42" 50)"
+    [[ "$result" == *"Mock pane content"* ]]
+}
+
+# ====================
+# count_active_sessions テスト
+# ====================
+
+@test "count_active_sessions returns session count" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    result="$(count_active_sessions)"
+    [ "$result" -ge 0 ]
+}
+
+# ====================
+# check_concurrent_limit テスト
+# ====================
+
+@test "check_concurrent_limit passes when no limit set" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    unset PI_RUNNER_PARALLEL_MAX_CONCURRENT
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run check_concurrent_limit
+    [ "$status" -eq 0 ]
+}
+
+@test "check_concurrent_limit passes when limit is 0" {
+    mock_tmux_exists
+    export PATH="$MOCK_DIR:$PATH"
+    export PI_RUNNER_PARALLEL_MAX_CONCURRENT="0"
+    
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    
+    run check_concurrent_limit
+    [ "$status" -eq 0 ]
+}

--- a/test/lib/workflow.bats
+++ b/test/lib/workflow.bats
@@ -1,0 +1,340 @@
+#!/usr/bin/env bats
+# workflow.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # 設定をリセット
+    unset _CONFIG_LOADED
+    
+    # テスト用ディレクトリ構造を作成
+    export TEST_PROJECT_ROOT="$BATS_TEST_TMPDIR/project"
+    mkdir -p "$TEST_PROJECT_ROOT/workflows"
+    mkdir -p "$TEST_PROJECT_ROOT/agents"
+    mkdir -p "$TEST_PROJECT_ROOT/.pi/agents"
+    
+    # yqキャッシュをリセット
+    unset _YQ_CHECK_RESULT
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# find_workflow_file テスト
+# ====================
+
+@test "find_workflow_file returns builtin when no files exist" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(find_workflow_file "default" "$TEST_PROJECT_ROOT")"
+    [ "$result" = "builtin:default" ]
+}
+
+@test "find_workflow_file finds workflows/default.yaml" {
+    cat > "$TEST_PROJECT_ROOT/workflows/default.yaml" << 'EOF'
+name: default
+steps:
+  - plan
+  - implement
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(find_workflow_file "default" "$TEST_PROJECT_ROOT")"
+    [ "$result" = "$TEST_PROJECT_ROOT/workflows/default.yaml" ]
+}
+
+@test "find_workflow_file finds custom workflow" {
+    cat > "$TEST_PROJECT_ROOT/workflows/custom.yaml" << 'EOF'
+name: custom
+steps:
+  - test
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(find_workflow_file "custom" "$TEST_PROJECT_ROOT")"
+    [ "$result" = "$TEST_PROJECT_ROOT/workflows/custom.yaml" ]
+}
+
+@test "find_workflow_file finds .pi/workflow.yaml" {
+    mkdir -p "$TEST_PROJECT_ROOT/.pi"
+    cat > "$TEST_PROJECT_ROOT/.pi/workflow.yaml" << 'EOF'
+name: project
+steps:
+  - build
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(find_workflow_file "default" "$TEST_PROJECT_ROOT")"
+    [ "$result" = "$TEST_PROJECT_ROOT/.pi/workflow.yaml" ]
+}
+
+# ====================
+# find_agent_file テスト
+# ====================
+
+@test "find_agent_file returns builtin for missing agent" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(find_agent_file "plan" "$TEST_PROJECT_ROOT")"
+    [ "$result" = "builtin:plan" ]
+}
+
+@test "find_agent_file finds agents/plan.md" {
+    cat > "$TEST_PROJECT_ROOT/agents/plan.md" << 'EOF'
+# Plan Agent
+Custom plan agent.
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(find_agent_file "plan" "$TEST_PROJECT_ROOT")"
+    [ "$result" = "$TEST_PROJECT_ROOT/agents/plan.md" ]
+}
+
+@test "find_agent_file finds .pi/agents/plan.md" {
+    cat > "$TEST_PROJECT_ROOT/.pi/agents/plan.md" << 'EOF'
+# Plan Agent
+From .pi directory.
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(find_agent_file "plan" "$TEST_PROJECT_ROOT")"
+    [ "$result" = "$TEST_PROJECT_ROOT/.pi/agents/plan.md" ]
+}
+
+# ====================
+# get_workflow_steps テスト
+# ====================
+
+@test "get_workflow_steps returns builtin default steps" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(get_workflow_steps "builtin:default")"
+    [ "$result" = "plan implement review merge" ]
+}
+
+@test "get_workflow_steps returns builtin simple steps" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(get_workflow_steps "builtin:simple")"
+    [ "$result" = "implement merge" ]
+}
+
+@test "get_workflow_steps parses YAML file with yq" {
+    if ! command -v yq &>/dev/null; then
+        skip "yq not installed"
+    fi
+    
+    cat > "$TEST_PROJECT_ROOT/workflows/test.yaml" << 'EOF'
+name: test
+steps:
+  - step1
+  - step2
+  - step3
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(get_workflow_steps "$TEST_PROJECT_ROOT/workflows/test.yaml")"
+    [ "$result" = "step1 step2 step3" ]
+}
+
+# ====================
+# render_template テスト
+# ====================
+
+@test "render_template replaces issue_number" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(render_template "Issue #{{issue_number}}" "42")"
+    [ "$result" = "Issue #42" ]
+}
+
+@test "render_template replaces branch_name" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(render_template "Branch: {{branch_name}}" "" "feature/test")"
+    [ "$result" = "Branch: feature/test" ]
+}
+
+@test "render_template replaces multiple variables" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    template="Issue #{{issue_number}} on {{branch_name}} in {{worktree_path}}"
+    result="$(render_template "$template" "42" "feature/test" "/path/to/worktree")"
+    
+    [ "$result" = "Issue #42 on feature/test in /path/to/worktree" ]
+}
+
+@test "render_template replaces issue_title" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(render_template "Title: {{issue_title}}" "42" "" "" "" "default" "Test Issue")"
+    [ "$result" = "Title: Test Issue" ]
+}
+
+@test "render_template handles empty variables" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(render_template "Issue #{{issue_number}}" "")"
+    [ "$result" = "Issue #" ]
+}
+
+# ====================
+# get_agent_prompt テスト
+# ====================
+
+@test "get_agent_prompt returns builtin plan prompt" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(get_agent_prompt "builtin:plan" "42")"
+    [[ "$result" == *"Plan the implementation"* ]]
+    [[ "$result" == *"#42"* ]]
+}
+
+@test "get_agent_prompt returns builtin implement prompt" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(get_agent_prompt "builtin:implement" "42")"
+    [[ "$result" == *"Implement the changes"* ]]
+}
+
+@test "get_agent_prompt reads from file" {
+    cat > "$TEST_PROJECT_ROOT/agents/custom.md" << 'EOF'
+# Custom Agent for Issue #{{issue_number}}
+Do custom work.
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(get_agent_prompt "$TEST_PROJECT_ROOT/agents/custom.md" "99")"
+    [[ "$result" == *"Custom Agent for Issue #99"* ]]
+    [[ "$result" == *"Do custom work"* ]]
+}
+
+# ====================
+# parse_step_result テスト
+# ====================
+
+@test "parse_step_result detects DONE" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(parse_step_result "[DONE] All done")"
+    [ "$result" = "DONE" ]
+}
+
+@test "parse_step_result detects BLOCKED" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(parse_step_result "[BLOCKED] Cannot proceed")"
+    [ "$result" = "BLOCKED" ]
+}
+
+@test "parse_step_result detects FIX_NEEDED" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(parse_step_result "[FIX_NEEDED] Please fix")"
+    [ "$result" = "FIX_NEEDED" ]
+}
+
+@test "parse_step_result defaults to DONE" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(parse_step_result "No marker here")"
+    [ "$result" = "DONE" ]
+}
+
+# ====================
+# run_step テスト
+# ====================
+
+@test "run_step returns agent prompt" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(run_step "plan" "42" "feature/test" "/path" "$TEST_PROJECT_ROOT")"
+    [[ "$result" == *"Plan"* ]] || [[ "$result" == *"plan"* ]]
+}
+
+# ====================
+# run_workflow テスト
+# ====================
+
+@test "run_workflow outputs step info" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(run_workflow "default" "42" "feature/test" "/path" "$TEST_PROJECT_ROOT")"
+    
+    [[ "$result" == *"step:0:"* ]]
+    [[ "$result" == *"total:"* ]]
+}
+
+# ====================
+# generate_workflow_prompt テスト
+# ====================
+
+@test "generate_workflow_prompt includes issue info" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(generate_workflow_prompt "default" "42" "Test Issue" "Issue body" "feature/test" "/path" "$TEST_PROJECT_ROOT")"
+    
+    [[ "$result" == *"Issue #42"* ]]
+    [[ "$result" == *"Test Issue"* ]]
+    [[ "$result" == *"Issue body"* ]]
+}
+
+@test "generate_workflow_prompt includes all steps" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(generate_workflow_prompt "default" "42" "Test" "Body" "branch" "/path" "$TEST_PROJECT_ROOT")"
+    
+    [[ "$result" == *"Step 1:"* ]]
+    [[ "$result" == *"Step 2:"* ]]
+}
+
+@test "generate_workflow_prompt includes completion marker instructions" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(generate_workflow_prompt "default" "42" "Test" "Body" "branch" "/path" "$TEST_PROJECT_ROOT")"
+    
+    [[ "$result" == *"TASK"* ]]
+    [[ "$result" == *"COMPLETE"* ]]
+    [[ "$result" == *"42"* ]]
+}
+
+# ====================
+# list_available_workflows テスト
+# ====================
+
+@test "list_available_workflows shows builtin workflows" {
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(list_available_workflows "$TEST_PROJECT_ROOT")"
+    
+    [[ "$result" == *"default"* ]]
+    [[ "$result" == *"simple"* ]]
+}
+
+@test "list_available_workflows shows custom workflows" {
+    cat > "$TEST_PROJECT_ROOT/workflows/myworkflow.yaml" << 'EOF'
+name: myworkflow
+EOF
+    
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    result="$(list_available_workflows "$TEST_PROJECT_ROOT")"
+    
+    [[ "$result" == *"myworkflow"* ]]
+}

--- a/test/lib/worktree.bats
+++ b/test/lib/worktree.bats
@@ -1,0 +1,372 @@
+#!/usr/bin/env bats
+# worktree.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # 設定をリセット
+    unset _CONFIG_LOADED
+    unset CONFIG_WORKTREE_BASE_DIR
+    
+    # worktree_base_dirを一時ディレクトリに設定
+    export PI_RUNNER_WORKTREE_BASE_DIR="${BATS_TEST_TMPDIR}/.worktrees"
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees"
+    
+    # モックディレクトリをセットアップ
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    export ORIGINAL_PATH="$PATH"
+}
+
+teardown() {
+    if [[ -n "${ORIGINAL_PATH:-}" ]]; then
+        export PATH="$ORIGINAL_PATH"
+    fi
+    
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# gitのモック
+mock_git_success() {
+    local mock_script="$MOCK_DIR/git"
+    cat > "$mock_script" << MOCK_EOF
+#!/usr/bin/env bash
+case "\$1" in
+    "worktree")
+        case "\$2" in
+            "add")
+                # worktreeディレクトリを作成
+                if [[ "\$3" == "-b" ]]; then
+                    mkdir -p "\$5" 2>/dev/null
+                    echo "Created worktree at \$5"
+                else
+                    mkdir -p "\$3" 2>/dev/null
+                    echo "Created worktree at \$3"
+                fi
+                exit 0
+                ;;
+            "remove")
+                rm -rf "\$3" 2>/dev/null
+                exit 0
+                ;;
+            "list")
+                if [[ "\$3" == "--porcelain" ]]; then
+                    echo "worktree /main"
+                    echo "HEAD abc123"
+                    echo "branch refs/heads/main"
+                    echo ""
+                    echo "worktree ${BATS_TEST_TMPDIR}/.worktrees/issue-42-test"
+                    echo "HEAD def456"
+                    echo "branch refs/heads/feature/issue-42-test"
+                    echo ""
+                fi
+                exit 0
+                ;;
+        esac
+        ;;
+    "rev-parse")
+        if [[ "\$2" == "--verify" ]]; then
+            exit 1  # ブランチが存在しない
+        fi
+        exit 0
+        ;;
+    "branch")
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$mock_script"
+}
+
+mock_git_worktree_exists() {
+    local mock_script="$MOCK_DIR/git"
+    cat > "$mock_script" << MOCK_EOF
+#!/usr/bin/env bash
+case "\$1" in
+    "worktree")
+        case "\$2" in
+            "list")
+                if [[ "\$3" == "--porcelain" ]]; then
+                    echo "worktree ${BATS_TEST_TMPDIR}/.worktrees/issue-42-test"
+                    echo "HEAD abc123"
+                    echo "branch refs/heads/feature/issue-42-test"
+                    echo ""
+                    echo "worktree ${BATS_TEST_TMPDIR}/.worktrees/issue-99-fix"
+                    echo "HEAD def456"
+                    echo "branch refs/heads/feature/issue-99-fix"
+                fi
+                exit 0
+                ;;
+            "remove")
+                rm -rf "\$3" 2>/dev/null || rm -rf "\$4" 2>/dev/null
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$mock_script"
+}
+
+# ====================
+# create_worktree テスト
+# ====================
+
+@test "create_worktree creates directory" {
+    mock_git_success
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    result="$(create_worktree "issue-42-test")"
+    
+    # パスが返されることを確認
+    [[ "$result" == *"issue-42-test"* ]]
+}
+
+@test "create_worktree fails when directory exists" {
+    mock_git_success
+    export PATH="$MOCK_DIR:$PATH"
+    
+    # 既存のディレクトリを作成
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees/existing-branch"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    run create_worktree "existing-branch"
+    [ "$status" -ne 0 ]
+}
+
+@test "create_worktree uses custom base branch" {
+    mock_git_success
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    result="$(create_worktree "issue-43-test" "develop")"
+    [[ "$result" == *"issue-43-test"* ]]
+}
+
+# ====================
+# remove_worktree テスト
+# ====================
+
+@test "remove_worktree removes existing worktree" {
+    mock_git_worktree_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    # テスト用worktreeディレクトリを作成
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees/issue-42-test"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    run remove_worktree "${BATS_TEST_TMPDIR}/.worktrees/issue-42-test"
+    [ "$status" -eq 0 ]
+}
+
+@test "remove_worktree fails for non-existent worktree" {
+    mock_git_success
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    run remove_worktree "/nonexistent/path"
+    [ "$status" -ne 0 ]
+}
+
+@test "remove_worktree with force option" {
+    mock_git_worktree_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees/issue-42-test"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    run remove_worktree "${BATS_TEST_TMPDIR}/.worktrees/issue-42-test" "true"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# list_worktrees テスト
+# ====================
+
+@test "list_worktrees returns worktrees in base dir" {
+    mock_git_worktree_exists
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    result="$(list_worktrees)"
+    [[ "$result" == *"issue-42-test"* ]]
+}
+
+@test "list_worktrees returns empty for no worktrees" {
+    local mock_script="$MOCK_DIR/git"
+    cat > "$mock_script" << 'MOCK_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "worktree" && "$2" == "list" ]]; then
+    echo "worktree /main"
+    echo "HEAD abc123"
+    echo "branch refs/heads/main"
+fi
+exit 0
+MOCK_EOF
+    chmod +x "$mock_script"
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    result="$(list_worktrees)"
+    [ -z "$result" ]
+}
+
+# ====================
+# get_worktree_branch テスト
+# ====================
+
+@test "get_worktree_branch returns branch name" {
+    # 実際のディレクトリを作成
+    local worktree_dir="${BATS_TEST_TMPDIR}/.worktrees/issue-42-test"
+    mkdir -p "$worktree_dir"
+    
+    # 正規化されたパスを取得
+    local normalized_path="$(cd "$worktree_dir" && pwd -P)"
+    
+    # モックを作成（正規化されたパスを使用）
+    local mock_script="$MOCK_DIR/git"
+    cat > "$mock_script" << MOCK_EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "worktree" && "\$2" == "list" ]]; then
+    echo "worktree ${normalized_path}"
+    echo "HEAD abc123"
+    echo "branch refs/heads/feature/issue-42-test"
+    echo ""
+fi
+exit 0
+MOCK_EOF
+    chmod +x "$mock_script"
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    result="$(get_worktree_branch "$worktree_dir")"
+    [ "$result" = "feature/issue-42-test" ]
+}
+
+@test "get_worktree_branch returns empty for unknown path" {
+    local mock_script="$MOCK_DIR/git"
+    cat > "$mock_script" << 'MOCK_EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "worktree" && "$2" == "list" ]]; then
+    echo "worktree /some/other/path"
+    echo "HEAD abc123"
+    echo "branch refs/heads/main"
+    echo ""
+fi
+exit 0
+MOCK_EOF
+    chmod +x "$mock_script"
+    export PATH="$MOCK_DIR:$PATH"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    # Use run to capture potential failures
+    run get_worktree_branch "/unknown/path"
+    [ -z "$output" ]
+}
+
+# ====================
+# find_worktree_by_issue テスト
+# ====================
+
+@test "find_worktree_by_issue finds matching worktree" {
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    # テスト用ディレクトリを作成
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees/issue-42-test"
+    
+    result="$(find_worktree_by_issue "42")"
+    [[ "$result" == *"issue-42"* ]]
+}
+
+@test "find_worktree_by_issue returns failure for no match" {
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    run find_worktree_by_issue "999"
+    [ "$status" -ne 0 ]
+}
+
+@test "find_worktree_by_issue handles multiple worktrees" {
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    # 複数のworktreeディレクトリを作成
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees/issue-10-first"
+    mkdir -p "${BATS_TEST_TMPDIR}/.worktrees/issue-20-second"
+    
+    result="$(find_worktree_by_issue "20")"
+    [[ "$result" == *"issue-20"* ]]
+}
+
+# ====================
+# copy_files_to_worktree テスト
+# ====================
+
+@test "copy_files_to_worktree copies configured files" {
+    export PI_RUNNER_WORKTREE_COPY_FILES=".env .env.local"
+    
+    # ソースファイルを作成（カレントディレクトリに）
+    echo "TEST=value" > "$BATS_TEST_TMPDIR/.env"
+    
+    # worktreeディレクトリを作成
+    local worktree_dir="${BATS_TEST_TMPDIR}/test-worktree"
+    mkdir -p "$worktree_dir"
+    
+    # カレントディレクトリを変更してテスト
+    cd "$BATS_TEST_TMPDIR"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    copy_files_to_worktree "$worktree_dir"
+    
+    [ -f "$worktree_dir/.env" ]
+}
+
+@test "copy_files_to_worktree handles missing files gracefully" {
+    export PI_RUNNER_WORKTREE_COPY_FILES=".nonexistent"
+    
+    local worktree_dir="${BATS_TEST_TMPDIR}/test-worktree"
+    mkdir -p "$worktree_dir"
+    
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    # エラーにならないことを確認
+    run copy_files_to_worktree "$worktree_dir"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# 統合テスト
+# ====================
+
+@test "worktree functions load without error" {
+    source "$PROJECT_ROOT/lib/worktree.sh"
+    
+    # 関数が定義されていることを確認
+    declare -f create_worktree > /dev/null
+    declare -f remove_worktree > /dev/null
+    declare -f list_worktrees > /dev/null
+    declare -f find_worktree_by_issue > /dev/null
+}


### PR DESCRIPTION
## Summary
Closes #200

## Changes
- Add `test/lib/notify.bats` (13 tests) - Platform detection, notifications
- Add `test/lib/status.bats` (22 tests) - JSON operations, status management
- Add `test/lib/tmux.bats` (18 tests) - Session management, session name generation
- Add `test/lib/workflow.bats` (29 tests) - Workflow parsing, template rendering
- Add `test/lib/worktree.bats` (16 tests) - Worktree operations, issue lookup
- Add `docs/plans/issue-200-plan.md` - Implementation plan

## Testing
```bash
# Run all Bats tests
bats test/lib/*.bats

# Results: 134 tests pass (98 new tests from this PR)
```

## Acceptance Criteria
- [x] 5 Bats test files created
- [x] `bats test/lib/*.bats` executes successfully
- [x] Each test file contains at least 3 test cases