### PR TITLE
docs: README.mdとAGENTS.mdのテスト構造記載を実際の構造に修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,29 @@ pi-issue-runner/
 ├── docs/              # ドキュメント
 ├── test/              # Batsテスト（*.bats形式）
 │   ├── lib/           # ライブラリのユニットテスト
+│   │   ├── config.bats
+│   │   ├── github.bats
+│   │   ├── log.bats
+│   │   ├── notify.bats
+│   │   ├── status.bats
+│   │   ├── tmux.bats
+│   │   ├── workflow.bats
+│   │   └── worktree.bats
 │   ├── scripts/       # スクリプトの統合テスト
+│   │   ├── attach.bats
+│   │   ├── cleanup.bats
+│   │   ├── improve.bats
+│   │   ├── init.bats
+│   │   ├── list.bats
+│   │   ├── run.bats
+│   │   ├── status.bats
+│   │   ├── stop.bats
+│   │   ├── wait-for-sessions.bats
+│   │   └── watch-session.bats
 │   ├── regression/    # 回帰テスト
+│   │   └── critical-fixes.bats
 │   ├── fixtures/      # テスト用フィクスチャ
+│   │   └── sample-config.yaml
 │   └── test_helper.bash  # Bats共通ヘルパー
 └── .worktrees/        # 実行時に作成されるworktreeディレクトリ
 ```

--- a/README.md
+++ b/README.md
@@ -351,19 +351,31 @@ bats --tap test/lib/*.bats
 
 ```
 test/
-├── lib/                    # ライブラリのユニットテスト
-│   ├── config.bats         # config.sh のテスト
-│   ├── github.bats         # github.sh のテスト
-│   └── log.bats            # log.sh のテスト
-├── scripts/                # スクリプトの統合テスト
-│   ├── run.bats            # run.sh のテスト
-│   ├── list.bats           # list.sh のテスト
-│   └── cleanup.bats        # cleanup.sh のテスト
-├── regression/             # 回帰テスト
+├── lib/                         # ライブラリのユニットテスト
+│   ├── config.bats              # config.sh のテスト
+│   ├── github.bats              # github.sh のテスト
+│   ├── log.bats                 # log.sh のテスト
+│   ├── notify.bats              # notify.sh のテスト
+│   ├── status.bats              # status.sh のテスト
+│   ├── tmux.bats                # tmux.sh のテスト
+│   ├── workflow.bats            # workflow.sh のテスト
+│   └── worktree.bats            # worktree.sh のテスト
+├── scripts/                     # スクリプトの統合テスト
+│   ├── attach.bats              # attach.sh のテスト
+│   ├── cleanup.bats             # cleanup.sh のテスト
+│   ├── improve.bats             # improve.sh のテスト
+│   ├── init.bats                # init.sh のテスト
+│   ├── list.bats                # list.sh のテスト
+│   ├── run.bats                 # run.sh のテスト
+│   ├── status.bats              # status.sh のテスト
+│   ├── stop.bats                # stop.sh のテスト
+│   ├── wait-for-sessions.bats   # wait-for-sessions.sh のテスト
+│   └── watch-session.bats       # watch-session.sh のテスト
+├── regression/                  # 回帰テスト
 │   └── critical-fixes.bats
-├── fixtures/               # テスト用フィクスチャ
+├── fixtures/                    # テスト用フィクスチャ
 │   └── sample-config.yaml
-└── test_helper.bash        # Bats共通ヘルパー（モック関数含む）
+└── test_helper.bash             # Bats共通ヘルパー（モック関数含む）
 ```
 
 ## トラブルシューティング

--- a/docs/plans/issue-246-plan.md
+++ b/docs/plans/issue-246-plan.md
@@ -1,0 +1,63 @@
+# Implementation Plan for Issue #246
+
+## 概要
+
+README.mdとAGENTS.mdのテスト構造記載を実際のディレクトリ構造に合わせて更新する。
+
+## 現状分析
+
+### 実際のテスト構造
+
+```
+test/
+├── lib/                         # ライブラリのユニットテスト（8ファイル）
+│   ├── config.bats
+│   ├── github.bats
+│   ├── log.bats
+│   ├── notify.bats
+│   ├── status.bats
+│   ├── tmux.bats
+│   ├── workflow.bats
+│   └── worktree.bats
+├── scripts/                     # スクリプトの統合テスト（10ファイル）
+│   ├── attach.bats
+│   ├── cleanup.bats
+│   ├── improve.bats
+│   ├── init.bats
+│   ├── list.bats
+│   ├── run.bats
+│   ├── status.bats
+│   ├── stop.bats
+│   ├── wait-for-sessions.bats
+│   └── watch-session.bats
+├── regression/                  # 回帰テスト
+│   └── critical-fixes.bats
+├── fixtures/                    # テスト用フィクスチャ
+│   └── sample-config.yaml
+└── test_helper.bash             # Bats共通ヘルパー（モック関数含む）
+```
+
+### 現在の問題点
+
+1. **README.md**: test/lib/ と test/scripts/ のファイル一覧が不完全（3ファイルのみ記載）
+2. **AGENTS.md**: 個別のテストファイルが列挙されていない
+
+## 影響範囲
+
+- README.md (テスト構造セクション: 約20行)
+- AGENTS.md (ディレクトリ構造セクション: 約5行)
+
+## 実装ステップ
+
+1. README.md のテスト構造セクション（lines 352-373）を全てのテストファイルを含むように更新
+2. AGENTS.md のディレクトリ構造は既に regression/ を含んでいるため、詳細情報の追加のみ
+
+## テスト方針
+
+- ドキュメントのみの変更のため、静的検証のみ
+- 実際のディレクトリ構造と照合
+
+## リスクと対策
+
+- 低リスク: ドキュメント変更のみ
+- 検証: find コマンドで実際の構造と一致を確認


### PR DESCRIPTION
## Summary
Closes #246

## Changes
- Updated README.md test structure section to list all 19 test files
- Updated AGENTS.md directory structure to include detailed test file listings
- Added implementation plan document

### Files Changed
- `README.md`: Expanded test structure section from 6 example files to complete 19 files
- `AGENTS.md`: Added individual test file listings under lib/, scripts/, regression/, and fixtures/
- `docs/plans/issue-246-plan.md`: New implementation plan document

## Testing
- All 368 Bats tests pass
- Verified test file count matches documentation:
  - test/lib/: 8 files
  - test/scripts/: 10 files  
  - test/regression/: 1 file
  - Total: 19 test files