### PR TITLE
fix: lib/*.shのSCRIPT_DIR変数がimprove.shのSCRIPT_DIRを上書きする

### DIFF
--- a/docs/plans/issue-275-plan.md
+++ b/docs/plans/issue-275-plan.md
@@ -1,0 +1,52 @@
+# Issue #275 実装計画
+
+## 概要
+
+`lib/*.sh` ファイルで定義されている `SCRIPT_DIR` 変数が、`improve.sh` の `SCRIPT_DIR` を上書きしてしまう問題を修正する。
+
+## 原因分析
+
+`improve.sh` では以下の順序で処理が行われる:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"  # → /path/to/scripts
+source "$SCRIPT_DIR/../lib/config.sh"  # config.sh内でSCRIPT_DIRが上書きされる
+```
+
+その結果、後の `"$SCRIPT_DIR/run.sh"` が `lib/run.sh` を参照してしまい、ファイルが見つからないエラーが発生。
+
+## 影響範囲
+
+`SCRIPT_DIR` を定義しているライブラリファイル:
+- `lib/config.sh` (line 8-9)
+- `lib/notify.sh` (line 6-9, line 106)
+- `lib/tmux.sh` (line 6-8)
+- `lib/workflow.sh` (line 6-10)
+- `lib/worktree.sh` (line 7, 10-11)
+
+## 実装ステップ
+
+### 方法1: lib/*.shの変数名を変更（採用）
+
+各ファイルでユニークなプレフィックスを使用:
+
+| ファイル | 現在の変数名 | 新しい変数名 |
+|----------|-------------|-------------|
+| lib/config.sh | SCRIPT_DIR | _CONFIG_LIB_DIR |
+| lib/notify.sh | SCRIPT_DIR | _NOTIFY_LIB_DIR |
+| lib/tmux.sh | SCRIPT_DIR | _TMUX_LIB_DIR |
+| lib/workflow.sh | SCRIPT_DIR | _WORKFLOW_LIB_DIR |
+| lib/worktree.sh | SCRIPT_DIR | _WORKTREE_LIB_DIR |
+
+## テスト方針
+
+1. 既存のBatsテストがすべてパスすることを確認
+2. `improve.sh` が正常に動作することを手動で確認
+3. ShellCheckでエラーがないことを確認
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| 変更漏れ | grep で全ての SCRIPT_DIR 参照を確認 |
+| 他のスクリプトへの影響 | lib/*.sh の変更は内部変数のみなので影響なし |

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -5,8 +5,8 @@
 # このファイルでは設定しない（呼び出し元で設定）
 
 # 共通YAMLパーサーを読み込み
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/yaml.sh"
+_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_CONFIG_LIB_DIR/yaml.sh"
 
 # 設定読み込みフラグ（重複呼び出し防止）
 _CONFIG_LOADED=""

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -3,10 +3,10 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/config.sh"
-source "$SCRIPT_DIR/log.sh"
-source "$SCRIPT_DIR/status.sh"
+_NOTIFY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_NOTIFY_LIB_DIR/config.sh"
+source "$_NOTIFY_LIB_DIR/log.sh"
+source "$_NOTIFY_LIB_DIR/status.sh"
 
 # 後方互換性のために以下の関数はstatus.shで定義済み:
 # - get_status_dir()
@@ -103,7 +103,7 @@ open_terminal_and_attach() {
     fi
     
     # 現在のスクリプトディレクトリからattach.shのパスを計算
-    local attach_script="${SCRIPT_DIR}/../scripts/attach.sh"
+    local attach_script="${_NOTIFY_LIB_DIR}/../scripts/attach.sh"
     
     if [[ ! -x "$attach_script" ]]; then
         log_error "attach.sh not found or not executable: $attach_script"

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -3,9 +3,9 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/config.sh"
-source "$SCRIPT_DIR/log.sh"
+_TMUX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_TMUX_LIB_DIR/config.sh"
+source "$_TMUX_LIB_DIR/log.sh"
 
 # tmuxがインストールされているか確認
 check_tmux() {

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -3,11 +3,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/yaml.sh"
-source "$SCRIPT_DIR/config.sh"
-source "$SCRIPT_DIR/log.sh"
-source "$SCRIPT_DIR/template.sh"
+_WORKFLOW_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_WORKFLOW_LIB_DIR/yaml.sh"
+source "$_WORKFLOW_LIB_DIR/config.sh"
+source "$_WORKFLOW_LIB_DIR/log.sh"
+source "$_WORKFLOW_LIB_DIR/template.sh"
 
 # ビルトインワークフロー定義
 # workflows/ ディレクトリが存在しない場合に使用

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -4,11 +4,11 @@
 set -euo pipefail
 
 # 現在のディレクトリを取得
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_WORKTREE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # configとlogを読み込み
-source "$SCRIPT_DIR/config.sh"
-source "$SCRIPT_DIR/log.sh"
+source "$_WORKTREE_LIB_DIR/config.sh"
+source "$_WORKTREE_LIB_DIR/log.sh"
 
 # worktreeを作成
 create_worktree() {


### PR DESCRIPTION
## Summary
Closes #275

## Changes
- Renamed `SCRIPT_DIR` variable in lib/*.sh files to unique names to prevent overwriting script-level `SCRIPT_DIR`:
  - `lib/config.sh` → `_CONFIG_LIB_DIR`
  - `lib/notify.sh` → `_NOTIFY_LIB_DIR`
  - `lib/tmux.sh` → `_TMUX_LIB_DIR`
  - `lib/workflow.sh` → `_WORKFLOW_LIB_DIR`
  - `lib/worktree.sh` → `_WORKTREE_LIB_DIR`

## Root Cause
When `improve.sh` sources library files like `lib/config.sh`, the library's `SCRIPT_DIR` variable overwrote `improve.sh`'s `SCRIPT_DIR`, causing `$SCRIPT_DIR/run.sh` to incorrectly resolve to `lib/run.sh` instead of `scripts/run.sh`.

## Testing
- All 425 Bats tests pass
- ShellCheck passes on all 21 files