### PR TITLE
docs: add template.sh and yaml.sh to directory structure documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,11 @@ pi-issue-runner/
 │   ├── log.sh         # ログ出力
 │   ├── notify.sh      # 通知機能
 │   ├── status.sh      # 状態管理
+│   ├── template.sh    # テンプレート処理
 │   ├── tmux.sh        # tmux操作
 │   ├── workflow.sh    # ワークフローエンジン
-│   └── worktree.sh    # Git worktree操作
+│   ├── worktree.sh    # Git worktree操作
+│   └── yaml.sh        # YAMLパーサー
 ├── workflows/         # ビルトインワークフロー定義
 │   ├── default.yaml   # 完全ワークフロー
 │   └── simple.yaml    # 簡易ワークフロー
@@ -55,9 +57,11 @@ pi-issue-runner/
 │   │   ├── log.bats
 │   │   ├── notify.bats
 │   │   ├── status.bats
+│   │   ├── template.bats
 │   │   ├── tmux.bats
 │   │   ├── workflow.bats
-│   │   └── worktree.bats
+│   │   ├── worktree.bats
+│   │   └── yaml.bats
 │   ├── scripts/       # スクリプトの統合テスト
 │   │   ├── attach.bats
 │   │   ├── cleanup.bats

--- a/README.md
+++ b/README.md
@@ -305,9 +305,11 @@ pi-issue-runner/
 │   ├── log.sh              # ログ出力
 │   ├── notify.sh           # 通知機能
 │   ├── status.sh           # ステータスファイル管理
+│   ├── template.sh         # テンプレート処理
 │   ├── tmux.sh             # tmux操作
 │   ├── workflow.sh         # ワークフローエンジン
-│   └── worktree.sh         # Git worktree操作
+│   ├── worktree.sh         # Git worktree操作
+│   └── yaml.sh             # YAMLパーサー
 ├── workflows/               # ビルトインワークフロー定義
 │   ├── default.yaml        # 完全ワークフロー
 │   └── simple.yaml         # 簡易ワークフロー
@@ -369,9 +371,11 @@ test/
 │   ├── log.bats                 # log.sh のテスト
 │   ├── notify.bats              # notify.sh のテスト
 │   ├── status.bats              # status.sh のテスト
+│   ├── template.bats            # template.sh のテスト
 │   ├── tmux.bats                # tmux.sh のテスト
 │   ├── workflow.bats            # workflow.sh のテスト
-│   └── worktree.bats            # worktree.sh のテスト
+│   ├── worktree.bats            # worktree.sh のテスト
+│   └── yaml.bats                # yaml.sh のテスト
 ├── scripts/                     # スクリプトの統合テスト
 │   ├── attach.bats              # attach.sh のテスト
 │   ├── cleanup.bats             # cleanup.sh のテスト

--- a/docs/plans/issue-272-plan.md
+++ b/docs/plans/issue-272-plan.md
@@ -1,0 +1,31 @@
+# Issue #272 実装計画書
+
+## 概要
+
+`lib/` および `test/lib/` ディレクトリに存在する `template.sh`, `yaml.sh`, `template.bats`, `yaml.bats` が README.md と AGENTS.md のディレクトリ構造ツリーに記載されていない問題を修正する。
+
+## 影響範囲
+
+- `README.md` - ディレクトリ構造セクションとテスト構造セクション
+- `AGENTS.md` - ディレクトリ構造セクション
+
+## 実装ステップ
+
+1. README.md の lib/ セクションに `template.sh` と `yaml.sh` を追加
+2. README.md の test/lib/ セクションに `template.bats` と `yaml.bats` を追加
+3. AGENTS.md の lib/ セクションに `template.sh` と `yaml.sh` を追加
+4. AGENTS.md の test/lib/ セクションに `template.bats` と `yaml.bats` を追加
+
+## テスト方針
+
+- ドキュメント変更のため、テストコードの変更は不要
+- 変更後のファイル構造とドキュメントの整合性を確認
+
+## リスクと対策
+
+- **リスク**: 他にも記載漏れがある可能性
+- **対策**: 実際のファイル構造と比較して確認済み
+
+## 作業時間見積もり
+
+約15分


### PR DESCRIPTION
## Summary
Closes #272

## Changes
- Add `template.sh` and `yaml.sh` to lib/ section in README.md and AGENTS.md
- Add `template.bats` and `yaml.bats` to test/lib/ section in README.md and AGENTS.md

## Testing
- Documentation change only, no functional changes
- Verified that all listed files exist in the repository