### PR TITLE
docs: add error marker documentation to generate_workflow_prompt

### DIFF
--- a/docs/plans/issue-250-plan.md
+++ b/docs/plans/issue-250-plan.md
@@ -1,0 +1,57 @@
+# Implementation Plan: Issue #250
+
+## 概要
+
+`lib/workflow.sh` の `generate_workflow_prompt` 関数のフッター部分に、エラーマーカー（`###TASK_ERROR_<issue>###`）の説明を追加する。
+
+## 影響範囲
+
+- **変更ファイル**:
+  - `lib/workflow.sh` - `generate_workflow_prompt` 関数のフッター部分
+  
+- **テスト追加**:
+  - `test/lib/workflow.bats` - エラーマーカー説明がプロンプトに含まれることを確認
+
+## 現状分析
+
+### 問題点
+1. `generate_workflow_prompt` 関数のフッター（L455-471）で完了マーカーは詳しく説明されているが、エラーマーカーの説明がない
+2. `agents/*.md` ではエラーマーカーを説明しているが、ビルトインワークフロープロンプトでは欠けている
+3. `watch-session.sh` はエラーマーカーも監視している（L105: `error_marker="###TASK_ERROR_${issue_number}###"`）
+
+### 現在のフッター構造
+```bash
+### On Error
+- If tests fail, fix the issue before committing
+- If PR merge fails, report the error
+
+### On Completion
+**CRITICAL**: After completing all workflow steps...
+```
+
+## 実装ステップ
+
+1. `lib/workflow.sh` のフッター部分を修正
+   - `### On Error` セクションにエラーマーカーの説明を追加
+   - `agents/plan.md` と同様のフォーマットを使用
+
+2. テストを追加
+   - `generate_workflow_prompt` の出力にエラーマーカー説明が含まれることを確認
+
+3. 既存テストの実行確認
+
+## テスト方針
+
+- **単体テスト**: `generate_workflow_prompt` の出力に `###TASK_ERROR_` の説明が含まれることを確認
+- **回帰テスト**: 既存のテストがすべてパスすることを確認
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| 既存のワークフロー動作への影響 | ドキュメント追加のみなので動作影響なし |
+| エージェントテンプレートとの不整合 | `agents/*.md` のフォーマットに合わせる |
+
+## 見積もり
+
+作業時間: 約30分

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -451,6 +451,13 @@ EOF
 ### On Error
 - If tests fail, fix the issue before committing
 - If PR merge fails, report the error
+- **For unrecoverable errors**, output the error marker:
+  - Prefix: \`###TASK\`
+  - Middle: \`_ERROR_\`
+  - Issue number: \`${issue_number}\`
+  - Suffix: \`###\`
+
+This will notify the user and allow manual intervention.
 
 ### On Completion
 **CRITICAL**: After completing all workflow steps (including PR merge), you MUST output the completion marker.

--- a/test/lib/workflow.bats
+++ b/test/lib/workflow.bats
@@ -303,3 +303,31 @@ EOF
     result="$(get_workflow_steps_array "default" "/nonexistent")"
     [ "$result" = "plan implement review merge" ]
 }
+
+# ====================
+# generate_workflow_prompt テスト
+# ====================
+
+@test "generate_workflow_prompt includes error marker documentation" {
+    result="$(generate_workflow_prompt "default" "42" "Test Issue" "Body" "feature/test" "/path" "$TEST_DIR")"
+    [[ "$result" == *"###TASK"* ]]
+    [[ "$result" == *"_ERROR_"* ]]
+    [[ "$result" == *"unrecoverable errors"* ]]
+}
+
+@test "generate_workflow_prompt includes completion marker documentation" {
+    result="$(generate_workflow_prompt "default" "42" "Test Issue" "Body" "feature/test" "/path" "$TEST_DIR")"
+    [[ "$result" == *"###TASK"* ]]
+    [[ "$result" == *"_COMPLETE_"* ]]
+}
+
+@test "generate_workflow_prompt includes issue number in markers" {
+    result="$(generate_workflow_prompt "default" "99" "Test Issue" "Body" "feature/test" "/path" "$TEST_DIR")"
+    [[ "$result" == *"99"* ]]
+}
+
+@test "generate_workflow_prompt includes On Error section" {
+    result="$(generate_workflow_prompt "default" "42" "Test Issue" "Body" "feature/test" "/path" "$TEST_DIR")"
+    [[ "$result" == *"### On Error"* ]]
+    [[ "$result" == *"manual intervention"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #250

## Changes
- Added error marker (`###TASK_ERROR_<issue>###`) documentation to the `generate_workflow_prompt` function's footer in `lib/workflow.sh`
- Added 4 new tests to verify error marker documentation is included in the generated prompt

## Details
The `generate_workflow_prompt` function now includes documentation for both:
- **Completion marker**: `###TASK_COMPLETE_<issue>###` (already existed)
- **Error marker**: `###TASK_ERROR_<issue>###` (newly added)

This is consistent with the individual agent templates in `agents/*.md` and ensures that custom agents created without using the templates will also have proper error reporting guidance.

## Testing
- All 383 existing tests pass
- 4 new tests added for `generate_workflow_prompt`
- ShellCheck passes without warnings