### PR TITLE
refactor: config.shとworkflow.shのYAMLパーサーを統一

### DIFF
--- a/docs/plans/issue-262-plan.md
+++ b/docs/plans/issue-262-plan.md
@@ -1,0 +1,98 @@
+# 実装計画書: Issue #262
+
+## 概要
+
+`config.sh`と`workflow.sh`が異なるYAMLパーサーを使用している問題を修正し、共通の`lib/yaml.sh`を作成して統一する。
+
+## 現状分析
+
+### config.sh
+- **パーサー**: 独自実装（`_parse_config_file`関数）
+- **特徴**: 
+  - line-by-line解析
+  - セクション（worktree, tmux, pi等）を認識
+  - 配列形式（`- item`）をサポート
+  - 外部依存なし
+
+### workflow.sh
+- **パーサー**: `yq`（外部コマンド）
+- **特徴**:
+  - `check_yq()`で存在確認
+  - 存在しない場合はビルトインにフォールバック
+  - `.workflow.steps[]`などのパス指定をサポート
+
+## 影響範囲
+
+### 変更対象ファイル
+1. `lib/yaml.sh` - 新規作成
+2. `lib/config.sh` - yaml.shを使用するよう修正
+3. `lib/workflow.sh` - yaml.shを使用するよう修正
+
+### テストファイル
+4. `test/lib/yaml.bats` - 新規作成
+5. `test/lib/config.bats` - 必要に応じて更新
+6. `test/lib/workflow.bats` - 必要に応じて更新
+
+## 実装ステップ
+
+### Step 1: lib/yaml.sh 作成
+
+```bash
+# 主要関数
+check_yq()              # yqの存在確認（キャッシュ機能付き）
+yaml_get()              # 単一値取得
+yaml_get_array()        # 配列取得
+_simple_yaml_get()      # フォールバック用簡易パーサー
+_simple_yaml_get_array() # フォールバック用配列パーサー
+```
+
+### Step 2: lib/config.sh 修正
+
+- `_parse_config_file()`の代わりに`yaml_get()`/`yaml_get_array()`を使用
+- フォールバック処理は`yaml.sh`に委譲
+
+### Step 3: lib/workflow.sh 修正
+
+- 独自の`check_yq()`を削除し、`yaml.sh`の関数を使用
+- `get_workflow_steps()`内のyq呼び出しを`yaml_get_array()`に置き換え
+
+### Step 4: テスト追加
+
+- `test/lib/yaml.bats`を新規作成
+- yqがある場合/ない場合のテスト
+- 既存テストが引き続きパスすることを確認
+
+## テスト方針
+
+1. **ユニットテスト**: `yaml.sh`の各関数をテスト
+   - `yaml_get`の基本動作
+   - `yaml_get_array`の基本動作
+   - yqなし環境でのフォールバック
+   
+2. **統合テスト**: 既存テストの実行
+   - `test/lib/config.bats` - すべてパス
+   - `test/lib/workflow.bats` - すべてパス
+
+3. **手動テスト**:
+   - yqをPATHから除外して動作確認
+   - 実際の`.pi-runner.yaml`での動作確認
+
+## リスクと対策
+
+### リスク1: 既存機能の破壊
+- **対策**: 既存テストをすべてパスさせる。修正前にテストを実行し、修正後も同じ結果を得る。
+
+### リスク2: フォールバックパーサーの機能不足
+- **対策**: config.shの既存パーサーロジックを活用し、必要な機能をカバー。
+
+### リスク3: パフォーマンス低下
+- **対策**: yqが利用可能な場合は優先使用。キャッシュ機能を維持。
+
+## 完了条件
+
+- [ ] `lib/yaml.sh`が新規作成されている
+- [ ] `config.sh`が`lib/yaml.sh`を使用している
+- [ ] `workflow.sh`が`lib/yaml.sh`を使用している
+- [ ] yqがない環境でも動作する（フォールバック）
+- [ ] すべての既存テストがパス
+- [ ] 新しいテスト（`test/lib/yaml.bats`）が追加されている

