### PR TITLE
docs: アーキテクチャドキュメントを現在のBash実装に合わせて修正

### DIFF
--- a/docs/plans/issue-236-plan.md
+++ b/docs/plans/issue-236-plan.md
@@ -1,0 +1,90 @@
+# 実装計画: Issue #236
+
+## 概要
+
+`docs/` 配下のアーキテクチャドキュメントをTypeScript/Bun実装からBashシェルスクリプト実装に合わせて書き直す。
+
+## 影響範囲
+
+以下のドキュメントファイルを更新：
+
+| ファイル | 内容 |
+|----------|------|
+| `docs/architecture.md` | システム全体のアーキテクチャ |
+| `docs/parallel-execution.md` | 並列実行の仕組み |
+| `docs/state-management.md` | 状態管理の仕組み |
+| `docs/tmux-integration.md` | Tmux統合の詳細 |
+| `docs/worktree-management.md` | Git worktree管理 |
+
+## 実装ステップ
+
+### Step 1: architecture.md の更新
+- TypeScript クラス定義を Bash 関数参照に変更
+- `cli.ts`, `commands/*.ts` を `scripts/*.sh`, `lib/*.sh` に変更
+- Bun CLI API への言及を削除
+- 実際のファイル構造とコンポーネント図を更新
+
+### Step 2: parallel-execution.md の更新
+- TypeScript インターフェース・クラスを Bash 関数に変更
+- `lib/tmux.sh` の `check_concurrent_limit()` を参照
+- `scripts/wait-for-sessions.sh` を参照
+- async/await パターンを Bash のバックグラウンドプロセスに変更
+
+### Step 3: state-management.md の更新
+- TypeScript の TaskStateStore クラスを `lib/status.sh` の関数群に変更
+- JSON操作を jq ベースの実装に変更
+- `.worktrees/.status/` ディレクトリ構造を反映
+
+### Step 4: tmux-integration.md の更新
+- TypeScript 実装を `lib/tmux.sh` の関数群に変更
+- `Bun.spawn()` を直接の tmux コマンド呼び出しに変更
+- 実際のセッション管理フローを反映
+
+### Step 5: worktree-management.md の更新
+- TypeScript 実装を `lib/worktree.sh` の関数群に変更
+- `Bun.file()` を Bash のファイル操作に変更
+- 実際のブランチ命名規則 (`feature/issue-XXX-*`) を反映
+
+## テスト方針
+
+- ドキュメントの更新のみのため、単体テストは不要
+- ShellCheck は影響なし
+- マークダウンの構文チェック（目視確認）
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| 既存リンクの破損 | 内部リンクの整合性を確認 |
+| 情報の欠落 | 実装コードと照合して網羅性を確認 |
+
+## 参照する実装ファイル
+
+### scripts/
+- `run.sh` - メインエントリーポイント
+- `list.sh` - セッション一覧
+- `status.sh` - 状態確認
+- `cleanup.sh` - クリーンアップ
+- `wait-for-sessions.sh` - 複数セッション待機
+- `watch-session.sh` - セッション監視
+
+### lib/
+- `config.sh` - 設定管理
+- `status.sh` - 状態管理
+- `tmux.sh` - Tmux操作
+- `worktree.sh` - Git worktree操作
+- `workflow.sh` - ワークフローエンジン
+- `github.sh` - GitHub CLI操作
+- `log.sh` - ログ出力
+- `notify.sh` - 通知機能
+
+## 完了条件
+
+- [x] 実装計画書を作成
+- [x] `docs/architecture.md` をBash実装に更新
+- [x] `docs/parallel-execution.md` をBash実装に更新
+- [x] `docs/state-management.md` をBash実装に更新
+- [x] `docs/tmux-integration.md` をBash実装に更新
+- [x] `docs/worktree-management.md` をBash実装に更新
+- [x] TypeScript/Bunへの参照が削除されている
+- [x] 実際のスクリプトファイルへの参照が追加されている

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -2,825 +2,418 @@
 
 ## 概要
 
-Pi Issue Runnerの状態管理システムは、タスクの実行状態、設定、ログなどを永続化し、プロセス再起動後も復元できるようにします。
+Pi Issue Runnerの状態管理システムは、タスクの実行状態をJSONファイルで永続化し、プロセス再起動後も状態を復元できるようにします。
 
 ## データ永続化
 
 ### ストレージ構造
 
 ```
-.pi-runner/
-├── tasks.json          # タスク状態データベース
-├── config.json         # 実行時設定（自動生成）
-├── metadata.json       # メタデータ（バージョン、統計等）
-└── logs/               # ログファイル
-    ├── issue-42.log    # タスクログ
-    ├── issue-43.log
-    └── system.log      # システムログ
+.worktrees/
+├── .status/                  # ステータスディレクトリ
+│   ├── 42.json               # Issue #42のステータス
+│   ├── 43.json               # Issue #43のステータス
+│   └── 44.json               # Issue #44のステータス
+├── issue-42-feature/         # Issue #42のworktree
+├── issue-43-bugfix/          # Issue #43のworktree
+└── issue-44-refactor/        # Issue #44のworktree
 ```
 
-### tasks.jsonフォーマット
+### ステータスファイルフォーマット
 
+**ファイル**: `.worktrees/.status/{issue_number}.json`
+
+**形式**:
 ```json
 {
-  "version": "1.0.0",
-  "lastUpdated": "2024-01-30T09:00:00.000Z",
-  "tasks": [
-    {
-      "id": "pi-issue-42",
-      "issue": 42,
-      "status": "running",
-      "branch": "issue-42",
-      "worktreePath": ".worktrees/issue-42",
-      "tmuxSession": "pi-issue-42",
-      "startedAt": "2024-01-30T09:00:00.000Z",
-      "completedAt": null,
-      "exitCode": null,
-      "error": null,
-      "metadata": {
-        "retryCount": 0,
-        "priority": 0,
-        "labels": ["feature"],
-        "assignee": "username"
-      },
-      "logs": {
-        "path": ".pi-runner/logs/issue-42.log",
-        "size": 12345
-      }
-    }
-  ]
+  "issue": 42,
+  "status": "running",
+  "session": "pi-issue-42",
+  "timestamp": "2024-01-30T09:00:00Z"
 }
 ```
 
