### PR TITLE
fix: clean up worktrees when improve.sh is interrupted

### DIFF
--- a/docs/plans/issue-247-plan.md
+++ b/docs/plans/issue-247-plan.md
@@ -1,0 +1,86 @@
+# 実装計画: Issue #247
+
+## fix: improve.sh中断時にworktreeがクリーンアップされない
+
+### 概要
+
+improve.shが中断された場合（Ctrl+C、エラー等）、実行中のセッションのworktreeがクリーンアップされずに残る問題を修正する。
+
+### 原因分析
+
+1. **クリーンアップのタイミング**: watch-session.shが完了マーカーを検出した時のみcleanup.shを実行
+2. **中断時の挙動**: improve.shが中断されると、wait-for-sessions.shも終了し、watch-session.shの監視が中断される
+3. **結果**: 完了マーカーが検出されないため、worktreeとセッションが残る
+
+### 影響範囲
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `scripts/improve.sh` | EXITトラップを追加してクリーンアップ処理を実装 |
+| `scripts/wait-for-sessions.sh` | 完了時にcleanup.shを呼び出す |
+| `test/scripts/improve.bats` | 新規：improve.shのテスト |
+| `test/scripts/wait-for-sessions.bats` | 既存テストの更新 |
+
+### 実装ステップ
+
+#### 1. improve.shにトラップを追加
+
+```bash
+# 実行中のセッションを追跡
+declare -a ACTIVE_SESSIONS=()
+
+cleanup_on_exit() {
+    log_warn "Cleaning up on exit..."
+    for issue in "${ACTIVE_SESSIONS[@]}"; do
+        "$SCRIPT_DIR/cleanup.sh" "pi-issue-$issue" --force 2>/dev/null || true
+    done
+}
+
+trap cleanup_on_exit EXIT INT TERM
+```
+
+- run.shでセッション開始後、Issue番号をACTIVE_SESSIONSに追加
+- wait-for-sessions.sh完了後、ACTIVE_SESSIONSをクリア
+
+#### 2. wait-for-sessions.shにクリーンアップオプションを追加
+
+```bash
+# --cleanup オプション追加
+# 完了検出時にcleanup.shを実行
+complete)
+    completed_list="$completed_list $issue"
+    if [[ "$cleanup" == "true" ]]; then
+        "$SCRIPT_DIR/cleanup.sh" "pi-issue-$issue" --force 2>/dev/null || true
+    fi
+    ;;
+```
+
+#### 3. improve.shからwait-for-sessions.shを--cleanupオプション付きで呼び出し
+
+### テスト方針
+
+1. **ユニットテスト**
+   - improve.shのトラップ関数のテスト
+   - wait-for-sessions.shの--cleanupオプションのテスト
+
+2. **統合テスト**
+   - 正常完了時のクリーンアップ確認
+   - タイムアウト時のクリーンアップ確認
+
+3. **手動テスト**
+   - Ctrl+Cでの中断時にworktreeが削除されることを確認
+
+### リスクと対策
+
+| リスク | 対策 |
+|-------|------|
+| クリーンアップ中にエラーが発生 | `|| true`で握り潰し、ログ出力で追跡可能に |
+| 未コミットの変更がある場合 | `--force`オプションを使用 |
+| セッションが既に削除されている | cleanup.shはエラーを無視する設計 |
+
+### 完了条件
+
+- [x] Issueの要件を完全に理解した
+- [x] 関連するコードを調査した
+- [x] 実装計画書を作成した
+- [x] 計画書をファイルに保存した

--- a/test/scripts/improve.bats
+++ b/test/scripts/improve.bats
@@ -298,3 +298,37 @@ teardown() {
     source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
     [[ "$source_content" == *'Failed to start session'* ]]
 }
+
+# ====================
+# クリーンアップ機能テスト (Issue #247)
+# ====================
+
+@test "improve.sh has cleanup_on_exit function" {
+    grep -q 'cleanup_on_exit()' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh has ACTIVE_ISSUE_NUMBERS array" {
+    grep -q 'ACTIVE_ISSUE_NUMBERS' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh sets trap for EXIT INT TERM" {
+    grep -q 'trap cleanup_on_exit EXIT INT TERM' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh calls wait-for-sessions.sh with --cleanup option" {
+    grep -q 'wait-for-sessions.sh.*--cleanup' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh tracks active sessions in array" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'ACTIVE_ISSUE_NUMBERS+=("$issue")'* ]]
+}
+
+@test "improve.sh clears active sessions after completion" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'ACTIVE_ISSUE_NUMBERS=()'* ]]
+}
+
+@test "improve.sh cleanup uses --force flag" {
+    grep -q 'cleanup.sh.*--force' "$PROJECT_ROOT/scripts/improve.sh"
+}


### PR DESCRIPTION
## Summary
Closes #247

## Changes
- Add EXIT trap to improve.sh for cleanup on interruption (Ctrl+C, error)
- Add `--cleanup` option to wait-for-sessions.sh for auto-cleanup on completion
- Track active sessions in ACTIVE_ISSUE_NUMBERS array
- Clean up worktrees for completed, errored, and unknown (session ended) states

## Testing
- Added 8 new tests for cleanup functionality
- All 379 tests pass
- ShellCheck passes

## Behavior
1. **Normal completion**: wait-for-sessions.sh with `--cleanup` option cleans up each session's worktree when it completes
2. **Interruption (Ctrl+C)**: EXIT trap in improve.sh cleans up all active sessions
3. **Error**: Both normal cleanup and trap cleanup handle errors gracefully with `--force` flag