### PR TITLE
fix: implement --dry-run, --review-only, --auto-continue options for improve.sh

### DIFF
--- a/docs/plans/issue-294-plan.md
+++ b/docs/plans/issue-294-plan.md
@@ -1,0 +1,84 @@
+# Issue #294 実装計画
+
+## 概要
+
+SKILL.mdに記載されている `improve.sh` の3つのオプションを実装する：
+1. `--dry-run` - レビューのみ（Issue作成しない）
+2. `--review-only` - 問題表示のみ  
+3. `--auto-continue` - 自動継続（承認スキップ）
+
+## 影響範囲
+
+- `scripts/improve.sh` - メインの変更対象
+- `test/scripts/improve.bats` - テスト追加
+
+## 現状分析
+
+現在の `improve.sh` は以下のフローで動作：
+1. Phase 1: `pi --print` でレビュー実行 → Issue自動作成
+2. Phase 2: GitHub APIでIssue取得
+3. Phase 3: `run.sh --no-attach` で並列実行
+4. Phase 4: `wait-for-sessions.sh` で待機
+5. Phase 5: 次のイテレーションへ再帰呼び出し
+
+## 実装ステップ
+
+### 1. 変数追加
+```bash
+local dry_run=false
+local review_only=false
+local auto_continue=false
+```
+
+### 2. オプションパース追加
+```bash
+--dry-run)
+    dry_run=true
+    shift
+    ;;
+--review-only)
+    review_only=true
+    shift
+    ;;
+--auto-continue)
+    auto_continue=true
+    shift
+    ;;
+```
+
+### 3. 各オプションの動作
+
+#### `--dry-run`
+- Phase 1でレビュープロンプトを変更：「問題を報告するがIssueは作成しない」
+- Phase 2〜5をスキップ
+- レビュー結果のみを表示して終了
+
+#### `--review-only`
+- Phase 1のレビュー結果のみを表示
+- Phase 2以降をスキップ
+- `--dry-run` より軽量（Issue作成せず報告のみ）
+
+#### `--auto-continue`
+- イテレーション間の承認確認をスキップ
+- 現在は自動継続が既定のため、将来の拡張用に準備
+- （現在は実質的にnoop、ただしフラグとして受け付ける）
+
+### 4. usage() 更新
+ヘルプに新オプションを追加
+
+### 5. テスト追加
+- オプションがヘルプに表示されることを確認
+- オプションパースのテスト
+- 構造テスト（grep でオプション処理コードを確認）
+
+## テスト方針
+
+- ユニットテスト: オプションパースと構造確認
+- 統合テスト: 実際の動作確認（モック使用）
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| 既存の動作に影響 | デフォルト値をfalseに設定し、既存動作を維持 |
+| pi --print のプロンプト変更 | dry-runフラグで条件分岐 |

--- a/test/scripts/improve.bats
+++ b/test/scripts/improve.bats
@@ -63,6 +63,21 @@ teardown() {
     [[ "$output" == *"--log-dir"* ]]
 }
 
+@test "improve.sh --help shows --dry-run option" {
+    run "$PROJECT_ROOT/scripts/improve.sh" --help
+    [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "improve.sh --help shows --review-only option" {
+    run "$PROJECT_ROOT/scripts/improve.sh" --help
+    [[ "$output" == *"--review-only"* ]]
+}
+
+@test "improve.sh --help shows --auto-continue option" {
+    run "$PROJECT_ROOT/scripts/improve.sh" --help
+    [[ "$output" == *"--auto-continue"* ]]
+}
+
 @test "improve.sh --help shows description" {
     run "$PROJECT_ROOT/scripts/improve.sh" --help
     [[ "$output" == *"Description:"* ]]
@@ -160,6 +175,18 @@ teardown() {
     grep -q '\-\-log-dir)' "$PROJECT_ROOT/scripts/improve.sh"
 }
 
+@test "improve.sh handles --dry-run option" {
+    grep -q '\-\-dry-run)' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh handles --review-only option" {
+    grep -q '\-\-review-only)' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh handles --auto-continue option" {
+    grep -q '\-\-auto-continue)' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
 # ====================
 # デフォルト値テスト
 # ====================
@@ -178,6 +205,22 @@ teardown() {
 
 @test "improve.sh has LOG_DIR" {
     grep -q 'LOG_DIR=' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+# ====================
+# オプションフラグテスト
+# ====================
+
+@test "improve.sh has dry_run variable" {
+    grep -q 'dry_run=' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh has review_only variable" {
+    grep -q 'review_only=' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+@test "improve.sh has auto_continue variable" {
+    grep -q 'auto_continue=' "$PROJECT_ROOT/scripts/improve.sh"
 }
 
 # ====================
@@ -331,4 +374,46 @@ teardown() {
 
 @test "improve.sh cleanup uses --force flag" {
     grep -q 'cleanup.sh.*--force' "$PROJECT_ROOT/scripts/improve.sh"
+}
+
+# ====================
+# --dry-run オプションテスト
+# ====================
+
+@test "improve.sh dry-run mode modifies prompt" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'Issueは作成しないでください'* ]]
+}
+
+@test "improve.sh dry-run mode exits early" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'Dry-run mode complete'* ]]
+}
+
+@test "improve.sh dry-run mode shows message about no Issues created" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'No Issues were created'* ]]
+}
+
+# ====================
+# --review-only オプションテスト
+# ====================
+
+@test "improve.sh review-only mode exits early" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'Review-only mode complete'* ]]
+}
+
+# ====================
+# --auto-continue オプションテスト
+# ====================
+
+@test "improve.sh has confirmation prompt for manual mode" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'Press Enter to continue'* ]]
+}
+
+@test "improve.sh preserves --auto-continue flag in recursive call" {
+    source_content=$(cat "$PROJECT_ROOT/scripts/improve.sh")
+    [[ "$source_content" == *'args+=(--auto-continue)'* ]]
 }


### PR DESCRIPTION
## Summary
Closes #294

## Changes
- Add `--dry-run` option: Review only, do not create Issues
- Add `--review-only` option: Show problems only (no Issue creation or execution)
- Add `--auto-continue` option: Skip confirmation prompt between iterations
- Update `usage()` help text with new options and examples
- Add confirmation prompt before continuing to next iteration (skipped with `--auto-continue`)
- Preserve `--auto-continue` flag in recursive calls

## Testing
- Added 15 new Bats tests for option parsing and functionality
- All 463 tests pass
- ShellCheck passes with no warnings

## Acceptance Criteria
- [x] `--dry-run` option works
- [x] `--review-only` option works
- [x] `--auto-continue` option works
- [x] `improve.sh --help` shows all options
- [x] Tests added