### PR TITLE
feat: イベントhook機能の追加（on_success, on_error等）

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,24 @@ steps:
 | `{{step_name}}` | 現在のステップ名（カスタム用） |
 | `{{workflow_name}}` | ワークフロー名（カスタム用） |
 
+## Hook機能
+
+セッションのライフサイクルイベントでカスタムスクリプトを実行できます。
+
+```yaml
+# .pi-runner.yaml
+hooks:
+  on_start: ./hooks/on-start.sh
+  on_success: terminal-notifier -title "完了" -message "Issue #{{issue_number}} が完了しました"
+  on_error: |
+    curl -X POST -H 'Content-Type: application/json' \
+      -d '{"text": "Issue #{{issue_number}} でエラー"}' \
+      $SLACK_WEBHOOK_URL
+  on_cleanup: echo "クリーンアップ完了" >> ~/.pi-runner/activity.log
+```
+
+詳細は[docs/hooks.md](docs/hooks.md)を参照してください。
+
 ## ディレクトリ構造
 
 ```
@@ -302,6 +320,7 @@ pi-issue-runner/
 ├── lib/
 │   ├── config.sh           # 設定読み込み
 │   ├── github.sh           # GitHub API操作
+│   ├── hooks.sh            # イベントhook機能
 │   ├── log.sh              # ログ出力
 │   ├── notify.sh           # 通知機能
 │   ├── status.sh           # ステータスファイル管理

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,155 @@
+# Hook機能
+
+pi-issue-runnerは、セッションのライフサイクルイベントでカスタムスクリプトを実行できるhook機能をサポートしています。
+
+## 対応イベント
+
+| イベント | 発火タイミング |
+|----------|----------------|
+| `on_start` | セッション開始時 |
+| `on_success` | タスク正常完了時 |
+| `on_error` | エラー検出時 |
+| `on_cleanup` | クリーンアップ完了後 |
+
+## 設定方法
+
+`.pi-runner.yaml` の `hooks` セクションで設定します。
+
+### スクリプトファイル指定
+
+```yaml
+hooks:
+  on_start: ./hooks/on-start.sh
+  on_success: ./hooks/on-success.sh
+  on_error: ./hooks/on-error.sh
+  on_cleanup: ./hooks/on-cleanup.sh
+```
+
+### インラインコマンド
+
+```yaml
+hooks:
+  on_success: |
+    terminal-notifier -title "完了" -message "Issue #{{issue_number}} が完了しました"
+  on_error: |
+    osascript -e 'display notification "エラー発生" with title "Pi Issue Runner"'
+    curl -X POST -H 'Content-Type: application/json' \
+      -d '{"text": "Issue #{{issue_number}} でエラー: {{error_message}}"}' \
+      $SLACK_WEBHOOK_URL
+```
+
+### 特定イベントのみ設定
+
+```yaml
+hooks:
+  on_error: ./hooks/on-error.sh  # エラー時のみhookを実行
+```
+
+## テンプレート変数
+
+hookコマンド/スクリプト内で使用可能な変数：
+
+| 変数 | 説明 | 利用可能イベント |
+|------|------|-----------------|
+| `{{issue_number}}` | Issue番号 | 全て |
+| `{{issue_title}}` | Issueタイトル | 全て |
+| `{{session_name}}` | セッション名 | 全て |
+| `{{branch_name}}` | ブランチ名 | 全て |
+| `{{worktree_path}}` | worktreeパス | 全て |
+| `{{error_message}}` | エラーメッセージ | on_error |
+| `{{exit_code}}` | 終了コード | 全て |
+
+## 環境変数
+
+hookスクリプトには環境変数としても値が渡されます：
+
+| 環境変数 | 説明 |
+|----------|------|
+| `PI_ISSUE_NUMBER` | Issue番号 |
+| `PI_ISSUE_TITLE` | Issueタイトル |
+| `PI_SESSION_NAME` | セッション名 |
+| `PI_BRANCH_NAME` | ブランチ名 |
+| `PI_WORKTREE_PATH` | worktreeパス |
+| `PI_ERROR_MESSAGE` | エラーメッセージ（on_errorのみ） |
+| `PI_EXIT_CODE` | 終了コード |
+
+### 環境変数の使用例
+
+```bash
+#!/bin/bash
+# hooks/on-success.sh
+
+echo "Issue #$PI_ISSUE_NUMBER completed"
+echo "Session: $PI_SESSION_NAME"
+echo "Branch: $PI_BRANCH_NAME"
+
+# Slack通知
+if [[ -n "$SLACK_WEBHOOK_URL" ]]; then
+    curl -X POST -H 'Content-Type: application/json' \
+        -d "{\"text\": \"Issue #$PI_ISSUE_NUMBER が完了しました\"}" \
+        "$SLACK_WEBHOOK_URL"
+fi
+```
+
+## デフォルト動作
+
+hookが設定されていない場合：
+
+- **on_success**: macOS/Linux通知を表示
+- **on_error**: macOS/Linux通知を表示
+- **on_start**: 何もしない
+- **on_cleanup**: 何もしない
+
+## 使用例
+
+### Slack通知
+
+```yaml
+hooks:
+  on_success: |
+    curl -X POST -H 'Content-Type: application/json' \
+      -d '{"text": ":white_check_mark: Issue #{{issue_number}} 完了"}' \
+      $SLACK_WEBHOOK_URL
+  on_error: |
+    curl -X POST -H 'Content-Type: application/json' \
+      -d '{"text": ":x: Issue #{{issue_number}} でエラー: {{error_message}}"}' \
+      $SLACK_WEBHOOK_URL
+```
+
+### Discord通知
+
+```yaml
+hooks:
+  on_success: |
+    curl -X POST -H 'Content-Type: application/json' \
+      -d '{"content": "Issue #{{issue_number}} が完了しました"}' \
+      $DISCORD_WEBHOOK_URL
+```
+
+### カスタムログ記録
+
+```yaml
+hooks:
+  on_start: echo "[$(date)] Issue #{{issue_number}} started" >> ~/.pi-runner/activity.log
+  on_success: echo "[$(date)] Issue #{{issue_number}} completed" >> ~/.pi-runner/activity.log
+  on_error: echo "[$(date)] Issue #{{issue_number}} error: {{error_message}}" >> ~/.pi-runner/activity.log
+```
+
+### macOS通知（カスタマイズ）
+
+```yaml
+hooks:
+  on_success: |
+    osascript -e 'display notification "Issue #{{issue_number}} が完了しました" with title "Pi Runner" sound name "Glass"'
+  on_error: |
+    osascript -e 'display notification "{{error_message}}" with title "Pi Runner エラー" sound name "Basso"'
+```
+
+## エラーハンドリング
+
+hookスクリプトでエラーが発生しても、pi-issue-runnerのメイン処理は継続します。hookのエラーはログに記録されますが、セッションの監視やクリーンアップには影響しません。
+
+## 関連ドキュメント
+
+- [設定ファイル](./configuration.md)
+- [ワークフロー](./workflows.md)

--- a/docs/plans/issue-280-plan.md
+++ b/docs/plans/issue-280-plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Issue #280 - Event Hook機能の追加
+
+## 概要
+
+セッションのライフサイクルイベント（on_start, on_success, on_error, on_cleanup）でカスタムスクリプトを実行できるhook機能を追加する。
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `lib/hooks.sh` | 新規作成 - hook実行エンジン |
+| `lib/config.sh` | hooks設定の読み込み対応 |
+| `lib/yaml.sh` | 複雑なYAMLパス対応（既存機能で対応可能） |
+| `scripts/watch-session.sh` | on_success/on_errorフックの呼び出し |
+| `scripts/run.sh` | on_startフックの呼び出し |
+| `scripts/cleanup.sh` | on_cleanupフックの呼び出し |
+| `test/lib/hooks.bats` | 新規作成 - hookテスト |
+| `docs/hooks.md` | 新規作成 - ドキュメント |
+
+## 実装ステップ
+
+### Step 1: lib/hooks.sh の作成
+
+1. `get_hook(event)` - 設定からhookを取得
+2. `run_hook(event, ...)` - hookを実行
+3. `_run_default_hook(event, ...)` - デフォルト動作（現在のnotify.sh相当）
+4. 環境変数の設定とテンプレート変数展開
+
+### Step 2: lib/config.sh の修正
+
+1. hooks設定の読み込み対応
+2. `get_hook_config(event)` 関数の追加
+
+### Step 3: scripts/watch-session.sh の修正
+
+1. hooks.sh のソース
+2. `handle_complete()` → `run_hook("on_success", ...)`
+3. `handle_error()` → `run_hook("on_error", ...)`
+
+### Step 4: scripts/run.sh の修正
+
+1. hooks.sh のソース
+2. セッション開始時に `run_hook("on_start", ...)`
+
+### Step 5: scripts/cleanup.sh の修正
+
+1. hooks.sh のソース
+2. クリーンアップ後に `run_hook("on_cleanup", ...)`
+
+### Step 6: テストの追加
+
+1. `test/lib/hooks.bats` の作成
+2. 各イベントのテスト
+3. テンプレート変数展開のテスト
+4. 環境変数のテスト
+
+### Step 7: ドキュメントの追加
+
+1. `docs/hooks.md` の作成
+2. README.md への参照追加
+
+## テスト方針
+
+### ユニットテスト（test/lib/hooks.bats）
+
+- [ ] `get_hook()` がhooks設定を正しく取得
+- [ ] `run_hook()` がスクリプトファイルを実行
+- [ ] `run_hook()` がインラインコマンドを実行
+- [ ] テンプレート変数が正しく展開される
+- [ ] 環境変数が正しく設定される
+- [ ] hook未設定時はデフォルト動作
+
+### 統合テスト（test/scripts/watch-session.bats）
+
+- [ ] on_success hookが呼び出される
+- [ ] on_error hookが呼び出される
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| hookスクリプトのエラーでセッション監視が止まる | hook実行を`|| true`でラップ |
+| テンプレート変数の特殊文字でsedが壊れる | sedのデリミタを`|`に変更、エスケープ処理 |
+| 既存の通知機能との競合 | hook未設定時は現在の動作を維持 |
+| YAMLマルチライン対応 | yaml.shの既存機能を活用 |
+
+## 完了条件
+
+- [ ] lib/hooks.shを新規作成
+- [ ] .pi-runner.yamlでhooksセクションをサポート
+- [ ] on_start, on_success, on_error, on_cleanupイベントをサポート
+- [ ] スクリプトファイルとインラインコマンドの両方をサポート
+- [ ] テンプレート変数の展開
+- [ ] 環境変数での値渡し
+- [ ] hookが未設定の場合はデフォルト動作
+- [ ] ドキュメント追加
+- [ ] テスト追加

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# hooks.sh - イベントhook実行
+#
+# セッションのライフサイクルイベントでカスタムスクリプトを実行する。
+# 対応イベント: on_start, on_success, on_error, on_cleanup
+
+# Note: set -euo pipefail はsource先の環境に影響するため、
+# このファイルでは設定しない（呼び出し元で設定）
+
+_HOOKS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 依存ライブラリの読み込み（未読み込みの場合のみ）
+if ! declare -f yaml_get &>/dev/null; then
+    source "$_HOOKS_LIB_DIR/yaml.sh"
+fi
+
+if ! declare -f log_info &>/dev/null; then
+    source "$_HOOKS_LIB_DIR/log.sh"
+fi
+
+if ! declare -f notify_success &>/dev/null; then
+    source "$_HOOKS_LIB_DIR/notify.sh"
+fi
+
+# ===================
+# Hook 設定取得
+# ===================
+
+# hook設定を取得
+# Usage: get_hook <event>
+# Events: on_start, on_success, on_error, on_cleanup
+# Returns: hookの値（スクリプトパスまたはインラインコマンド）
+get_hook() {
+    local event="$1"
+    
+    # 設定ファイルを探す
+    local config_file
+    if config_file="$(find_config_file "$(pwd)" 2>/dev/null)"; then
+        yaml_get "$config_file" ".hooks.$event" ""
+    else
+        echo ""
+    fi
+}
+
+# ===================
+# Hook 実行
+# ===================
+
+# hookを実行
+# Usage: run_hook <event> <issue_number> <session_name> [branch_name] [worktree_path] [error_message] [exit_code] [issue_title]
+run_hook() {
+    local event="$1"
+    local issue_number="$2"
+    local session_name="$3"
+    local branch_name="${4:-}"
+    local worktree_path="${5:-}"
+    local error_message="${6:-}"
+    local exit_code="${7:-0}"
+    local issue_title="${8:-}"
+    
+    local hook
+    hook="$(get_hook "$event")"
+    
+    if [[ -z "$hook" ]]; then
+        # hookが設定されていない場合はデフォルト動作
+        _run_default_hook "$event" "$issue_number" "$session_name" "$error_message"
+        return 0
+    fi
+    
+    log_info "Running hook for event: $event"
+    
+    # 環境変数を設定
+    export PI_ISSUE_NUMBER="$issue_number"
+    export PI_ISSUE_TITLE="$issue_title"
+    export PI_SESSION_NAME="$session_name"
+    export PI_BRANCH_NAME="$branch_name"
+    export PI_WORKTREE_PATH="$worktree_path"
+    export PI_ERROR_MESSAGE="$error_message"
+    export PI_EXIT_CODE="$exit_code"
+    
+    # テンプレート変数を展開
+    hook="$(_expand_hook_template "$hook" "$issue_number" "$issue_title" "$session_name" "$branch_name" "$worktree_path" "$error_message" "$exit_code")"
+    
+    # hook実行
+    _execute_hook "$hook" || {
+        log_warn "Hook execution failed for event: $event"
+        return 0  # hookの失敗でメイン処理を止めない
+    }
+    
+    log_info "Hook completed for event: $event"
+}
+
+# テンプレート変数を展開
+_expand_hook_template() {
+    local hook="$1"
+    local issue_number="$2"
+    local issue_title="$3"
+    local session_name="$4"
+    local branch_name="$5"
+    local worktree_path="$6"
+    local error_message="$7"
+    local exit_code="$8"
+    
+    # Bash文字列置換を使用（sedより安全）
+    hook="${hook//\{\{issue_number\}\}/$issue_number}"
+    hook="${hook//\{\{issue_title\}\}/$issue_title}"
+    hook="${hook//\{\{session_name\}\}/$session_name}"
+    hook="${hook//\{\{branch_name\}\}/$branch_name}"
+    hook="${hook//\{\{worktree_path\}\}/$worktree_path}"
+    hook="${hook//\{\{error_message\}\}/$error_message}"
+    hook="${hook//\{\{exit_code\}\}/$exit_code}"
+    
+    echo "$hook"
+}
+
+# hookを実行（ファイルまたはインラインコマンド）
+_execute_hook() {
+    local hook="$1"
+    
+    # ファイルパスの場合（スクリプトファイル）
+    if [[ -f "$hook" ]]; then
+        log_debug "Executing hook script: $hook"
+        if [[ -x "$hook" ]]; then
+            "$hook"
+        else
+            bash "$hook"
+        fi
+        return $?
+    fi
+    
+    # インラインコマンドとして実行
+    log_debug "Executing inline hook"
+    eval "$hook"
+}
+
+# ===================
+# デフォルト動作
+# ===================
+
+# デフォルトhook（notify.sh相当の動作）
+_run_default_hook() {
+    local event="$1"
+    local issue_number="$2"
+    local session_name="$3"
+    local error_message="${4:-}"
+    
+    case "$event" in
+        on_success)
+            notify_success "$session_name" "$issue_number"
+            ;;
+        on_error)
+            notify_error "$session_name" "$issue_number" "$error_message"
+            ;;
+        on_start|on_cleanup)
+            # デフォルトでは何もしない
+            log_debug "No default action for event: $event"
+            ;;
+        *)
+            log_warn "Unknown hook event: $event"
+            ;;
+    esac
+}

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -9,6 +9,7 @@ source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
 source "$SCRIPT_DIR/../lib/worktree.sh"
 source "$SCRIPT_DIR/../lib/status.sh"
+source "$SCRIPT_DIR/../lib/hooks.sh"
 
 usage() {
     cat << EOF
@@ -276,6 +277,9 @@ main() {
         fi
     fi
 
+    # on_cleanup hookを実行
+    run_hook "on_cleanup" "$issue_number" "$session_name" "" "" "" "0" ""
+    
     log_info "Cleanup completed."
 }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -63,6 +63,7 @@ source "$SCRIPT_DIR/../lib/worktree.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/workflow.sh"
+source "$SCRIPT_DIR/../lib/hooks.sh"
 
 # 依存関係チェック
 check_dependencies || exit 1
@@ -256,6 +257,9 @@ main() {
     
     # セッション作成成功 - クリーンアップ対象から除外
     unregister_worktree_for_cleanup
+    
+    # on_start hookを実行
+    run_hook "on_start" "$issue_number" "$session_name" "feature/$branch_name" "$full_worktree_path" "" "0" "$issue_title"
 
     # 自動クリーンアップが有効な場合、監視プロセスを起動
     if [[ "$cleanup_mode" != "none" ]]; then

--- a/scripts/watch-session.sh
+++ b/scripts/watch-session.sh
@@ -9,6 +9,8 @@ source "$WATCHER_SCRIPT_DIR/../lib/config.sh"
 source "$WATCHER_SCRIPT_DIR/../lib/log.sh"
 source "$WATCHER_SCRIPT_DIR/../lib/tmux.sh"
 source "$WATCHER_SCRIPT_DIR/../lib/notify.sh"
+source "$WATCHER_SCRIPT_DIR/../lib/worktree.sh"
+source "$WATCHER_SCRIPT_DIR/../lib/hooks.sh"
 
 usage() {
     cat << EOF
@@ -152,8 +154,23 @@ main() {
             local error_message
             error_message=$(echo "$output" | grep -A 1 "$error_marker" | tail -n 1 | head -c 200) || error_message="Unknown error"
             
-            # エラー処理を実行
-            handle_error "$session_name" "$issue_number" "$error_message" "$auto_attach"
+            # worktreeパスとブランチ名を取得
+            local worktree_path=""
+            local branch_name=""
+            if worktree_path="$(find_worktree_by_issue "$issue_number" 2>/dev/null)"; then
+                branch_name="$(get_worktree_branch "$worktree_path" 2>/dev/null)" || branch_name=""
+            fi
+            
+            # ステータスを保存
+            save_status "$issue_number" "error" "$session_name" "$error_message"
+            
+            # on_error hookを実行（hook未設定時はデフォルト動作）
+            run_hook "on_error" "$issue_number" "$session_name" "$branch_name" "$worktree_path" "$error_message" "1" ""
+            
+            # auto_attachが有効な場合はTerminalを開く
+            if [[ "$auto_attach" == "true" ]] && is_macos; then
+                open_terminal_and_attach "$session_name"
+            fi
             
             log_warn "Error notification sent. Session is still running for manual intervention."
             
@@ -170,8 +187,18 @@ main() {
         if [[ "$marker_count_current" -gt "$marker_count_baseline" ]]; then
             log_info "Completion marker detected! (baseline: $marker_count_baseline, current: $marker_count_current)"
             
-            # 完了処理
-            handle_complete "$session_name" "$issue_number"
+            # worktreeパスとブランチ名を取得
+            local worktree_path=""
+            local branch_name=""
+            if worktree_path="$(find_worktree_by_issue "$issue_number" 2>/dev/null)"; then
+                branch_name="$(get_worktree_branch "$worktree_path" 2>/dev/null)" || branch_name=""
+            fi
+            
+            # ステータスを保存
+            save_status "$issue_number" "complete" "$session_name"
+            
+            # on_success hookを実行（hook未設定時はデフォルト動作）
+            run_hook "on_success" "$issue_number" "$session_name" "$branch_name" "$worktree_path" "" "0" ""
             
             log_info "Running cleanup..."
             

--- a/test/lib/hooks.bats
+++ b/test/lib/hooks.bats
@@ -1,0 +1,320 @@
+#!/usr/bin/env bats
+# hooks.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # テスト用ワークディレクトリを作成
+    export TEST_WORKDIR="$BATS_TEST_TMPDIR/workdir"
+    mkdir -p "$TEST_WORKDIR"
+    cd "$TEST_WORKDIR"
+    
+    # ステータスディレクトリを設定
+    export TEST_WORKTREE_DIR="$BATS_TEST_TMPDIR/.worktrees"
+    mkdir -p "$TEST_WORKTREE_DIR/.status"
+    
+    # ログレベルを抑制
+    export LOG_LEVEL="ERROR"
+    
+    # 設定のリセット
+    export _CONFIG_LOADED=""
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ヘルパー: config.shのget_configをオーバーライド
+override_get_config() {
+    get_config() {
+        case "$1" in
+            worktree_base_dir) echo "$TEST_WORKTREE_DIR" ;;
+            *) echo "" ;;
+        esac
+    }
+}
+
+# ヘルパー: notify.shの関数をモック
+mock_notify() {
+    notify_success() {
+        echo "NOTIFY_SUCCESS: $1 $2"
+    }
+    
+    notify_error() {
+        echo "NOTIFY_ERROR: $1 $2 $3"
+    }
+    
+    is_macos() {
+        return 1  # 常にfalseを返す
+    }
+}
+
+# ====================
+# get_hook テスト
+# ====================
+
+@test "get_hook returns empty when no config file exists" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    
+    result="$(get_hook "on_success")"
+    [ -z "$result" ]
+}
+
+@test "get_hook returns hook value from config file" {
+    # 設定ファイルを作成
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
+hooks:
+  on_success: echo "success hook"
+  on_error: ./hooks/on-error.sh
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    
+    result="$(get_hook "on_success")"
+    [ "$result" = 'echo "success hook"' ]
+}
+
+@test "get_hook returns script path from config file" {
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
+hooks:
+  on_error: ./hooks/on-error.sh
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    
+    result="$(get_hook "on_error")"
+    [ "$result" = "./hooks/on-error.sh" ]
+}
+
+@test "get_hook returns empty for undefined hook" {
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
+hooks:
+  on_success: echo "success"
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    
+    result="$(get_hook "on_start")"
+    [ -z "$result" ]
+}
+
+# ====================
+# _expand_hook_template テスト
+# ====================
+
+@test "_expand_hook_template expands issue_number" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(_expand_hook_template 'Issue #{{issue_number}} completed' '42' '' '' '' '' '' '')"
+    [ "$result" = "Issue #42 completed" ]
+}
+
+@test "_expand_hook_template expands multiple variables" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(_expand_hook_template 'Issue #{{issue_number}} on {{branch_name}}' '42' 'My Title' 'session-42' 'feature/issue-42' '/path' '' '0')"
+    [ "$result" = "Issue #42 on feature/issue-42" ]
+}
+
+@test "_expand_hook_template expands error_message" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(_expand_hook_template 'Error: {{error_message}}' '42' '' '' '' '' 'Test error' '1')"
+    [ "$result" = "Error: Test error" ]
+}
+
+@test "_expand_hook_template expands all variables" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    template='{{issue_number}}|{{issue_title}}|{{session_name}}|{{branch_name}}|{{worktree_path}}|{{error_message}}|{{exit_code}}'
+    result="$(_expand_hook_template "$template" '42' 'My Title' 'pi-42' 'feature/issue-42' '/worktrees/42' 'oops' '1')"
+    [ "$result" = "42|My Title|pi-42|feature/issue-42|/worktrees/42|oops|1" ]
+}
+
+# ====================
+# run_hook テスト（デフォルト動作）
+# ====================
+
+@test "run_hook calls default on_success notification when no hook defined" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" == *"NOTIFY_SUCCESS"* ]]
+}
+
+@test "run_hook calls default on_error notification when no hook defined" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_error" "42" "pi-42" "" "" "Test error" "1" "")"
+    [[ "$result" == *"NOTIFY_ERROR"* ]]
+}
+
+@test "run_hook does nothing for on_start when no hook defined" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_start" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" != *"NOTIFY"* ]]
+}
+
+@test "run_hook does nothing for on_cleanup when no hook defined" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_cleanup" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" != *"NOTIFY"* ]]
+}
+
+# ====================
+# run_hook テスト（インラインコマンド）
+# ====================
+
+@test "run_hook executes inline command" {
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
+hooks:
+  on_success: echo "INLINE_HOOK_EXECUTED"
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" == *"INLINE_HOOK_EXECUTED"* ]]
+}
+
+@test "run_hook expands template in inline command" {
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
+hooks:
+  on_success: echo "Issue {{issue_number}} done"
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" == *"Issue 42 done"* ]]
+}
+
+# ====================
+# run_hook テスト（スクリプトファイル）
+# ====================
+
+@test "run_hook executes script file" {
+    mkdir -p "$TEST_WORKDIR/hooks"
+    cat > "$TEST_WORKDIR/hooks/on-success.sh" << 'EOF'
+#!/bin/bash
+echo "SCRIPT_HOOK_EXECUTED"
+echo "Issue: $PI_ISSUE_NUMBER"
+EOF
+    chmod +x "$TEST_WORKDIR/hooks/on-success.sh"
+    
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << EOF
+hooks:
+  on_success: $TEST_WORKDIR/hooks/on-success.sh
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" == *"SCRIPT_HOOK_EXECUTED"* ]]
+    [[ "$result" == *"Issue: 42"* ]]
+}
+
+@test "run_hook sets environment variables" {
+    mkdir -p "$TEST_WORKDIR/hooks"
+    cat > "$TEST_WORKDIR/hooks/test-env.sh" << 'EOF'
+#!/bin/bash
+echo "NUM:$PI_ISSUE_NUMBER"
+echo "SESSION:$PI_SESSION_NAME"
+echo "BRANCH:$PI_BRANCH_NAME"
+echo "PATH:$PI_WORKTREE_PATH"
+echo "ERROR:$PI_ERROR_MESSAGE"
+echo "EXIT:$PI_EXIT_CODE"
+EOF
+    chmod +x "$TEST_WORKDIR/hooks/test-env.sh"
+    
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << EOF
+hooks:
+  on_error: $TEST_WORKDIR/hooks/test-env.sh
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    result="$(run_hook "on_error" "42" "pi-42" "feature/issue-42" "/worktrees/42" "oops" "1" "Test Title")"
+    [[ "$result" == *"NUM:42"* ]]
+    [[ "$result" == *"SESSION:pi-42"* ]]
+    [[ "$result" == *"BRANCH:feature/issue-42"* ]]
+    [[ "$result" == *"PATH:/worktrees/42"* ]]
+    [[ "$result" == *"ERROR:oops"* ]]
+    [[ "$result" == *"EXIT:1"* ]]
+}
+
+# ====================
+# run_hook テスト（エラーハンドリング）
+# ====================
+
+@test "run_hook continues on hook failure" {
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
+hooks:
+  on_success: false
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    # Should not fail even if hook exits with error
+    run run_hook "on_success" "42" "pi-42" "" "" "" "0" ""
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# 空のhook設定テスト
+# ====================
+
+@test "run_hook with empty value disables hook" {
+    cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
+hooks:
+  on_success: ""
+EOF
+    
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    mock_notify
+    
+    # Empty hook means no action, should use default behavior
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    # With empty string, it should fall through to default
+    [[ "$result" == *"NOTIFY_SUCCESS"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #280

## Changes

### 新規ファイル
- **lib/hooks.sh**: イベントhook実行エンジン
  - `get_hook()`: 設定からhookを取得
  - `run_hook()`: hookを実行（ファイルまたはインラインコマンド）
  - テンプレート変数展開（`{{issue_number}}`等）
  - 環境変数渡し（`PI_ISSUE_NUMBER`等）
  - hookが未設定の場合はデフォルト動作（notify.sh相当）

- **docs/hooks.md**: 詳細なhook機能ドキュメント
- **test/lib/hooks.bats**: 18テスト追加

### 変更ファイル
- **scripts/run.sh**: on_startフック呼び出し追加
- **scripts/watch-session.sh**: on_success/on_errorフック呼び出し追加
- **scripts/cleanup.sh**: on_cleanupフック呼び出し追加
- **README.md**: hook機能の概要を追加

## 対応イベント

| イベント | 発火タイミング |
|----------|----------------|
| `on_start` | セッション開始時 |
| `on_success` | タスク正常完了時 |
| `on_error` | エラー検出時 |
| `on_cleanup` | クリーンアップ完了後 |

## 設定例

```yaml
hooks:
  on_success: terminal-notifier -title "完了" -message "Issue #{{issue_number}} が完了しました"
  on_error: ./hooks/on-error.sh
```

## Testing
- `./scripts/test.sh` - 全443テストパス
- `./scripts/test.sh --shellcheck` - ShellCheckパス
- 手動テスト: hook設定ありなしで動作確認済み