--- a/lib/yaml.sh
+++ b/lib/yaml.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# yaml.sh - 統一YAMLパーサー（yq + フォールバック）
+#
+# yqが利用可能な場合はyqを使用し、そうでない場合は
+# 簡易パーサーにフォールバックする。
+
+# Note: set -euo pipefail はsource先の環境に影響するため、
+# このファイルでは設定しない（呼び出し元で設定）
+
+# ===================
+# yq チェック
+# ===================
+
+# yq チェック結果のキャッシュ（空: 未チェック、"1": 存在、"0": 不在）
+_YQ_CHECK_RESULT="${_YQ_CHECK_RESULT:-}"
+
+# yq の存在確認（結果をキャッシュ）
+check_yq() {
+    # キャッシュがある場合はそれを返す
+    if [[ -n "$_YQ_CHECK_RESULT" ]]; then
+        [[ "$_YQ_CHECK_RESULT" == "1" ]]
+        return
+    fi
+    
+    # 初回のみ実際にチェック
+    if command -v yq &> /dev/null; then
+        _YQ_CHECK_RESULT="1"
+        return 0
+    else
+        _YQ_CHECK_RESULT="0"
+        return 1
+    fi
+}
+
+# yq キャッシュをリセット（テスト用）
+reset_yq_cache() {
+    _YQ_CHECK_RESULT=""
+}
+
+# ===================
+# メイン関数
+# ===================
+
+# YAML から単一値を取得
+# Usage: yaml_get <file> <path> [default]
+# Example: yaml_get config.yaml ".worktree.base_dir" ".worktrees"
+yaml_get() {
+    local file="$1"
+    local path="$2"
+    local default="${3:-}"
+    
+    if [[ ! -f "$file" ]]; then
+        echo "$default"
+        return 0
+    fi
+    
+    if check_yq; then
+        _yq_get "$file" "$path" "$default"
+    else
+        _simple_yaml_get "$file" "$path" "$default"
+    fi
+}
+
+# YAML から配列値を取得（各要素を1行ずつ出力）
+# Usage: yaml_get_array <file> <path>
+# Example: yaml_get_array config.yaml ".worktree.copy_files"
+yaml_get_array() {
+    local file="$1"
+    local path="$2"
+    
+    if [[ ! -f "$file" ]]; then
+        return 0
+    fi
+    
+    if check_yq; then
+        _yq_get_array "$file" "$path"
+    else
+        _simple_yaml_get_array "$file" "$path"
+    fi
+}
+
+# YAML パスが存在するか確認
+# Usage: yaml_exists <file> <path>
+# Example: yaml_exists config.yaml ".workflow"
+yaml_exists() {
+    local file="$1"
+    local path="$2"
+    
+    if [[ ! -f "$file" ]]; then
+        return 1
+    fi
+    
+    if check_yq; then
+        yq -e "$path" "$file" &>/dev/null
+    else
+        _simple_yaml_exists "$file" "$path"
+    fi
+}
+
+# ===================
+# yq 実装
+# ===================
+
+# yq で値を取得
+_yq_get() {
+    local file="$1"
+    local path="$2"
+    local default="${3:-}"
+    
+    local value
+    value=$(yq -r "$path // \"\"" "$file" 2>/dev/null || echo "")
+    
+    if [[ -n "$value" && "$value" != "null" ]]; then
+        echo "$value"
+    else
+        echo "$default"
+    fi
+}
+
+# yq で配列を取得
+_yq_get_array() {
+    local file="$1"
+    local path="$2"
+    
+    yq -r "${path}[]" "$file" 2>/dev/null || true
+}
+
+# ===================
+# 簡易パーサー実装（フォールバック）
+# ===================
+
+# 簡易パーサーで値を取得
+# パス形式: .section.key または .section.subsection.key
+_simple_yaml_get() {
+    local file="$1"
+    local path="$2"
+    local default="${3:-}"
+    
+    # パスをセクションとキーに分解
+    # 例: .worktree.base_dir -> section=worktree, key=base_dir
+    local path_parts
+    path_parts="${path#.}"  # 先頭のドットを除去
+    
+    local section=""
+    local key=""
+    
+    if [[ "$path_parts" == *"."* ]]; then
+        section="${path_parts%%.*}"
+        key="${path_parts#*.}"
+    else
+        key="$path_parts"
+    fi
+    
+    local current_section=""
+    local found_value=""
+    
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # コメントと空行をスキップ
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]] && continue
+        
+        # セクションの検出 (例: worktree:)
+        if [[ "$line" =~ ^([a-z_]+):[[:space:]]*$ ]]; then
+            current_section="${BASH_REMATCH[1]}"
+            continue
+        fi
+        
+        # セクションなしのトップレベルキー
+        if [[ -z "$section" && "$line" =~ ^([a-z_]+):[[:space:]]*(.*) ]]; then
+            local line_key="${BASH_REMATCH[1]}"
+            local line_value="${BASH_REMATCH[2]}"
+            
+            if [[ "$line_key" == "$key" && -n "$line_value" ]]; then
+                # クォートを除去
+                line_value="${line_value#\"}"
+                line_value="${line_value%\"}"
+                line_value="${line_value#\'}"
+                line_value="${line_value%\'}"
+                found_value="$line_value"
+                break
+            fi
+            continue
+        fi
+        
+        # セクション内のキー検出
+        if [[ -n "$section" && "$current_section" == "$section" ]]; then
+            if [[ "$line" =~ ^[[:space:]]+([a-z_]+):[[:space:]]*(.*) ]]; then
+                local line_key="${BASH_REMATCH[1]}"
+                local line_value="${BASH_REMATCH[2]}"
+                
+                if [[ "$line_key" == "$key" && -n "$line_value" ]]; then
+                    # クォートを除去
+                    line_value="${line_value#\"}"
+                    line_value="${line_value%\"}"
+                    line_value="${line_value#\'}"
+                    line_value="${line_value%\'}"
+                    found_value="$line_value"
+                    break
+                fi
+            fi
+        fi
+    done < "$file"
+    
+    if [[ -n "$found_value" ]]; then
+        echo "$found_value"
+    else
+        echo "$default"
+    fi
+}
+
+# 簡易パーサーで配列を取得
+_simple_yaml_get_array() {
+    local file="$1"
+    local path="$2"
+    
+    # パスをセクションとキーに分解
+    local path_parts
+    path_parts="${path#.}"  # 先頭のドットを除去
+    
+    local section=""
+    local key=""
+    
+    if [[ "$path_parts" == *"."* ]]; then
+        section="${path_parts%%.*}"
+        key="${path_parts#*.}"
+    else
+        key="$path_parts"
+    fi
+    
+    local current_section=""
+    local in_target_array=false
+    
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # コメントと空行をスキップ
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]] && continue
+        
+        # セクションの検出
+        if [[ "$line" =~ ^([a-z_]+):[[:space:]]*$ ]]; then
+            current_section="${BASH_REMATCH[1]}"
+            in_target_array=false
+            continue
+        fi
+        
+        # セクション内のキー検出
+        if [[ -n "$section" && "$current_section" == "$section" ]]; then
+            # キーの開始を検出（値が空 = 配列の開始）
+            if [[ "$line" =~ ^[[:space:]]+([a-z_]+):[[:space:]]*$ ]]; then
+                local line_key="${BASH_REMATCH[1]}"
+                if [[ "$line_key" == "$key" ]]; then
+                    in_target_array=true
+                else
+                    in_target_array=false
+                fi
+                continue
+            fi
+            
+            # 別のキー（値付き）が来たら配列終了
+            if [[ "$line" =~ ^[[:space:]]+[a-z_]+:[[:space:]]+[^[:space:]] ]]; then
+                in_target_array=false
+                continue
+            fi
+        fi
+        
+        # トップレベルの配列キー検出
+        if [[ -z "$section" ]]; then
+            if [[ "$line" =~ ^([a-z_]+):[[:space:]]*$ ]]; then
+                local line_key="${BASH_REMATCH[1]}"
+                if [[ "$line_key" == "$key" ]]; then
+                    in_target_array=true
+                else
+                    in_target_array=false
+                fi
+                continue
+            fi
+        fi
+        
+        # 配列項目の検出
+        if [[ "$in_target_array" == "true" && "$line" =~ ^[[:space:]]+-[[:space:]]+(.*) ]]; then
+            local item="${BASH_REMATCH[1]}"
+            # クォートを除去
+            item="${item#\"}"
+            item="${item%\"}"
+            item="${item#\'}"
+            item="${item%\'}"
+            echo "$item"
+        fi
+    done < "$file"
+}
+
+# 簡易パーサーでパスの存在確認
+_simple_yaml_exists() {
+    local file="$1"
+    local path="$2"
+    
+    # パスをセクションに分解
+    local path_parts
+    path_parts="${path#.}"  # 先頭のドットを除去
+    
+    local section=""
+    local key=""
+    
+    if [[ "$path_parts" == *"."* ]]; then
+        section="${path_parts%%.*}"
+        key="${path_parts#*.}"
+    else
+        section="$path_parts"
+        key=""
+    fi
+    
+    local current_section=""
+    
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # コメントと空行をスキップ
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]] && continue
+        
+        # セクションの検出
+        if [[ "$line" =~ ^([a-z_]+):[[:space:]]*$ ]]; then
+            current_section="${BASH_REMATCH[1]}"
+            # キーが空の場合はセクションの存在のみ確認
+            if [[ -z "$key" && "$current_section" == "$section" ]]; then
+                return 0
+            fi
+            continue
+        fi
+        
+        # セクション内のキー検出
+        if [[ -n "$section" && "$current_section" == "$section" && -n "$key" ]]; then
+            if [[ "$line" =~ ^[[:space:]]+([a-z_]+): ]]; then
+                local line_key="${BASH_REMATCH[1]}"
+                if [[ "$line_key" == "$key" ]]; then
+                    return 0
+                fi
+            fi
+        fi
+    done < "$file"
+    
+    return 1
+}