-## TaskManager実装
-
-### データアクセス層
-
-```typescript
-class TaskStateStore {
-  private filePath: string;
-  private cache: TaskDatabase | null = null;
-  private dirty = false;
-  
-  constructor(dataDir: string) {
-    this.filePath = path.join(dataDir, 'tasks.json');
-  }
-  
-  async load(): Promise<TaskDatabase> {
-    if (this.cache) {
-      return this.cache;
-    }
-    
-    try {
-      const file = Bun.file(this.filePath);
-      if (await file.exists()) {
-        const data = await file.json();
-        this.cache = this.validate(data);
-        return this.cache;
-      }
-    } catch (error) {
-      this.logger.warn('Failed to load tasks.json, using empty database');
-    }
-    
-    // 初期データベース
-    this.cache = {
-      version: '1.0.0',
-      lastUpdated: new Date().toISOString(),
-      tasks: []
-    };
-    
-    return this.cache;
-  }
-  
-  async save(): Promise<void> {
-    if (!this.dirty || !this.cache) return;
-    
-    this.cache.lastUpdated = new Date().toISOString();
-    
-    await Bun.write(
-      this.filePath,
-      JSON.stringify(this.cache, null, 2)
-    );
-    
-    this.dirty = false;
-  }
-  
-  markDirty(): void {
-    this.dirty = true;
-  }
-  
-  private validate(data: any): TaskDatabase {
-    // バージョンチェック
-    if (data.version !== '1.0.0') {
-      throw new InvalidVersionError(`Unsupported version: ${data.version}`);
-    }
-    
-    // データ構造の検証
-    if (!Array.isArray(data.tasks)) {
-      throw new InvalidDataError('tasks must be an array');
-    }
-    
-    return data as TaskDatabase;
-  }
+**エラー時**:
+```json
+{
+  "issue": 42,
+  "status": "error",
+  "session": "pi-issue-42",
+  "error_message": "テストが失敗しました",
+  "timestamp": "2024-01-30T09:05:00Z"
 }
 ```
 
-### TaskManager
+## 状態管理API
 
-```typescript
-class TaskManager {
-  private store: TaskStateStore;
-  private autoSaveInterval: Timer;
-  
-  constructor(config: Config) {
-    this.store = new TaskStateStore(config.dataDir);
+### lib/status.sh
+
+#### 基本操作
+
+```bash
+# ライブラリ読み込み
+source lib/status.sh
+
+# ステータスを保存
+save_status 42 "running" "pi-issue-42"
+save_status 42 "complete" "pi-issue-42"
+save_status 42 "error" "pi-issue-42" "エラーメッセージ"
+
+# 簡易版（セッション名を自動生成）
+set_status 42 "running"
+set_status 42 "complete"
+set_status 42 "error" "エラーメッセージ"
+```
+
+#### ステータス取得
+
+```bash
+# ステータス値を取得
+status="$(get_status 42)"
+# → "running", "complete", "error", "unknown"
+
+# 完全なJSONを取得
+json="$(load_status 42)"
+# → {"issue":42,"status":"running",...}
+
+# エラーメッセージを取得
+error="$(get_error_message 42)"
+```
+
+#### 一覧操作
+
+```bash
+# 全ステータスを一覧
+list_all_statuses
+# 出力:
+# 42	running
+# 43	complete
+# 44	error
+
+# 特定ステータスのIssueを取得
+list_issues_by_status "running"
+# 出力:
+# 42
+
+list_issues_by_status "complete"
+# 出力:
+# 43
+```
+
+#### クリーンアップ
+
+```bash
+# ステータスファイルを削除
+remove_status 42
+
+# 孤立したステータスファイルを検出
+find_orphaned_statuses
+# → 対応するworktreeが存在しないステータスファイルのIssue番号
+```
+
+## 実装詳細
+
+### JSON構築
+
+jqが利用可能な場合はjqを使用、なければ純粋なBashでフォールバック:
+
+```bash
+# lib/status.sh
+
+# jqを使用（推奨）
+build_json_with_jq() {
+    local issue_number="$1"
+    local status="$2"
+    local session_name="$3"
+    local timestamp="$4"
+    local error_message="${5:-}"
     
-    // 自動保存（5秒ごと）
-    this.autoSaveInterval = setInterval(() => {
-      this.store.save();
-    }, 5000);
-  }
-  
-  async createTask(issueNumber: number, options?: TaskOptions): Promise<Task> {
-    const db = await this.store.load();
+    if [[ -n "$error_message" ]]; then
+        jq -n \
+            --argjson issue "$issue_number" \
+            --arg status "$status" \
+            --arg session "$session_name" \
+            --arg error "$error_message" \
+            --arg timestamp "$timestamp" \
+            '{issue: $issue, status: $status, session: $session, error_message: $error, timestamp: $timestamp}'
+    else
+        jq -n \
+            --argjson issue "$issue_number" \
+            --arg status "$status" \
+            --arg session "$session_name" \
+            --arg timestamp "$timestamp" \
+            '{issue: $issue, status: $status, session: $session, timestamp: $timestamp}'
+    fi
+}
+
+# Bashフォールバック（jqなし）
+build_json_fallback() {
+    local issue_number="$1"
+    local status="$2"
+    local session_name="$3"
+    local timestamp="$4"
+    local error_message="${5:-}"
     
-    // タスクIDを生成
-    const taskId = this.generateTaskId(issueNumber);
+    # JSONエスケープ処理
+    local escaped_status escaped_session escaped_timestamp
+    escaped_status="$(json_escape "$status")"
+    escaped_session="$(json_escape "$session_name")"
+    escaped_timestamp="$(json_escape "$timestamp")"
     
-    // 既存タスクをチェック
-    if (db.tasks.some(t => t.id === taskId)) {
-      throw new TaskExistsError(`Task already exists: ${taskId}`);
-    }
-    
-    // GitHub Issueを取得
-    const issue = await this.githubClient.getIssue(issueNumber);
-    
-    // タスクを作成
-    const task: Task = {
-      id: taskId,
-      issue: issueNumber,
-      status: 'queued',
-      branch: options?.branch ?? `issue-${issueNumber}`,
-      worktreePath: '',
-      tmuxSession: taskId,
-      startedAt: null,
-      completedAt: null,
-      exitCode: null,
-      error: null,
-      metadata: {
-        retryCount: 0,
-        priority: this.calculatePriority(issue),
-        labels: issue.labels,
-        assignee: issue.assignee
-      },
-      logs: {
-        path: path.join(this.config.logsDir, `issue-${issueNumber}.log`),
-        size: 0
-      }
-    };
-    
-    db.tasks.push(task);
-    this.store.markDirty();
-    
-    return task;
-  }
-  
-  async getTask(taskId: string): Promise<Task | null> {
-    const db = await this.store.load();
-    return db.tasks.find(t => t.id === taskId) ?? null;
-  }
-  
-  async updateTask(task: Task): Promise<void> {
-    const db = await this.store.load();
-    const index = db.tasks.findIndex(t => t.id === task.id);
-    
-    if (index === -1) {
-      throw new TaskNotFoundError(`Task not found: ${task.id}`);
-    }
-    
-    db.tasks[index] = task;
-    this.store.markDirty();
-  }
-  
-  async updateTaskStatus(
-    taskId: string,
-    status: TaskStatus,
-    metadata?: Partial<Task>
-  ): Promise<void> {
-    const task = await this.getTask(taskId);
-    if (!task) {
-      throw new TaskNotFoundError(`Task not found: ${taskId}`);
-    }
-    
-    task.status = status;
-    
-    if (status === 'running' && !task.startedAt) {
-      task.startedAt = new Date().toISOString();
-    }
-    
-    if ((status === 'completed' || status === 'failed') && !task.completedAt) {
-      task.completedAt = new Date().toISOString();
-    }
-    
-    if (metadata) {
-      Object.assign(task, metadata);
-    }
-    
-    await this.updateTask(task);
-  }
-  
-  async listTasks(filter?: TaskFilter): Promise<Task[]> {
-    const db = await this.store.load();
-    let tasks = db.tasks;
-    
-    if (filter) {
-      if (filter.status) {
-        tasks = tasks.filter(t => t.status === filter.status);
-      }
-      if (filter.issue) {
-        tasks = tasks.filter(t => t.issue === filter.issue);
-      }
-      if (filter.label) {
-        tasks = tasks.filter(t => t.metadata.labels.includes(filter.label));
-      }
-    }
-    
-    return tasks;
-  }
-  
-  async removeTask(taskId: string): Promise<void> {
-    const db = await this.store.load();
-    const index = db.tasks.findIndex(t => t.id === taskId);
-    
-    if (index === -1) {
-      throw new TaskNotFoundError(`Task not found: ${taskId}`);
-    }
-    
-    db.tasks.splice(index, 1);
-    this.store.markDirty();
-    await this.store.save();  // 即座に保存
-  }
-  
-  async shutdown(): Promise<void> {
-    clearInterval(this.autoSaveInterval);
-    await this.store.save();
-  }
+    if [[ -n "$error_message" ]]; then
+        local escaped_message
+        escaped_message="$(json_escape "$error_message")"
+        cat << EOF
+{
+  "issue": $issue_number,
+  "status": "$escaped_status",
+  "session": "$escaped_session",
+  "error_message": "$escaped_message",
+  "timestamp": "$escaped_timestamp"
+}
+EOF
+    else
+        cat << EOF
+{
+  "issue": $issue_number,
+  "status": "$escaped_status",
+  "session": "$escaped_session",
+  "timestamp": "$escaped_timestamp"
+}
+EOF
+    fi
 }
 ```
 
-## 状態遷移の管理
+### JSONエスケープ
 
-### 状態マシン
-
-```typescript
-type TaskStatus = 'queued' | 'running' | 'completed' | 'failed';
-
-interface StateTransition {
-  from: TaskStatus;
-  to: TaskStatus;
-  conditions?: (task: Task) => boolean;
-  actions?: (task: Task) => Promise<void>;
-}
-
-class TaskStateMachine {
-  private transitions: StateTransition[] = [
-    {
-      from: 'queued',
-      to: 'running',
-      conditions: (task) => this.canStartTask(task),
-      actions: async (task) => {
-        await this.worktreeManager.createWorktree(task.issue, task.branch);
-        await this.tmuxManager.createSession(task.tmuxSession, task.worktreePath);
-      }
-    },
-    {
-      from: 'running',
-      to: 'completed',
-      conditions: (task) => task.exitCode === 0,
-      actions: async (task) => {
-        await this.notifyCompletion(task);
-        if (this.config.autoCleanup) {
-          await this.cleanup(task);
-        }
-      }
-    },
-    {
-      from: 'running',
-      to: 'failed',
-      conditions: (task) => task.exitCode !== 0,
-      actions: async (task) => {
-        await this.notifyFailure(task);
-        await this.handleFailure(task);
-      }
-    }
-  ];
-  
-  async transition(
-    task: Task,
-    to: TaskStatus
-  ): Promise<void> {
-    const transition = this.transitions.find(
-      t => t.from === task.status && t.to === to
-    );
-    
-    if (!transition) {
-      throw new InvalidTransitionError(
-        `Cannot transition from ${task.status} to ${to}`
-      );
-    }
-    
-    // 条件をチェック
-    if (transition.conditions && !transition.conditions(task)) {
-      throw new TransitionConditionError(
-        `Conditions not met for transition from ${task.status} to ${to}`
-      );
-    }
-    
-    // アクションを実行
-    if (transition.actions) {
-      await transition.actions(task);
-    }
-    
-    // 状態を更新
-    await this.taskManager.updateTaskStatus(task.id, to);
-  }
+```bash
+# 特殊文字のエスケープ
+json_escape() {
+    local str="$1"
+    # バックスラッシュを最初にエスケープ（順序重要）
+    str="${str//\\/\\\\}"
+    # ダブルクォート
+    str="${str//\"/\\\"}"
+    # タブ
+    str="${str//$'\t'/\\t}"
+    # 改行
+    str="${str//$'\n'/\\n}"
+    # キャリッジリターン
+    str="${str//$'\r'/\\r}"
+    echo "$str"
 }
 ```
 
-### イベント駆動の状態管理
+### ステータス保存
 
-```typescript
-enum TaskEvent {
-  CREATED = 'task.created',
-  STARTED = 'task.started',
-  COMPLETED = 'task.completed',
-  FAILED = 'task.failed',
-  CANCELLED = 'task.cancelled'
-}
-
-interface TaskEventPayload {
-  taskId: string;
-  timestamp: Date;
-  data?: any;
-}
-
-class TaskEventBus {
-  private handlers = new Map<TaskEvent, Set<EventHandler>>();
-  
-  on(event: TaskEvent, handler: EventHandler): void {
-    if (!this.handlers.has(event)) {
-      this.handlers.set(event, new Set());
-    }
-    this.handlers.get(event)!.add(handler);
-  }
-  
-  off(event: TaskEvent, handler: EventHandler): void {
-    this.handlers.get(event)?.delete(handler);
-  }
-  
-  async emit(event: TaskEvent, payload: TaskEventPayload): Promise<void> {
-    const handlers = this.handlers.get(event);
-    if (!handlers) return;
+```bash
+save_status() {
+    local issue_number="$1"
+    local status="$2"
+    local session_name="${3:-}"
+    local error_message="${4:-}"
     
-    // イベントをログに記録
-    await this.logEvent(event, payload);
+    # ディレクトリ初期化
+    init_status_dir
     
-    // 全ハンドラーを実行
-    await Promise.all(
-      Array.from(handlers).map(h => h(payload))
-    );
-  }
-  
-  private async logEvent(
-    event: TaskEvent,
-    payload: TaskEventPayload
-  ): Promise<void> {
-    const logEntry = {
-      event,
-      ...payload,
-      timestamp: new Date().toISOString()
-    };
+    local status_dir
+    status_dir="$(get_status_dir)"
+    local status_file="${status_dir}/${issue_number}.json"
+    local timestamp
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     
-    await Bun.write(
-      path.join(this.config.dataDir, 'events.jsonl'),
-      JSON.stringify(logEntry) + '\n',
-      { append: true }
-    );
-  }
-}
-
-// 使用例
-eventBus.on(TaskEvent.STARTED, async (payload) => {
-  const task = await taskManager.getTask(payload.taskId);
-  console.log(`Task ${task?.issue} started at ${payload.timestamp}`);
-});
-
-eventBus.on(TaskEvent.COMPLETED, async (payload) => {
-  const task = await taskManager.getTask(payload.taskId);
-  console.log(`Task ${task?.issue} completed successfully`);
-  
-  // 次のタスクをキューから起動
-  await queueManager.processQueue();
-});
-```
-
-## トランザクション管理
-
-### アトミック操作
-
-```typescript
-class TransactionManager {
-  private inProgress = new Map<string, Transaction>();
-  
-  async begin(transactionId: string): Promise<Transaction> {
-    if (this.inProgress.has(transactionId)) {
-      throw new TransactionExistsError(`Transaction already in progress: ${transactionId}`);
-    }
+    # JSONを構築
+    local json
+    if command -v jq &>/dev/null; then
+        json="$(build_json_with_jq "$issue_number" "$status" "$session_name" "$timestamp" "$error_message")"
+    else
+        json="$(build_json_fallback "$issue_number" "$status" "$session_name" "$timestamp" "$error_message")"
+    fi
     
-    const transaction: Transaction = {
-      id: transactionId,
-      operations: [],
-      startedAt: new Date(),
-      status: 'active'
-    };
-    
-    this.inProgress.set(transactionId, transaction);
-    return transaction;
-  }
-  
-  async commit(transactionId: string): Promise<void> {
-    const tx = this.inProgress.get(transactionId);
-    if (!tx) {
-      throw new TransactionNotFoundError(`Transaction not found: ${transactionId}`);
-    }
-    
-    try {
-      // 全操作を実行
-      for (const op of tx.operations) {
-        await op.execute();
-      }
-      
-      tx.status = 'committed';
-      this.inProgress.delete(transactionId);
-    } catch (error) {
-      // ロールバック
-      await this.rollback(transactionId);
-      throw error;
-    }
-  }
-  
-  async rollback(transactionId: string): Promise<void> {
-    const tx = this.inProgress.get(transactionId);
-    if (!tx) return;
-    
-    // 逆順でロールバック
-    for (let i = tx.operations.length - 1; i >= 0; i--) {
-      const op = tx.operations[i];
-      if (op.rollback) {
-        await op.rollback();
-      }
-    }
-    
-    tx.status = 'rolled_back';
-    this.inProgress.delete(transactionId);
-  }
-  
-  addOperation(transactionId: string, operation: Operation): void {
-    const tx = this.inProgress.get(transactionId);
-    if (!tx) {
-      throw new TransactionNotFoundError(`Transaction not found: ${transactionId}`);
-    }
-    
-    tx.operations.push(operation);
-  }
-}
-
-// 使用例
-const tx = await transactionManager.begin('create-task-42');
-
-try {
-  // Worktree作成
-  transactionManager.addOperation(tx.id, {
-    execute: async () => {
-      task.worktreePath = await worktreeManager.createWorktree(42);
-    },
-    rollback: async () => {
-      await worktreeManager.removeWorktree(task.worktreePath, true);
-    }
-  });
-  
-  // Tmuxセッション作成
-  transactionManager.addOperation(tx.id, {
-    execute: async () => {
-      await tmuxManager.createSession(task.tmuxSession, task.worktreePath);
-    },
-    rollback: async () => {
-      await tmuxManager.killSession(task.tmuxSession);
-    }
-  });
-  
-  // タスク状態を保存
-  transactionManager.addOperation(tx.id, {
-    execute: async () => {
-      await taskManager.createTask(task);
-    },
-    rollback: async () => {
-      await taskManager.removeTask(task.id);
-    }
-  });
-  
-  // コミット
-  await transactionManager.commit(tx.id);
-} catch (error) {
-  // 自動的にロールバック
-  console.error('Failed to create task, rolling back...', error);
+    echo "$json" > "$status_file"
+    log_debug "Saved status for issue #$issue_number: $status"
 }
 ```
 
-## キャッシュ管理
+## 状態遷移
 
-### メモリキャッシュ
+### タスクライフサイクル
 
-```typescript
-class TaskCache {
-  private cache = new Map<string, CachedTask>();
-  private ttl: number = 60000;  // 60秒
-  
-  set(taskId: string, task: Task): void {
-    this.cache.set(taskId, {
-      task,
-      cachedAt: Date.now()
-    });
-  }
-  
-  get(taskId: string): Task | null {
-    const cached = this.cache.get(taskId);
-    if (!cached) return null;
-    
-    // TTLチェック
-    if (Date.now() - cached.cachedAt > this.ttl) {
-      this.cache.delete(taskId);
-      return null;
-    }
-    
-    return cached.task;
-  }
-  
-  invalidate(taskId: string): void {
-    this.cache.delete(taskId);
-  }
-  
-  clear(): void {
-    this.cache.clear();
-  }
-}
+```
+    run.sh 開始
+         │
+         ▼
+    ┌─────────┐
+    │ running │ ←── save_status(issue, "running", session)
+    └────┬────┘
+         │
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+┌────────┐ ┌───────┐
+│complete│ │ error │
+└───┬────┘ └───┬───┘
+    │          │
+    │          └── save_status(issue, "error", session, message)
+    │
+    └── save_status(issue, "complete", session)
+```
 
-// TaskManagerに統合
-class TaskManager {
-  private cache = new TaskCache();
-  
-  async getTask(taskId: string): Promise<Task | null> {
-    // キャッシュをチェック
-    const cached = this.cache.get(taskId);
-    if (cached) {
-      return cached;
-    }
+### 状態遷移のタイミング
+
+| タイミング | 状態 | トリガー |
+|-----------|------|---------|
+| セッション作成時 | `running` | `run.sh` がセッション作成後 |
+| 完了マーカー検出 | `complete` | `watch-session.sh` がマーカーを検出 |
+| エラーマーカー検出 | `error` | `watch-session.sh` がエラーを検出 |
+| セッション異常終了 | `error` | `watch-session.sh` がセッション消失を検出 |
+
+## 監視と復旧
+
+### watch-session.sh による監視
+
+```bash
+# scripts/watch-session.sh の状態更新ロジック
+
+# 完了マーカー検出時
+if echo "$output" | grep -q "###TASK_COMPLETE_${issue_number}###"; then
+    set_status "$issue_number" "complete"
+    cleanup_and_exit
+fi
+
+# エラーマーカー検出時
+if echo "$output" | grep -qE "###TASK_ERROR_${issue_number}###"; then
+    local error_msg
+    error_msg="$(extract_error_message "$output")"
+    set_status "$issue_number" "error" "$error_msg"
+    cleanup_and_exit
+fi
+
+# セッション消失時
+if ! session_exists "$session_name"; then
+    set_status "$issue_number" "error" "Session unexpectedly terminated"
+    cleanup_and_exit
+fi
+```
+
+### 孤立リソースの検出
+
+worktreeが存在しないのにステータスファイルが残っている場合を検出:
+
+```bash
+find_orphaned_statuses() {
+    local status_dir
+    status_dir="$(get_status_dir)"
     
-    // ストアから取得
-    const db = await this.store.load();
-    const task = db.tasks.find(t => t.id === taskId);
+    if [[ ! -d "$status_dir" ]]; then
+        return 0
+    fi
     
-    if (task) {
-      this.cache.set(taskId, task);
-    }
+    local worktree_base
+    worktree_base="$(get_config worktree_base_dir)"
     
-    return task ?? null;
-  }
-  
-  async updateTask(task: Task): Promise<void> {
-    await this.store.updateTask(task);
-    
-    // キャッシュを無効化
-    this.cache.invalidate(task.id);
-  }
+    for status_file in "$status_dir"/*.json; do
+        [[ -f "$status_file" ]] || continue
+        local issue_number
+        issue_number="$(basename "$status_file" .json)"
+        
+        # 対応するworktreeが存在するか確認
+        local has_worktree=false
+        for dir in "$worktree_base"/issue-"${issue_number}"-*; do
+            if [[ -d "$dir" ]]; then
+                has_worktree=true
+                break
+            fi
+        done
+        
+        # worktreeが存在しない場合は孤立
+        if [[ "$has_worktree" == "false" ]]; then
+            echo "$issue_number"
+        fi
+    done
 }
 ```
 
-## バックアップとリストア
+## scripts/status.sh
 
-### 自動バックアップ
+ステータス確認用のユーザー向けスクリプト:
 
-```typescript
-class BackupManager {
-  async createBackup(): Promise<string> {
-    const timestamp = new Date().toISOString().replace(/:/g, '-');
-    const backupPath = path.join(
-      this.config.backupDir,
-      `backup-${timestamp}.json`
-    );
+```bash
+# 使用例
+./scripts/status.sh 42
+
+# 出力例（正常）
+Issue #42: complete
+Session: pi-issue-42
+Timestamp: 2024-01-30T09:05:00Z
+
+# 出力例（エラー）
+Issue #42: error
+Session: pi-issue-42
+Error: テストが失敗しました
+Timestamp: 2024-01-30T09:05:00Z
+
+# 出力例（実行中）
+Issue #42: running
+Session: pi-issue-42
+Timestamp: 2024-01-30T09:00:00Z
+```
+
+## クリーンアップ
+
+### ステータスファイルの削除
+
+```bash
+# 特定のIssueのステータスを削除
+remove_status 42
+
+# クリーンアップスクリプトから呼び出し
+# scripts/cleanup.sh
+cleanup_issue() {
+    local issue_number="$1"
     
-    // 現在の状態をバックアップ
-    const db = await this.store.load();
-    await Bun.write(
-      backupPath,
-      JSON.stringify(db, null, 2)
-    );
+    # worktreeを削除
+    local worktree
+    if worktree="$(find_worktree_by_issue "$issue_number")"; then
+        remove_worktree "$worktree" true
+    fi
     
-    this.logger.info(`Created backup: ${backupPath}`);
-    return backupPath;
-  }
-  
-  async restore(backupPath: string): Promise<void> {
-    // バックアップファイルを読み込み
-    const backup = await Bun.file(backupPath).json();
+    # ステータスファイルを削除
+    remove_status "$issue_number"
     
-    // 検証
-    this.store.validate(backup);
-    
-    // 現在の状態をバックアップ
-    await this.createBackup();
-    
-    // リストア
-    await Bun.write(
-      this.store.filePath,
-      JSON.stringify(backup, null, 2)
-    );
-    
-    // キャッシュをクリア
-    this.cache.clear();
-    
-    this.logger.info(`Restored from backup: ${backupPath}`);
-  }
-  
-  async cleanOldBackups(maxAge: number = 7 * 24 * 60 * 60 * 1000): Promise<void> {
-    const backupDir = this.config.backupDir;
-    const files = await Array.fromAsync(
-      new Bun.Glob('backup-*.json').scan(backupDir)
-    );
-    
-    const now = Date.now();
-    
-    for (const file of files) {
-      const stats = await Bun.file(path.join(backupDir, file)).stat();
-      const age = now - stats.mtime.getTime();
-      
-      if (age > maxAge) {
-        await Bun.spawn(['rm', path.join(backupDir, file)]);
-        this.logger.info(`Deleted old backup: ${file}`);
-      }
-    }
-  }
+    log_info "Cleaned up issue #$issue_number"
 }
 ```
 
-## 復旧処理
+### 孤立リソースのクリーンアップ
 
-### プロセスクラッシュ後の復旧
-
-```typescript
-class RecoveryManager {
-  async recover(): Promise<void> {
-    this.logger.info('Starting recovery process...');
-    
-    // タスクデータベースを読み込み
-    const db = await this.store.load();
-    
-    // 実行中だったタスクを検出
-    const runningTasks = db.tasks.filter(t => t.status === 'running');
-    
-    for (const task of runningTasks) {
-      await this.recoverTask(task);
-    }
-    
-    // 孤立したリソースをクリーンアップ
-    await this.cleanupOrphanedResources();
-    
-    this.logger.info('Recovery completed');
-  }
-  
-  private async recoverTask(task: Task): Promise<void> {
-    this.logger.info(`Recovering task: ${task.id}`);
-    
-    // Tmuxセッションが存在するか確認
-    const sessionActive = await this.tmuxManager.isSessionActive(task.tmuxSession);
-    
-    if (sessionActive) {
-      // セッションが存在する場合、監視を再開
-      this.logger.info(`Task ${task.id} is still running, resuming monitoring`);
-      await this.taskMonitor.startMonitoring(task.id);
-    } else {
-      // セッションが存在しない場合、失敗としてマーク
-      this.logger.warn(`Task ${task.id} session not found, marking as failed`);
-      await this.taskManager.updateTaskStatus(task.id, 'failed', {
-        error: 'Process crashed or session lost'
-      });
-      
-      // クリーンアップ
-      if (task.worktreePath) {
-        await this.worktreeManager.removeWorktree(task.worktreePath, true);
-      }
-    }
-  }
-  
-  private async cleanupOrphanedResources(): Promise<void> {
-    // 孤立したworktreeを検出
-    const orphanedWorktrees = await this.worktreeManager.findOrphanedWorktrees();
-    for (const worktree of orphanedWorktrees) {
-      this.logger.warn(`Cleaning up orphaned worktree: ${worktree}`);
-      await this.worktreeManager.removeWorktree(worktree, true);
-    }
-    
-    // 孤立したtmuxセッションを検出
-    const orphanedSessions = await this.tmuxManager.findOrphanedSessions();
-    for (const session of orphanedSessions) {
-      this.logger.warn(`Cleaning up orphaned session: ${session}`);
-      await this.tmuxManager.killSession(session);
-    }
-  }
-}
-```
-
-## データマイグレーション
-
-### バージョン間のマイグレーション
-
-```typescript
-interface Migration {
-  version: string;
-  migrate: (data: any) => Promise<any>;
-}
-
-class MigrationManager {
-  private migrations: Migration[] = [
-    {
-      version: '1.0.0',
-      migrate: async (data) => {
-        // 初期バージョン、そのまま返す
-        return data;
-      }
-    },
-    {
-      version: '1.1.0',
-      migrate: async (data) => {
-        // metadata フィールドを追加
-        for (const task of data.tasks) {
-          if (!task.metadata) {
-            task.metadata = {
-              retryCount: 0,
-              priority: 0,
-              labels: [],
-              assignee: null
-            };
-          }
-        }
-        return data;
-      }
-    }
-  ];
-  
-  async migrate(data: any, targetVersion: string): Promise<any> {
-    const currentVersion = data.version || '1.0.0';
-    
-    // 現在のバージョンからターゲットまでのマイグレーションを適用
-    let migratedData = data;
-    
-    for (const migration of this.migrations) {
-      if (this.compareVersions(migration.version, currentVersion) > 0 &&
-          this.compareVersions(migration.version, targetVersion) <= 0) {
-        this.logger.info(`Applying migration to ${migration.version}`);
-        migratedData = await migration.migrate(migratedData);
-        migratedData.version = migration.version;
-      }
-    }
-    
-    return migratedData;
-  }
-  
-  private compareVersions(v1: string, v2: string): number {
-    const parts1 = v1.split('.').map(Number);
-    const parts2 = v2.split('.').map(Number);
-    
-    for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-      const p1 = parts1[i] || 0;
-      const p2 = parts2[i] || 0;
-      
-      if (p1 !== p2) {
-        return p1 - p2;
-      }
-    }
-    
-    return 0;
-  }
-}
+```bash
+# 孤立したステータスファイルをクリーンアップ
+for issue in $(find_orphaned_statuses); do
+    log_info "Removing orphaned status: $issue"
+    remove_status "$issue"
+done
 ```
 
 ## ベストプラクティス
 
-1. **定期的な自動保存**: 状態の変更を定期的に永続化（5秒ごと推奨）
-2. **トランザクション管理**: 複数のリソース操作をアトミックに実行
-3. **バックアップ**: 定期的なバックアップと古いバックアップの削除
-4. **復旧処理**: 起動時に必ず復旧処理を実行
-5. **バージョン管理**: データフォーマットのバージョンを管理し、マイグレーションを提供
-6. **エラーハンドリング**: 状態の不整合を検出し、適切に対処
-7. **ログ記録**: 全ての状態変更をログに記録
-8. **キャッシュ管理**: 頻繁にアクセスするデータはキャッシュ、TTLを設定
+1. **状態の一貫性**
+   - 状態変更は必ず `save_status()` または `set_status()` を通じて行う
+   - 直接ファイルを編集しない
+
+2. **エラー情報の保存**
+   - エラー時は必ずメッセージを含める
+   - 後からデバッグできるよう詳細な情報を記録
+
+3. **定期的なクリーンアップ**
+   - 完了したタスクのステータスは定期的に削除
+   - `find_orphaned_statuses()` で孤立を検出
+
+4. **jqの活用**
+   - jqがインストールされている環境では自動的に使用
+   - より堅牢なJSON処理が可能
+
+5. **タイムスタンプの活用**
+   - UTCフォーマットで記録
+   - デバッグや監査に活用

--- a/docs/tmux-integration.md
+++ b/docs/tmux-integration.md
@@ -8,581 +8,425 @@ Tmuxセッションを使用して、各タスクを独立した仮想ターミ�
 
 Tmux (Terminal Multiplexer) は、1つのターミナルウィンドウで複数のセッションを管理できるツールです。セッションはバックグラウンドで実行され、必要に応じてアタッチ/デタッチできます。
 
-### 主要な概念
+### Pi Issue Runnerでの利用
 
-- **セッション**: 独立したターミナル環境
-- **ウィンドウ**: セッション内の複数のペイン
-- **ペイン**: ウィンドウ内の分割された領域
-
-Pi Issue Runnerでは、各タスクを1つのセッションとして管理します。
+- 各Issue = 1つのTmuxセッション
+- セッション内でpiプロセスを実行
+- バックグラウンドで複数タスクを並列実行可能
 
 ## セッション管理フロー
 
 ```
-1. タスクIDを受け取る（例: pi-issue-42）
+1. Issue番号を受け取る（例: 42）
    ↓
-2. Worktreeパスを取得
+2. セッション名を生成（pi-issue-42）
    ↓
-3. Tmuxセッションを作成
+3. Worktreeを作成
+   ↓
+4. Tmuxセッションを作成（デタッチ状態）
    tmux new-session -s {session} -d -c {worktree}
    ↓
-4. セッション内でpiコマンドを実行
-   tmux send-keys -t {session} "pi '{prompt}'" Enter
+5. セッション内でpiコマンドを実行
+   tmux send-keys -t {session} "pi '@.pi-prompt.md'" Enter
    ↓
-5. セッション状態を監視
-   tmux list-sessions | grep {session}
+6. watch-session.shで状態を監視
    ↓
-6. タスク完了後、セッションを終了
-   tmux kill-session -t {session}
+7. タスク完了後、クリーンアップ
 ```
 
-## コマンド詳細
+## lib/tmux.sh API
+
+### セッション名生成
+
+```bash
+# Issue番号からセッション名を生成
+session_name="$(generate_session_name 42)"
+# → "pi-issue-42"
+
+# セッション名からIssue番号を抽出
+issue_number="$(extract_issue_number "pi-issue-42")"
+# → "42"
+```
+
+**実装**:
+
+```bash
+generate_session_name() {
+    local issue_number="$1"
+    
+    load_config
+    local prefix
+    prefix="$(get_config tmux_session_prefix)"  # デフォルト: "pi"
+    
+    if [[ "$prefix" == *"-issue" ]]; then
+        echo "${prefix}-${issue_number}"
+    else
+        echo "${prefix}-issue-${issue_number}"
+    fi
+}
+```
 
 ### セッション作成
 
 ```bash
-# 基本的な作成（デタッチ状態）
-tmux new-session -s pi-issue-42 -d
-
-# 作業ディレクトリを指定
-tmux new-session -s pi-issue-42 -d -c /path/to/worktree
-
-# 作成後すぐにアタッチ
-tmux new-session -s pi-issue-42 -c /path/to/worktree
+# セッションを作成してコマンドを実行
+create_session "pi-issue-42" "/path/to/worktree" "pi '@.pi-prompt.md'"
 ```
 
 **実装**:
-```typescript
-async createSession(name: string, cwd: string): Promise<void> {
-  // セッションが既に存在するか確認
-  if (await this.isSessionActive(name)) {
-    throw new TmuxSessionExistsError(`Session already exists: ${name}`);
-  }
-
-  // セッションを作成
-  await this.exec([
-    'tmux',
-    'new-session',
-    '-s', name,
-    '-d',              // デタッチ状態で作成
-    '-c', cwd          // 作業ディレクトリ
-  ]);
-
-  this.logger.info(`Created tmux session: ${name}`);
-}
-```
-
-### コマンド実行
-
-セッション内でコマンドを実行する：
 
 ```bash
-# コマンドを送信
-tmux send-keys -t pi-issue-42 "echo hello" Enter
-
-# 複数行のコマンド
-tmux send-keys -t pi-issue-42 "pi 'Issue #42: Add feature'" Enter
-```
-
-**実装**:
-```typescript
-async executeInSession(
-  sessionName: string,
-  command: string
-): Promise<void> {
-  // セッションが存在するか確認
-  if (!await this.isSessionActive(sessionName)) {
-    throw new TmuxSessionNotFoundError(`Session not found: ${sessionName}`);
-  }
-
-  // コマンドを送信
-  await this.exec([
-    'tmux',
-    'send-keys',
-    '-t', sessionName,
-    command,
-    'Enter'
-  ]);
-
-  this.logger.info(`Executed command in session ${sessionName}`);
-}
-```
-
-### セッション状態確認
-
-```bash
-# セッション一覧
-tmux list-sessions
-
-# 特定セッションの存在確認
-tmux has-session -t pi-issue-42
-```
-
-**実装**:
-```typescript
-async isSessionActive(sessionName: string): Promise<boolean> {
-  try {
-    await this.exec(['tmux', 'has-session', '-t', sessionName]);
-    return true;
-  } catch (error) {
-    return false;
-  }
-}
-```
-
-### セッション一覧取得
-
-```bash
-# セッション一覧（詳細）
-tmux list-sessions -F "#{session_name}:#{session_created}:#{session_attached}"
-```
-
-**出力例**:
-```
-pi-issue-42:1706592000:0
-pi-issue-43:1706592100:1
-```
-
-**実装**:
-```typescript
-interface TmuxSession {
-  name: string;
-  created: Date;
-  attached: boolean;
-  windows: number;
-}
-
-async listSessions(): Promise<TmuxSession[]> {
-  const format = [
-    '#{session_name}',
-    '#{session_created}',
-    '#{session_attached}',
-    '#{session_windows}'
-  ].join(':');
-
-  const output = await this.exec([
-    'tmux',
-    'list-sessions',
-    '-F', format
-  ]);
-
-  const sessions: TmuxSession[] = [];
-  
-  for (const line of output.split('\n')) {
-    if (!line.trim()) continue;
+create_session() {
+    local session_name="$1"
+    local working_dir="$2"
+    local command="$3"
     
-    const [name, created, attached, windows] = line.split(':');
+    # Tmuxが利用可能か確認
+    check_tmux || return 1
     
-    sessions.push({
-      name,
-      created: new Date(parseInt(created) * 1000),
-      attached: attached === '1',
-      windows: parseInt(windows)
-    });
-  }
-
-  return sessions;
+    # 既存セッションチェック
+    if session_exists "$session_name"; then
+        log_error "Session already exists: $session_name"
+        return 1
+    fi
+    
+    log_info "Creating tmux session: $session_name"
+    
+    # デタッチ状態でセッション作成
+    tmux new-session -d -s "$session_name" -c "$working_dir"
+    
+    # コマンドを実行
+    tmux send-keys -t "$session_name" "$command" Enter
+    
+    log_info "Session created: $session_name"
 }
 ```
 
-### 出力キャプチャ
-
-セッションの現在の出力を取得：
+### セッション存在確認
 
 ```bash
-# 最後の100行をキャプチャ
-tmux capture-pane -t pi-issue-42 -p -S -100
+if session_exists "pi-issue-42"; then
+    echo "セッションは実行中です"
+fi
 ```
 
 **実装**:
-```typescript
-async capturePane(
-  sessionName: string,
-  lines: number = 100
-): Promise<string> {
-  const output = await this.exec([
-    'tmux',
-    'capture-pane',
-    '-t', sessionName,
-    '-p',              // 標準出力に出力
-    '-S', `-${lines}`  // 開始行（負の値で末尾からの相対位置）
-  ]);
-
-  return output;
-}
-```
-
-### セッション終了
 
 ```bash
-# セッションを終了
-tmux kill-session -t pi-issue-42
-```
-
-**実装**:
-```typescript
-async killSession(sessionName: string): Promise<void> {
-  if (!await this.isSessionActive(sessionName)) {
-    this.logger.warn(`Session not found: ${sessionName}`);
-    return;
-  }
-
-  await this.exec(['tmux', 'kill-session', '-t', sessionName]);
-
-  this.logger.info(`Killed session: ${sessionName}`);
+session_exists() {
+    local session_name="$1"
+    tmux has-session -t "$session_name" 2>/dev/null
 }
 ```
 
 ### セッションにアタッチ
 
 ```bash
-# セッションにアタッチ（対話モード）
-tmux attach -t pi-issue-42
+attach_session "pi-issue-42"
 ```
 
 **実装**:
-```typescript
-async attachToSession(sessionName: string): Promise<void> {
-  if (!await this.isSessionActive(sessionName)) {
-    throw new TmuxSessionNotFoundError(`Session not found: ${sessionName}`);
-  }
-
-  // 対話的にアタッチ（現在のプロセスを置き換え）
-  await Bun.spawn(['tmux', 'attach', '-t', sessionName], {
-    stdin: 'inherit',
-    stdout: 'inherit',
-    stderr: 'inherit'
-  });
-}
-```
-
-## 高度な機能
-
-### ログファイルへの出力保存
-
-セッションの出力をリアルタイムでファイルに保存：
 
 ```bash
-# ログパイプを有効化
-tmux pipe-pane -t pi-issue-42 -o "cat >> /path/to/log.txt"
+attach_session() {
+    local session_name="$1"
+    
+    check_tmux || return 1
+    
+    if ! session_exists "$session_name"; then
+        log_error "Session not found: $session_name"
+        return 1
+    fi
+    
+    tmux attach-session -t "$session_name"
+}
+```
+
+### セッション終了
+
+```bash
+kill_session "pi-issue-42"
 ```
 
 **実装**:
-```typescript
-async enableLogging(
-  sessionName: string,
-  logPath: string
-): Promise<void> {
-  // ログディレクトリを作成
-  await Bun.write(logPath, ''); // ファイルを作成
 
-  // パイプパインを有効化
-  await this.exec([
-    'tmux',
-    'pipe-pane',
-    '-t', sessionName,
-    '-o',
-    `cat >> ${logPath}`
-  ]);
-
-  this.logger.info(`Enabled logging for session ${sessionName} to ${logPath}`);
+```bash
+kill_session() {
+    local session_name="$1"
+    
+    check_tmux || return 1
+    
+    if ! session_exists "$session_name"; then
+        log_warn "Session not found: $session_name"
+        return 0
+    fi
+    
+    log_info "Killing session: $session_name"
+    tmux kill-session -t "$session_name"
 }
 ```
 
-### セッションの状態監視
+### セッション一覧
 
-定期的にセッションの状態をポーリング：
+```bash
+# プレフィックスに一致するセッション一覧
+list_sessions
+# 出力:
+# pi-issue-42
+# pi-issue-43
+```
 
-```typescript
-class TmuxSessionMonitor {
-  private intervals = new Map<string, Timer>();
+**実装**:
 
-  startMonitoring(
-    sessionName: string,
-    callback: (status: SessionStatus) => void,
-    interval: number = 1000
-  ): void {
-    const timer = setInterval(async () => {
-      const isActive = await this.tmuxManager.isSessionActive(sessionName);
-      
-      if (!isActive) {
-        // セッションが終了した
-        this.stopMonitoring(sessionName);
-        callback({ active: false, exitCode: await this.getExitCode(sessionName) });
-        return;
-      }
-
-      // 出力をキャプチャして状態を確認
-      const output = await this.tmuxManager.capturePane(sessionName, 10);
-      
-      callback({ active: true, lastOutput: output });
-    }, interval);
-
-    this.intervals.set(sessionName, timer);
-  }
-
-  stopMonitoring(sessionName: string): void {
-    const timer = this.intervals.get(sessionName);
-    if (timer) {
-      clearInterval(timer);
-      this.intervals.delete(sessionName);
-    }
-  }
+```bash
+list_sessions() {
+    check_tmux || return 1
+    
+    load_config
+    local prefix
+    prefix="$(get_config tmux_session_prefix)"
+    
+    tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^${prefix}" || true
 }
 ```
 
-### 終了コードの取得
+### セッション出力キャプチャ
 
-piプロセスの終了コードを取得：
+```bash
+# 最新50行を取得
+output="$(get_session_output "pi-issue-42" 50)"
+```
 
-```typescript
-async getExitCode(sessionName: string): Promise<number | null> {
-  try {
-    // セッション内で最後に実行されたコマンドの終了コードを取得
-    const output = await this.exec([
-      'tmux',
-      'display-message',
-      '-t', sessionName,
-      '-p',
-      '#{pane_dead_status}'
-    ]);
+**実装**:
 
-    return parseInt(output.trim()) || 0;
-  } catch (error) {
-    return null;
-  }
+```bash
+get_session_output() {
+    local session_name="$1"
+    local lines="${2:-50}"
+    
+    check_tmux || return 1
+    
+    if ! session_exists "$session_name"; then
+        log_error "Session not found: $session_name"
+        return 1
+    fi
+    
+    tmux capture-pane -t "$session_name" -p -S "-$lines"
 }
 ```
 
-## ウィンドウとペインの活用
+### アクティブセッション数
 
-複雑なタスクでは、1つのセッション内に複数のウィンドウを作成：
+```bash
+count="$(count_active_sessions)"
+echo "現在 $count セッションが実行中"
+```
 
-```typescript
-async createWindowForTask(
-  sessionName: string,
-  windowName: string,
-  command: string
-): Promise<void> {
-  // 新しいウィンドウを作成
-  await this.exec([
-    'tmux',
-    'new-window',
-    '-t', sessionName,
-    '-n', windowName
-  ]);
+### 並列実行制限チェック
 
-  // コマンドを実行
-  await this.executeInWindow(
-    sessionName,
-    windowName,
-    command
-  );
-}
+```bash
+if ! check_concurrent_limit; then
+    echo "最大同時実行数に達しています"
+    exit 1
+fi
+```
 
-async executeInWindow(
-  sessionName: string,
-  windowName: string,
-  command: string
-): Promise<void> {
-  await this.exec([
-    'tmux',
-    'send-keys',
-    '-t', `${sessionName}:${windowName}`,
-    command,
-    'Enter'
-  ]);
+## scripts/attach.sh
+
+ユーザー向けのセッションアタッチスクリプト:
+
+```bash
+# Issue番号でアタッチ
+./scripts/attach.sh 42
+
+# セッション名でアタッチ
+./scripts/attach.sh pi-issue-42
+```
+
+## scripts/watch-session.sh
+
+### 概要
+
+セッションの完了を監視するバックグラウンドプロセス。`run.sh` から自動的に起動されます。
+
+### 監視内容
+
+1. **セッション存在確認**: セッションが終了していないか
+2. **完了マーカー検出**: `###TASK_COMPLETE_xxx###` パターン
+3. **エラーマーカー検出**: `###TASK_ERROR_xxx###` パターン
+
+### 処理フロー
+
+```bash
+# 主要ロジック（簡略化）
+monitor_loop() {
+    local session_name="$1"
+    local issue_number
+    issue_number="$(extract_issue_number "$session_name")"
+    
+    while true; do
+        # セッション存在確認
+        if ! session_exists "$session_name"; then
+            handle_session_ended
+            break
+        fi
+        
+        # 出力をキャプチャ
+        local output
+        output="$(get_session_output "$session_name" 100)"
+        
+        # 完了マーカーをチェック
+        if echo "$output" | grep -q "###TASK_COMPLETE_${issue_number}###"; then
+            set_status "$issue_number" "complete"
+            cleanup_session "$session_name"
+            break
+        fi
+        
+        # エラーマーカーをチェック
+        if echo "$output" | grep -qE "###TASK_ERROR_${issue_number}###"; then
+            local error_msg
+            error_msg="$(extract_error_message "$output")"
+            set_status "$issue_number" "error" "$error_msg"
+            cleanup_session "$session_name"
+            break
+        fi
+        
+        sleep 5  # 5秒間隔
+    done
 }
 ```
 
-**使用例**:
-```typescript
-// メインウィンドウでpiを実行
-await tmux.executeInSession('pi-issue-42', 'pi "Implement feature"');
+### クリーンアップ処理
 
-// 別ウィンドウでログを監視
-await tmux.createWindowForTask(
-  'pi-issue-42',
-  'logs',
-  'tail -f .pi-runner/logs/issue-42.log'
-);
+完了またはエラー検出時:
 
-// 別ウィンドウでテストを実行
-await tmux.createWindowForTask(
-  'pi-issue-42',
-  'tests',
-  'bun test --watch'
-);
+```bash
+cleanup_session() {
+    local session_name="$1"
+    local issue_number
+    issue_number="$(extract_issue_number "$session_name")"
+    
+    # Tmuxセッションを終了
+    kill_session "$session_name"
+    
+    # Worktreeを削除
+    local worktree
+    if worktree="$(find_worktree_by_issue "$issue_number")"; then
+        remove_worktree "$worktree" true
+    fi
+    
+    log_info "Cleanup completed for session: $session_name"
+}
+```
+
+## Tmuxコマンドリファレンス
+
+### よく使うコマンド
+
+```bash
+# セッション一覧
+tmux list-sessions
+
+# セッションにアタッチ
+tmux attach -t pi-issue-42
+
+# セッションからデタッチ
+# Ctrl+b d
+
+# セッション終了
+tmux kill-session -t pi-issue-42
+
+# ペイン出力をキャプチャ
+tmux capture-pane -t pi-issue-42 -p -S -100
+```
+
+### セッション作成オプション
+
+```bash
+# 基本的な作成（デタッチ状態）
+tmux new-session -s session-name -d
+
+# 作業ディレクトリを指定
+tmux new-session -s session-name -d -c /path/to/dir
+
+# 作成後すぐにアタッチ
+tmux new-session -s session-name -c /path/to/dir
+```
+
+### コマンド送信
+
+```bash
+# コマンドを送信
+tmux send-keys -t session-name "command" Enter
+
+# Ctrl+Cを送信（中断）
+tmux send-keys -t session-name C-c
 ```
 
 ## エラーハンドリング
 
-### セッションが既に存在する場合
+### Tmuxが利用できない場合
 
-```typescript
-async createSession(name: string, cwd: string): Promise<void> {
-  if (await this.isSessionActive(name)) {
-    // オプション1: エラーを投げる
-    throw new TmuxSessionExistsError(`Session already exists: ${name}`);
-    
-    // オプション2: 既存セッションを終了して再作成（--force フラグ時）
-    if (options.force) {
-      await this.killSession(name);
-      // 作成処理を続行
-    }
-  }
-  
-  // セッション作成
+```bash
+check_tmux() {
+    if ! command -v tmux &> /dev/null; then
+        log_error "tmux is not installed"
+        return 1
+    fi
 }
 ```
 
-### Tmuxが利用できない場合
+### セッションが既に存在する場合
 
-```typescript
-async checkTmuxAvailable(): Promise<boolean> {
-  try {
-    await this.exec(['which', 'tmux']);
-    return true;
-  } catch (error) {
-    return false;
-  }
-}
+`run.sh` での処理:
 
-// 初期化時にチェック
-async initialize(): Promise<void> {
-  if (!await this.checkTmuxAvailable()) {
-    throw new TmuxNotInstalledError('tmux is not installed or not in PATH');
-  }
-}
+```bash
+if session_exists "$session_name"; then
+    if [[ "$reattach" == "true" ]]; then
+        # 既存セッションにアタッチ
+        attach_session "$session_name"
+        exit 0
+    elif [[ "$force" == "true" ]]; then
+        # 既存セッションを削除して再作成
+        kill_session "$session_name"
+    else
+        log_error "Session already exists: $session_name"
+        log_info "Options:"
+        log_info "  --reattach  Attach to existing session"
+        log_info "  --force     Remove and recreate session"
+        exit 1
+    fi
+fi
 ```
 
 ### セッション終了の検出
 
-```typescript
-async waitForSessionExit(
-  sessionName: string,
-  timeout: number = 0
-): Promise<SessionExitInfo> {
-  const startTime = Date.now();
-  
-  while (await this.isSessionActive(sessionName)) {
-    // タイムアウトチェック
-    if (timeout > 0 && Date.now() - startTime > timeout) {
-      throw new TimeoutError(`Session ${sessionName} did not exit within ${timeout}ms`);
-    }
-    
-    // 短い間隔でポーリング
-    await Bun.sleep(500);
-  }
-  
-  return {
-    exitCode: await this.getExitCode(sessionName),
-    duration: Date.now() - startTime
-  };
-}
+`watch-session.sh` でのセッション消失検出:
+
+```bash
+if ! session_exists "$session_name"; then
+    # セッションが予期せず終了
+    log_warn "Session $session_name has ended unexpectedly"
+    set_status "$issue_number" "error" "Session unexpectedly terminated"
+    break
+fi
 ```
 
-## パフォーマンス最適化
+## 設定
 
-### セッション一覧のキャッシュ
+### .pi-runner.yaml
 
-頻繁にセッション一覧を取得する場合、キャッシュを使用：
-
-```typescript
-class TmuxManager {
-  private sessionCache: Map<string, boolean> = new Map();
-  private cacheExpiry = 1000; // 1秒
-  private lastCacheUpdate = 0;
-
-  async isSessionActive(sessionName: string): Promise<boolean> {
-    // キャッシュをチェック
-    if (Date.now() - this.lastCacheUpdate < this.cacheExpiry) {
-      return this.sessionCache.get(sessionName) ?? false;
-    }
-
-    // キャッシュを更新
-    await this.updateSessionCache();
-
-    return this.sessionCache.get(sessionName) ?? false;
-  }
-
-  private async updateSessionCache(): Promise<void> {
-    const sessions = await this.listSessions();
-    
-    this.sessionCache.clear();
-    for (const session of sessions) {
-      this.sessionCache.set(session.name, true);
-    }
-    
-    this.lastCacheUpdate = Date.now();
-  }
-}
+```yaml
+tmux:
+  session_prefix: "pi"           # セッション名プレフィックス
+  start_in_session: true         # セッション作成後に自動アタッチ
 ```
 
-### バッチコマンド実行
+### 環境変数
 
-複数のコマンドを一度に実行：
-
-```typescript
-async executeBatch(
-  sessionName: string,
-  commands: string[]
-): Promise<void> {
-  const script = commands.join(' && ');
-  await this.executeInSession(sessionName, script);
-}
-
-// 使用例
-await tmux.executeBatch('pi-issue-42', [
-  'cd /path/to/worktree',
-  'source .env',
-  'pi "Implement feature"'
-]);
-```
-
-## セキュリティ考慮事項
-
-### コマンドインジェクション対策
-
-```typescript
-async executeInSession(
-  sessionName: string,
-  command: string
-): Promise<void> {
-  // セッション名のバリデーション
-  if (!/^[a-zA-Z0-9_-]+$/.test(sessionName)) {
-    throw new InvalidSessionNameError('Invalid session name');
-  }
-
-  // コマンドのエスケープ
-  const escapedCommand = this.escapeCommand(command);
-
-  await this.exec([
-    'tmux',
-    'send-keys',
-    '-t', sessionName,
-    escapedCommand,
-    'Enter'
-  ]);
-}
-
-private escapeCommand(command: string): string {
-  // シングルクォートで囲み、内部のシングルクォートをエスケープ
-  return `'${command.replace(/'/g, "'\\''")}'`;
-}
-```
-
-### セッション名の検証
-
-```typescript
-validateSessionName(name: string): boolean {
-  // セッション名のルール:
-  // - 英数字、ハイフン、アンダースコアのみ
-  // - 先頭は英字
-  // - 1-64文字
-  const pattern = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/;
-  return pattern.test(name);
-}
+```bash
+PI_RUNNER_TMUX_SESSION_PREFIX="my-prefix"
+PI_RUNNER_TMUX_START_IN_SESSION="false"
 ```
 
 ## トラブルシューティング
@@ -596,14 +440,11 @@ brew install tmux
 
 # Ubuntu/Debian
 sudo apt-get install tmux
-
-# Arch Linux
-sudo pacman -S tmux
 ```
 
-### 問題: セッションがアタッチできない
+### 問題: セッションにアタッチできない
 
-**原因**: セッションが別のクライアントにアタッチされている
+**原因**: セッションが別のクライアントにアタッチ済み
 
 **解決**:
 ```bash
@@ -611,26 +452,15 @@ sudo pacman -S tmux
 tmux attach -t pi-issue-42 -d
 ```
 
-### 問題: セッションが終了しない
-
-**原因**: プロセスがバックグラウンドで実行中
+### 問題: セッションが残っている
 
 **解決**:
-```typescript
-async forceKillSession(sessionName: string): Promise<void> {
-  // セッション内の全プロセスを終了
-  await this.exec([
-    'tmux',
-    'send-keys',
-    '-t', sessionName,
-    'C-c'  // Ctrl+C
-  ]);
-  
-  await Bun.sleep(1000);
-  
-  // セッションを強制終了
-  await this.exec(['tmux', 'kill-session', '-t', sessionName]);
-}
+```bash
+# 手動で終了
+tmux kill-session -t pi-issue-42
+
+# またはスクリプトで
+./scripts/stop.sh 42
 ```
 
 ### 問題: 出力が文字化けする
@@ -638,25 +468,29 @@ async forceKillSession(sessionName: string): Promise<void> {
 **原因**: ロケール設定の問題
 
 **解決**:
-```typescript
-async createSession(name: string, cwd: string): Promise<void> {
-  // UTF-8ロケールを設定
-  await this.exec([
-    'tmux',
-    'new-session',
-    '-s', name,
-    '-d',
-    '-c', cwd,
-    'env', 'LANG=en_US.UTF-8'
-  ]);
-}
+```bash
+# 環境変数を設定
+export LANG=en_US.UTF-8
 ```
 
 ## ベストプラクティス
 
-1. **セッション名の命名規則**: 一貫した命名規則を使用（例: `{prefix}-issue-{番号}`）
-2. **定期的なクリーンアップ**: 孤立したセッションを定期的に削除
-3. **ログの保存**: 重要な出力はファイルに保存
-4. **タイムアウトの設定**: 長時間実行されるタスクにタイムアウトを設定
-5. **エラーハンドリング**: セッション操作の失敗を適切に処理
-6. **リソースリーク防止**: セッションの作成と削除を確実にペアで実行
+1. **セッション命名**
+   - プレフィックスを統一（デフォルト: `pi`）
+   - Issue番号を含める
+
+2. **バックグラウンド実行**
+   - `--no-attach` オプションで非対話的に起動
+   - `watch-session.sh` で監視
+
+3. **リソース管理**
+   - `parallel_max_concurrent` で同時実行数を制限
+   - 定期的に `list.sh` でセッションを確認
+
+4. **クリーンアップ**
+   - 完了マーカーで自動クリーンアップ
+   - 手動終了は `stop.sh` または `cleanup.sh` を使用
+
+5. **デバッグ**
+   - `attach.sh` でセッションにアタッチして状況確認
+   - `capture-pane` で出力を取得


### PR DESCRIPTION
## Summary
Closes #236

## Changes

### 更新したドキュメント
- `docs/architecture.md` - システムアーキテクチャをBash実装に更新
- `docs/parallel-execution.md` - 並列実行をBash実装に更新
- `docs/state-management.md` - 状態管理をBash実装に更新
- `docs/tmux-integration.md` - Tmux統合をBash実装に更新
- `docs/worktree-management.md` - Worktree管理をBash実装に更新

### 主な変更内容
- TypeScript/Bunへの参照を全て削除
- Bashシェルスクリプトのコード例に置き換え
- 実際のファイルパス（`scripts/*.sh`, `lib/*.sh`）を参照
- `lib/config.sh`, `lib/status.sh`, `lib/tmux.sh`, `lib/worktree.sh` のAPI説明を追加

## Testing
- ドキュメントの更新のみのため、単体テストは不要
- TypeScript参照が残っていないことを確認済み
- Bash code blockが適切に使用されていることを確認済み