### PR TITLE
docs: add missing hooks.sh and hooks.bats to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ pi-issue-runner/
 ├── lib/               # 共通ライブラリ
 │   ├── config.sh      # 設定読み込み
 │   ├── github.sh      # GitHub CLI操作
+│   ├── hooks.sh       # Hook機能
 │   ├── log.sh         # ログ出力
 │   ├── notify.sh      # 通知機能
 │   ├── status.sh      # 状態管理
@@ -54,6 +55,7 @@ pi-issue-runner/
 │   ├── lib/           # ライブラリのユニットテスト
 │   │   ├── config.bats
 │   │   ├── github.bats
+│   │   ├── hooks.bats
 │   │   ├── log.bats
 │   │   ├── notify.bats
 │   │   ├── status.bats

--- a/docs/plans/issue-295-plan.md
+++ b/docs/plans/issue-295-plan.md
@@ -1,0 +1,36 @@
+# Issue #295 実装計画書
+
+## 概要
+
+AGENTS.md のディレクトリ構造セクションに `lib/hooks.sh` と `test/lib/hooks.bats` の記載が欠落しているため、これを追加する。
+
+## 問題の分析
+
+### 発見した不整合
+
+1. **lib/hooks.sh が欠落**: lib/ セクションに `hooks.sh` が記載されていない
+2. **test/lib/hooks.bats が欠落**: test/lib/ セクションにも `hooks.bats` が記載されていない
+
+### 影響範囲
+
+- `AGENTS.md` のみ
+
+## 実装ステップ
+
+1. AGENTS.md の lib/ セクションに `hooks.sh` を追加（アルファベット順: github.sh の後）
+2. AGENTS.md の test/lib/ セクションに `hooks.bats` を追加（アルファベット順: github.bats の後）
+
+## テスト方針
+
+- ドキュメント変更のため、テストファイルの更新は不要
+- 変更後に diff で正しく追加されたことを確認
+
+## リスクと対策
+
+- リスク: 特になし（ドキュメント修正のみ）
+- 対策: 変更前に現在のファイル構造を確認済み
+
+## 完了条件
+
+- [x] AGENTS.md の lib/ セクションに `hooks.sh` が追加される
+- [x] AGENTS.md の test/lib/ セクションに `hooks.bats` が追加される


### PR DESCRIPTION
## Summary
Closes #295

## Changes
- Add `lib/hooks.sh` entry to lib/ directory structure section
- Add `test/lib/hooks.bats` entry to test/lib/ directory structure section

## Testing
- Verified that AGENTS.md directory structure now matches actual files in lib/ and test/lib/

## Review
- Entries are added in alphabetical order (after github.sh / github.bats)
- Formatting matches existing style