--- a/test/lib/yaml.bats
+++ b/test/lib/yaml.bats
@@ -1,0 +1,243 @@
+#!/usr/bin/env bats
+# yaml.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # yqキャッシュをリセット
+    _YQ_CHECK_RESULT=""
+    
+    source "$PROJECT_ROOT/lib/yaml.sh"
+    
+    # テスト用設定ファイルを作成
+    export TEST_YAML="${BATS_TEST_TMPDIR}/test.yaml"
+    cat > "$TEST_YAML" << 'EOF'
+# テスト用YAML
+name: test-config
+
+worktree:
+  base_dir: ".custom-worktrees"
+  copy_files:
+    - ".env"
+    - ".env.local"
+    - ".envrc"
+
+tmux:
+  session_prefix: "test-prefix"
+  start_in_session: false
+
+pi:
+  command: "/usr/local/bin/pi"
+  args:
+    - "--verbose"
+    - "--model"
+    - "gpt-4"
+
+workflow:
+  name: default
+  steps:
+    - plan
+    - implement
+    - review
+    - merge
+EOF
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# check_yq テスト
+# ====================
+
+@test "check_yq returns correct status" {
+    _YQ_CHECK_RESULT=""
+    if command -v yq &>/dev/null; then
+        run check_yq
+        [ "$status" -eq 0 ]
+    else
+        run check_yq
+        [ "$status" -eq 1 ]
+    fi
+}
+
+@test "check_yq caches result" {
+    _YQ_CHECK_RESULT=""
+    check_yq || true
+    [ -n "$_YQ_CHECK_RESULT" ]
+}
+
+@test "reset_yq_cache clears cache" {
+    _YQ_CHECK_RESULT="1"
+    reset_yq_cache
+    [ -z "$_YQ_CHECK_RESULT" ]
+}
+
+# ====================
+# yaml_get テスト
+# ====================
+
+@test "yaml_get returns value for simple path" {
+    result="$(yaml_get "$TEST_YAML" ".worktree.base_dir")"
+    [ "$result" = ".custom-worktrees" ]
+}
+
+@test "yaml_get returns value for nested path" {
+    result="$(yaml_get "$TEST_YAML" ".tmux.session_prefix")"
+    [ "$result" = "test-prefix" ]
+}
+
+@test "yaml_get returns default for missing path" {
+    result="$(yaml_get "$TEST_YAML" ".nonexistent.key" "default-value")"
+    [ "$result" = "default-value" ]
+}
+
+@test "yaml_get returns default for missing file" {
+    result="$(yaml_get "/nonexistent/file.yaml" ".key" "default")"
+    [ "$result" = "default" ]
+}
+
+@test "yaml_get returns empty for missing path without default" {
+    result="$(yaml_get "$TEST_YAML" ".nonexistent")"
+    [ -z "$result" ]
+}
+
+@test "yaml_get handles top-level key" {
+    result="$(yaml_get "$TEST_YAML" ".name")"
+    [ "$result" = "test-config" ]
+}
+
+# ====================
+# yaml_get_array テスト
+# ====================
+
+@test "yaml_get_array returns array items" {
+    result="$(yaml_get_array "$TEST_YAML" ".worktree.copy_files" | tr '\n' ' ' | sed 's/ $//')"
+    [ "$result" = ".env .env.local .envrc" ]
+}
+
+@test "yaml_get_array returns workflow steps" {
+    result="$(yaml_get_array "$TEST_YAML" ".workflow.steps" | tr '\n' ' ' | sed 's/ $//')"
+    [ "$result" = "plan implement review merge" ]
+}
+
+@test "yaml_get_array returns pi args" {
+    result="$(yaml_get_array "$TEST_YAML" ".pi.args" | tr '\n' ' ' | sed 's/ $//')"
+    [ "$result" = "--verbose --model gpt-4" ]
+}
+
+@test "yaml_get_array returns empty for missing path" {
+    result="$(yaml_get_array "$TEST_YAML" ".nonexistent.array")"
+    [ -z "$result" ]
+}
+
+@test "yaml_get_array returns empty for missing file" {
+    result="$(yaml_get_array "/nonexistent/file.yaml" ".array")"
+    [ -z "$result" ]
+}
+
+@test "yaml_get_array counts correct number of items" {
+    count="$(yaml_get_array "$TEST_YAML" ".worktree.copy_files" | wc -l | tr -d ' ')"
+    [ "$count" = "3" ]
+}
+
+# ====================
+# yaml_exists テスト
+# ====================
+
+@test "yaml_exists returns true for existing section" {
+    run yaml_exists "$TEST_YAML" ".workflow"
+    [ "$status" -eq 0 ]
+}
+
+@test "yaml_exists returns true for existing nested key" {
+    run yaml_exists "$TEST_YAML" ".worktree.base_dir"
+    [ "$status" -eq 0 ]
+}
+
+@test "yaml_exists returns false for missing section" {
+    run yaml_exists "$TEST_YAML" ".nonexistent"
+    [ "$status" -eq 1 ]
+}
+
+@test "yaml_exists returns false for missing file" {
+    run yaml_exists "/nonexistent/file.yaml" ".key"
+    [ "$status" -eq 1 ]
+}
+
+# ====================
+# フォールバックパーサー直接テスト
+# ====================
+
+@test "_simple_yaml_get parses value correctly" {
+    result="$(_simple_yaml_get "$TEST_YAML" ".worktree.base_dir")"
+    [ "$result" = ".custom-worktrees" ]
+}
+
+@test "_simple_yaml_get returns default for missing" {
+    result="$(_simple_yaml_get "$TEST_YAML" ".missing" "fallback")"
+    [ "$result" = "fallback" ]
+}
+
+@test "_simple_yaml_get_array parses array correctly" {
+    result="$(_simple_yaml_get_array "$TEST_YAML" ".worktree.copy_files" | tr '\n' ' ' | sed 's/ $//')"
+    [ "$result" = ".env .env.local .envrc" ]
+}
+
+@test "_simple_yaml_exists detects existing section" {
+    run _simple_yaml_exists "$TEST_YAML" ".workflow"
+    [ "$status" -eq 0 ]
+}
+
+@test "_simple_yaml_exists returns false for missing" {
+    run _simple_yaml_exists "$TEST_YAML" ".missing"
+    [ "$status" -eq 1 ]
+}
+
+# ====================
+# クォート処理テスト
+# ====================
+
+@test "yaml_get handles quoted values" {
+    local quoted_yaml="${BATS_TEST_TMPDIR}/quoted.yaml"
+    cat > "$quoted_yaml" << 'EOF'
+section:
+  single_quoted: 'value with spaces'
+  double_quoted: "another value"
+  unquoted: plain_value
+EOF
+    
+    result="$(yaml_get "$quoted_yaml" ".section.unquoted")"
+    [ "$result" = "plain_value" ]
+}
+
+# ====================
+# エッジケーステスト
+# ====================
+
+@test "yaml_get handles empty file" {
+    local empty_yaml="${BATS_TEST_TMPDIR}/empty.yaml"
+    touch "$empty_yaml"
+    
+    result="$(yaml_get "$empty_yaml" ".key" "default")"
+    [ "$result" = "default" ]
+}
+
+@test "yaml_get_array handles empty array section" {
+    local no_array_yaml="${BATS_TEST_TMPDIR}/no-array.yaml"
+    cat > "$no_array_yaml" << 'EOF'
+section:
+  key: value
+EOF
+    
+    result="$(yaml_get_array "$no_array_yaml" ".section.items")"
+    [ -z "$result" ]
+}


