### PR TITLE
docs: テストフィクスチャのコメントを実際のファイルパスに修正

### DIFF
--- a/docs/plans/issue-255-plan.md
+++ b/docs/plans/issue-255-plan.md
@@ -1,0 +1,34 @@
+# 実装計画: Issue #255
+
+## 概要
+
+`test/fixtures/sample-config.yaml` ファイルの冒頭コメントを実際のファイルパスに修正する。
+
+## 現状
+
+- **現在のコメント**: `# tests/fixtures/sample-config.yml`
+- **正しいコメント**: `# test/fixtures/sample-config.yaml`
+
+### 差分
+| 項目 | 現在 | 正しい値 |
+|------|------|----------|
+| ディレクトリ | `tests` | `test` |
+| 拡張子 | `.yml` | `.yaml` |
+
+## 影響範囲
+
+- `test/fixtures/sample-config.yaml` - 1行目のコメントのみ
+
+## 実装ステップ
+
+1. `test/fixtures/sample-config.yaml` の1行目を修正
+2. 変更をコミット
+
+## テスト方針
+
+- コメントのみの変更のため、テストの修正は不要
+- 既存テストがパスすることを確認
+
+## リスクと対策
+
+- リスク: なし（コメントのみの変更）

--- a/test/fixtures/sample-config.yaml
+++ b/test/fixtures/sample-config.yaml
@@ -1,4 +1,4 @@
-# tests/fixtures/sample-config.yml
+# test/fixtures/sample-config.yaml
 # テスト用サンプル設定ファイル
 
 worktree:


### PR DESCRIPTION
## Summary
Closes #255

## Changes
- `test/fixtures/sample-config.yaml` の冒頭コメントを修正
  - ディレクトリ名: `tests` → `test`
  - 拡張子: `.yml` → `.yaml`

## Testing
- 全テストがパスすることを確認済み