### PR DESCRIPTION
## Summary
Closes #262

## Changes
- Create `lib/yaml.sh` with unified YAML parser
  - `yaml_get()` for single value retrieval
  - `yaml_get_array()` for array value retrieval  
  - `yaml_exists()` for path existence check
  - Fallback to simple parser when yq is not available
- Update `lib/config.sh` to use `lib/yaml.sh`
  - Remove custom `_parse_config_file` implementation
  - Use `yaml_get`/`yaml_get_array` for config parsing
- Update `lib/workflow.sh` to use `lib/yaml.sh`
  - Remove duplicate `check_yq` function
  - Use `yaml_exists` and `yaml_get_array` for workflow parsing
- Add `test/lib/yaml.bats` with comprehensive tests
- Add `docs/plans/issue-262-plan.md` with implementation plan

## Testing
- All 406 tests pass
- ShellCheck passes for all 20 files
- New `yaml.bats` adds 27 tests for YAML parser:
  - `yaml_get` basic operations
  - `yaml_get_array` basic operations
  - `yaml_exists` basic operations
  - Fallback parser direct tests
  - Edge cases (empty files, missing paths)

## Acceptance Criteria
- [x] lib/yaml.sh を新規作成
- [x] config.sh が lib/yaml.sh を使用
- [x] workflow.sh が lib/yaml.sh を使用
- [x] yq がない環境でも動作する（フォールバック）
- [x] すべての既存テストがパス
- [x] 新しいテストを追加