### PR TITLE
test: ワークフロー関連ライブラリのテスト追加

### DIFF
--- a/docs/plans/issue-329-plan.md
+++ b/docs/plans/issue-329-plan.md
@@ -1,0 +1,80 @@
+# Issue #329 実装計画
+
+## 概要
+
+ワークフロー関連ライブラリのテストファイルを作成し、テストカバレッジを向上させます。
+
+## 影響範囲
+
+### 新規作成ファイル
+- `test/lib/workflow-finder.bats`
+- `test/lib/workflow-loader.bats`
+- `test/lib/workflow-prompt.bats`
+
+### 関連するライブラリ
+- `lib/workflow-finder.sh` - ワークフロー・エージェントファイル検索
+- `lib/workflow-loader.sh` - ワークフロー読み込み・解析
+- `lib/workflow-prompt.sh` - ワークフロープロンプト生成
+
+## 実装ステップ
+
+### 1. workflow-finder.bats の作成
+テスト対象関数:
+- `find_workflow_file()` - ワークフローファイル検索（優先順位順）
+- `find_agent_file()` - エージェントファイル検索
+
+テストケース:
+- `.pi-runner.yaml` が存在する場合の検索
+- `.pi/workflow.yaml` が存在する場合
+- `workflows/{name}.yaml` が存在する場合
+- ビルトインへのフォールバック
+- エージェントファイルの検索順序
+
+### 2. workflow-loader.bats の作成
+テスト対象関数:
+- `get_workflow_steps()` - ワークフローからステップ一覧を取得
+- `get_agent_prompt()` - エージェントプロンプトを取得
+
+テストケース:
+- ビルトインワークフロー（default, simple）のステップ取得
+- YAMLファイルからのステップ解析
+- `.pi-runner.yaml` 形式からの読み込み
+- ビルトインエージェントプロンプトの取得
+- カスタムエージェントファイルからの読み込み
+- テンプレート変数の展開
+
+### 3. workflow-prompt.bats の作成
+テスト対象関数:
+- `generate_workflow_prompt()` - ワークフロープロンプトを生成
+- `write_workflow_prompt()` - ワークフロープロンプトをファイルに書き出し
+
+テストケース:
+- プロンプトヘッダーの生成
+- 各ステップのプロンプト生成
+- フッターの生成（エラーマーカー、完了マーカー）
+- ファイルへの書き出し
+
+## テスト方針
+
+- 既存の `test/lib/*.bats` のパターンに従う
+- `test_helper.bash` のsetup/teardownを利用
+- 一時ディレクトリにテスト用ファイルを作成
+- `yaml.sh` を依存としてテスト
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| 依存ライブラリの不足 | 各テストファイルで必要なライブラリをsource |
+| yqの有無 | yqがない場合はフォールバックパーサーでテスト |
+| テストの重複 | workflow.batsとの重複を避け、個別ライブラリの単体テストに集中 |
+
+## 見積もり時間
+
+| タスク | 時間 |
+|--------|------|
+| workflow-finder.bats | 30分 |
+| workflow-loader.bats | 40分 |
+| workflow-prompt.bats | 30分 |
+| テスト実行・修正 | 20分 |
+| **合計** | **2時間** |

--- a/test/lib/workflow-finder.bats
+++ b/test/lib/workflow-finder.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# workflow-finder.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # yqキャッシュをリセット
+    _YQ_CHECK_RESULT=""
+    
+    source "$PROJECT_ROOT/lib/workflow-finder.sh"
+    
+    # テスト用ディレクトリ構造を作成
+    export TEST_PROJECT="$BATS_TEST_TMPDIR/project"
+    mkdir -p "$TEST_PROJECT/workflows"
+    mkdir -p "$TEST_PROJECT/agents"
+    mkdir -p "$TEST_PROJECT/.pi/agents"
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# find_workflow_file テスト
+# ====================
+
+@test "find_workflow_file returns builtin when no file exists" {
+    result="$(find_workflow_file "default" "$TEST_PROJECT")"
+    [ "$result" = "builtin:default" ]
+}
+
+@test "find_workflow_file returns builtin:simple for simple workflow" {
+    result="$(find_workflow_file "simple" "$TEST_PROJECT")"
+    [ "$result" = "builtin:simple" ]
+}
+
+@test "find_workflow_file returns workflows/{name}.yaml when exists" {
+    cat > "$TEST_PROJECT/workflows/default.yaml" << 'EOF'
+name: default
+steps:
+  - plan
+  - implement
+EOF
+    
+    result="$(find_workflow_file "default" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/workflows/default.yaml" ]
+}
+
+@test "find_workflow_file returns workflows/custom.yaml for custom workflow" {
+    cat > "$TEST_PROJECT/workflows/custom.yaml" << 'EOF'
+name: custom
+steps:
+  - step1
+  - step2
+EOF
+    
+    result="$(find_workflow_file "custom" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/workflows/custom.yaml" ]
+}
+
+@test "find_workflow_file prioritizes .pi/workflow.yaml over workflows/" {
+    cat > "$TEST_PROJECT/workflows/default.yaml" << 'EOF'
+name: default
+steps:
+  - plan
+EOF
+    mkdir -p "$TEST_PROJECT/.pi"
+    cat > "$TEST_PROJECT/.pi/workflow.yaml" << 'EOF'
+name: pi-custom
+steps:
+  - implement
+  - merge
+EOF
+    
+    result="$(find_workflow_file "default" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/.pi/workflow.yaml" ]
+}
+
+@test "find_workflow_file prioritizes .pi-runner.yaml with workflow section" {
+    cat > "$TEST_PROJECT/workflows/default.yaml" << 'EOF'
+name: default
+steps:
+  - plan
+EOF
+    mkdir -p "$TEST_PROJECT/.pi"
+    cat > "$TEST_PROJECT/.pi/workflow.yaml" << 'EOF'
+name: pi-custom
+steps:
+  - implement
+EOF
+    cat > "$TEST_PROJECT/.pi-runner.yaml" << 'EOF'
+workflow:
+  name: runner
+  steps:
+    - custom-step
+EOF
+    
+    result="$(find_workflow_file "default" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/.pi-runner.yaml" ]
+}
+
+@test "find_workflow_file ignores .pi-runner.yaml without workflow section" {
+    cat > "$TEST_PROJECT/.pi-runner.yaml" << 'EOF'
+worktree:
+  base_dir: .worktrees
+EOF
+    cat > "$TEST_PROJECT/workflows/default.yaml" << 'EOF'
+name: default
+steps:
+  - plan
+EOF
+    
+    result="$(find_workflow_file "default" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/workflows/default.yaml" ]
+}
+
+@test "find_workflow_file uses current directory when project_root not specified" {
+    cd "$TEST_PROJECT"
+    cat > "$TEST_PROJECT/workflows/default.yaml" << 'EOF'
+name: default
+steps:
+  - plan
+EOF
+    
+    result="$(find_workflow_file "default")"
+    [ "$result" = "./workflows/default.yaml" ]
+}
+
+# ====================
+# find_agent_file テスト
+# ====================
+
+@test "find_agent_file returns builtin when no agent file exists" {
+    result="$(find_agent_file "plan" "$TEST_PROJECT")"
+    [ "$result" = "builtin:plan" ]
+}
+
+@test "find_agent_file returns builtin for all builtin agents" {
+    result_plan="$(find_agent_file "plan" "$TEST_PROJECT")"
+    result_implement="$(find_agent_file "implement" "$TEST_PROJECT")"
+    result_review="$(find_agent_file "review" "$TEST_PROJECT")"
+    result_merge="$(find_agent_file "merge" "$TEST_PROJECT")"
+    
+    [ "$result_plan" = "builtin:plan" ]
+    [ "$result_implement" = "builtin:implement" ]
+    [ "$result_review" = "builtin:review" ]
+    [ "$result_merge" = "builtin:merge" ]
+}
+
+@test "find_agent_file returns agents/{step}.md when exists" {
+    echo "Custom plan agent" > "$TEST_PROJECT/agents/plan.md"
+    result="$(find_agent_file "plan" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/agents/plan.md" ]
+}
+
+@test "find_agent_file prioritizes agents/ over .pi/agents/" {
+    echo "Custom agent in agents/" > "$TEST_PROJECT/agents/implement.md"
+    echo "Custom agent in .pi/agents/" > "$TEST_PROJECT/.pi/agents/implement.md"
+    
+    result="$(find_agent_file "implement" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/agents/implement.md" ]
+}
+
+@test "find_agent_file falls back to .pi/agents/ when agents/ not found" {
+    echo "Agent in .pi/agents/" > "$TEST_PROJECT/.pi/agents/review.md"
+    
+    result="$(find_agent_file "review" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/.pi/agents/review.md" ]
+}
+
+@test "find_agent_file handles custom step names" {
+    echo "Custom step agent" > "$TEST_PROJECT/agents/custom-step.md"
+    result="$(find_agent_file "custom-step" "$TEST_PROJECT")"
+    [ "$result" = "$TEST_PROJECT/agents/custom-step.md" ]
+}
+
+@test "find_agent_file uses current directory when project_root not specified" {
+    cd "$TEST_PROJECT"
+    echo "Plan agent" > "$TEST_PROJECT/agents/plan.md"
+    
+    result="$(find_agent_file "plan")"
+    [ "$result" = "./agents/plan.md" ]
+}
+
+# ====================
+# エッジケーステスト
+# ====================
+
+@test "find_workflow_file handles non-existent project root gracefully" {
+    result="$(find_workflow_file "default" "/nonexistent/path")"
+    [ "$result" = "builtin:default" ]
+}
+
+@test "find_agent_file handles non-existent project root gracefully" {
+    result="$(find_agent_file "plan" "/nonexistent/path")"
+    [ "$result" = "builtin:plan" ]
+}
+
+@test "find_workflow_file handles empty workflow name" {
+    result="$(find_workflow_file "" "$TEST_PROJECT")"
+    [ "$result" = "builtin:default" ]
+}
+
+@test "find_workflow_file preserves workflow name in builtin result" {
+    result="$(find_workflow_file "thorough" "$TEST_PROJECT")"
+    [ "$result" = "builtin:thorough" ]
+}

--- a/test/lib/workflow-loader.bats
+++ b/test/lib/workflow-loader.bats
@@ -1,0 +1,270 @@
+#!/usr/bin/env bats
+# workflow-loader.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # yqキャッシュをリセット
+    _YQ_CHECK_RESULT=""
+    
+    source "$PROJECT_ROOT/lib/workflow-loader.sh"
+    
+    # テスト用ディレクトリ構造を作成
+    export TEST_PROJECT="$BATS_TEST_TMPDIR/project"
+    mkdir -p "$TEST_PROJECT/workflows"
+    mkdir -p "$TEST_PROJECT/agents"
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# ビルトインワークフロー定数テスト
+# ====================
+
+@test "_BUILTIN_WORKFLOW_DEFAULT is defined" {
+    [ -n "$_BUILTIN_WORKFLOW_DEFAULT" ]
+}
+
+@test "_BUILTIN_WORKFLOW_DEFAULT contains plan implement review merge" {
+    [ "$_BUILTIN_WORKFLOW_DEFAULT" = "plan implement review merge" ]
+}
+
+@test "_BUILTIN_WORKFLOW_SIMPLE is defined" {
+    [ -n "$_BUILTIN_WORKFLOW_SIMPLE" ]
+}
+
+@test "_BUILTIN_WORKFLOW_SIMPLE contains implement merge" {
+    [ "$_BUILTIN_WORKFLOW_SIMPLE" = "implement merge" ]
+}
+
+# ====================
+# get_workflow_steps テスト - ビルトイン
+# ====================
+
+@test "get_workflow_steps returns default builtin steps" {
+    result="$(get_workflow_steps "builtin:default")"
+    [ "$result" = "plan implement review merge" ]
+}
+
+@test "get_workflow_steps returns simple builtin steps" {
+    result="$(get_workflow_steps "builtin:simple")"
+    [ "$result" = "implement merge" ]
+}
+
+@test "get_workflow_steps returns default for unknown builtin" {
+    result="$(get_workflow_steps "builtin:unknown")"
+    [ "$result" = "plan implement review merge" ]
+}
+
+# ====================
+# get_workflow_steps テスト - YAMLファイル
+# ====================
+
+@test "get_workflow_steps parses YAML file with steps" {
+    cat > "$TEST_PROJECT/workflows/test.yaml" << 'EOF'
+name: test
+steps:
+  - step1
+  - step2
+  - step3
+EOF
+    
+    result="$(get_workflow_steps "$TEST_PROJECT/workflows/test.yaml")"
+    [ "$result" = "step1 step2 step3" ]
+}
+
+@test "get_workflow_steps parses .pi-runner.yaml format" {
+    cat > "$TEST_PROJECT/.pi-runner.yaml" << 'EOF'
+workflow:
+  name: runner
+  steps:
+    - plan
+    - implement
+EOF
+    
+    result="$(get_workflow_steps "$TEST_PROJECT/.pi-runner.yaml")"
+    [ "$result" = "plan implement" ]
+}
+
+@test "get_workflow_steps returns builtin when file not found" {
+    run get_workflow_steps "/nonexistent/file.yaml"
+    [ "$status" -eq 1 ]
+}
+
+@test "get_workflow_steps returns builtin when no steps in file" {
+    cat > "$TEST_PROJECT/workflows/empty.yaml" << 'EOF'
+name: empty
+description: No steps defined
+EOF
+    
+    result="$(get_workflow_steps "$TEST_PROJECT/workflows/empty.yaml")"
+    [ "$result" = "plan implement review merge" ]
+}
+
+@test "get_workflow_steps handles single step" {
+    cat > "$TEST_PROJECT/workflows/single.yaml" << 'EOF'
+name: single
+steps:
+  - implement
+EOF
+    
+    result="$(get_workflow_steps "$TEST_PROJECT/workflows/single.yaml")"
+    [ "$result" = "implement" ]
+}
+
+@test "get_workflow_steps handles many steps" {
+    cat > "$TEST_PROJECT/workflows/many.yaml" << 'EOF'
+name: many
+steps:
+  - plan
+  - design
+  - implement
+  - test
+  - review
+  - merge
+EOF
+    
+    result="$(get_workflow_steps "$TEST_PROJECT/workflows/many.yaml")"
+    [ "$result" = "plan design implement test review merge" ]
+}
+
+# ====================
+# get_agent_prompt テスト - ビルトイン
+# ====================
+
+@test "get_agent_prompt returns plan agent prompt" {
+    result="$(get_agent_prompt "builtin:plan" "42")"
+    [[ "$result" == *"#42"* ]]
+}
+
+@test "get_agent_prompt returns implement agent prompt" {
+    result="$(get_agent_prompt "builtin:implement" "99")"
+    [[ "$result" == *"#99"* ]]
+}
+
+@test "get_agent_prompt returns review agent prompt" {
+    result="$(get_agent_prompt "builtin:review" "123")"
+    [[ "$result" == *"#123"* ]]
+}
+
+@test "get_agent_prompt returns merge agent prompt" {
+    result="$(get_agent_prompt "builtin:merge" "456")"
+    [[ "$result" == *"#456"* ]]
+}
+
+@test "get_agent_prompt returns implement for unknown builtin" {
+    result="$(get_agent_prompt "builtin:unknown" "42")"
+    [[ "$result" == *"#42"* ]]
+}
+
+# ====================
+# get_agent_prompt テスト - カスタムファイル
+# ====================
+
+@test "get_agent_prompt reads from custom file" {
+    echo "Custom agent for issue #{{issue_number}}" > "$TEST_PROJECT/agents/custom.md"
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/custom.md" "42")"
+    [ "$result" = "Custom agent for issue #42" ]
+}
+
+@test "get_agent_prompt expands branch_name variable" {
+    echo "Branch: {{branch_name}}" > "$TEST_PROJECT/agents/test.md"
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/test.md" "" "feature/test")"
+    [ "$result" = "Branch: feature/test" ]
+}
+
+@test "get_agent_prompt expands worktree_path variable" {
+    echo "Path: {{worktree_path}}" > "$TEST_PROJECT/agents/test.md"
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/test.md" "" "" "/path/to/worktree")"
+    [ "$result" = "Path: /path/to/worktree" ]
+}
+
+@test "get_agent_prompt expands step_name variable" {
+    echo "Step: {{step_name}}" > "$TEST_PROJECT/agents/test.md"
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/test.md" "" "" "" "implement")"
+    [ "$result" = "Step: implement" ]
+}
+
+@test "get_agent_prompt expands issue_title variable" {
+    echo "Title: {{issue_title}}" > "$TEST_PROJECT/agents/test.md"
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/test.md" "" "" "" "" "Fix bug")"
+    [ "$result" = "Title: Fix bug" ]
+}
+
+@test "get_agent_prompt expands all variables" {
+    cat > "$TEST_PROJECT/agents/full.md" << 'EOF'
+Issue #{{issue_number}}: {{issue_title}}
+Branch: {{branch_name}}
+Path: {{worktree_path}}
+Step: {{step_name}}
+EOF
+    
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/full.md" "42" "feature/test" "/path/wt" "plan" "Add feature")"
+    [[ "$result" == *"Issue #42: Add feature"* ]]
+    [[ "$result" == *"Branch: feature/test"* ]]
+    [[ "$result" == *"Path: /path/wt"* ]]
+    [[ "$result" == *"Step: plan"* ]]
+}
+
+@test "get_agent_prompt fails for non-existent file" {
+    run get_agent_prompt "/nonexistent/agent.md" "42"
+    [ "$status" -eq 1 ]
+}
+
+# ====================
+# エッジケーステスト
+# ====================
+
+@test "get_agent_prompt handles empty issue_number" {
+    echo "Issue #{{issue_number}}" > "$TEST_PROJECT/agents/test.md"
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/test.md" "")"
+    [ "$result" = "Issue #" ]
+}
+
+@test "get_agent_prompt handles special characters in variables" {
+    echo "Title: {{issue_title}}" > "$TEST_PROJECT/agents/test.md"
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/test.md" "" "" "" "" "Fix: handle & and < characters")"
+    [ "$result" = "Title: Fix: handle & and < characters" ]
+}
+
+@test "get_agent_prompt handles multiline template" {
+    cat > "$TEST_PROJECT/agents/multiline.md" << 'EOF'
+# Agent
+
+Issue: #{{issue_number}}
+Branch: {{branch_name}}
+
+## Tasks
+1. First task
+2. Second task
+EOF
+    
+    result="$(get_agent_prompt "$TEST_PROJECT/agents/multiline.md" "42" "feature/test")"
+    [[ "$result" == *"Issue: #42"* ]]
+    [[ "$result" == *"Branch: feature/test"* ]]
+    [[ "$result" == *"## Tasks"* ]]
+}
+
+@test "get_workflow_steps handles YAML with comments" {
+    cat > "$TEST_PROJECT/workflows/commented.yaml" << 'EOF'
+# This is a comment
+name: commented
+# Another comment
+steps:
+  - plan
+  # Step comment
+  - implement
+EOF
+    
+    result="$(get_workflow_steps "$TEST_PROJECT/workflows/commented.yaml")"
+    [ "$result" = "plan implement" ]
+}

--- a/test/lib/workflow-prompt.bats
+++ b/test/lib/workflow-prompt.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+# workflow-prompt.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # yqキャッシュをリセット
+    _YQ_CHECK_RESULT=""
+    
+    # workflow.sh が workflow-prompt.sh を読み込むので、workflow.sh をsource
+    source "$PROJECT_ROOT/lib/workflow.sh"
+    
+    # テスト用ディレクトリ構造を作成
+    export TEST_PROJECT="$BATS_TEST_TMPDIR/project"
+    mkdir -p "$TEST_PROJECT/workflows"
+    mkdir -p "$TEST_PROJECT/agents"
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# generate_workflow_prompt テスト - ヘッダー
+# ====================
+
+@test "generate_workflow_prompt includes issue number in header" {
+    result="$(generate_workflow_prompt "default" "42" "Test Issue" "Issue body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"Implement GitHub Issue #42"* ]]
+}
+
+@test "generate_workflow_prompt includes issue title" {
+    result="$(generate_workflow_prompt "default" "42" "My Test Issue" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"## Title"* ]]
+    [[ "$result" == *"My Test Issue"* ]]
+}
+
+@test "generate_workflow_prompt includes issue body" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "This is the issue body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"## Description"* ]]
+    [[ "$result" == *"This is the issue body"* ]]
+}
+
+@test "generate_workflow_prompt includes workflow name" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"## Workflow: default"* ]]
+}
+
+@test "generate_workflow_prompt includes simple workflow name" {
+    result="$(generate_workflow_prompt "simple" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"## Workflow: simple"* ]]
+}
+
+# ====================
+# generate_workflow_prompt テスト - ステップ
+# ====================
+
+@test "generate_workflow_prompt includes Step 1: Plan for default workflow" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 1: Plan"* ]]
+}
+
+@test "generate_workflow_prompt includes Step 2: Implement for default workflow" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 2: Implement"* ]]
+}
+
+@test "generate_workflow_prompt includes Step 3: Review for default workflow" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 3: Review"* ]]
+}
+
+@test "generate_workflow_prompt includes Step 4: Merge for default workflow" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 4: Merge"* ]]
+}
+
+@test "generate_workflow_prompt includes Step 1: Implement for simple workflow" {
+    result="$(generate_workflow_prompt "simple" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 1: Implement"* ]]
+}
+
+@test "generate_workflow_prompt includes Step 2: Merge for simple workflow" {
+    result="$(generate_workflow_prompt "simple" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 2: Merge"* ]]
+}
+
+@test "generate_workflow_prompt does not include Step 3 for simple workflow" {
+    result="$(generate_workflow_prompt "simple" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" != *"### Step 3:"* ]]
+}
+
+# ====================
+# generate_workflow_prompt テスト - フッター
+# ====================
+
+@test "generate_workflow_prompt includes Commit Types section" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Commit Types"* ]]
+}
+
+@test "generate_workflow_prompt includes feat commit type" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"feat:"* ]] || [[ "$result" == *"- feat"* ]]
+}
+
+@test "generate_workflow_prompt includes On Error section" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### On Error"* ]]
+}
+
+@test "generate_workflow_prompt includes error marker format" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"###TASK"* ]]
+    [[ "$result" == *"_ERROR_"* ]]
+}
+
+@test "generate_workflow_prompt includes On Completion section" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### On Completion"* ]]
+}
+
+@test "generate_workflow_prompt includes completion marker format" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"_COMPLETE_"* ]]
+}
+
+@test "generate_workflow_prompt includes issue number in markers" {
+    result="$(generate_workflow_prompt "default" "99" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"99"* ]]
+}
+
+# ====================
+# generate_workflow_prompt テスト - カスタムワークフロー
+# ====================
+
+@test "generate_workflow_prompt uses custom workflow file" {
+    cat > "$TEST_PROJECT/workflows/custom.yaml" << 'EOF'
+name: custom
+steps:
+  - design
+  - implement
+  - test
+EOF
+    
+    result="$(generate_workflow_prompt "custom" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 1: Design"* ]]
+    [[ "$result" == *"### Step 2: Implement"* ]]
+    [[ "$result" == *"### Step 3: Test"* ]]
+}
+
+@test "generate_workflow_prompt uses custom agent file" {
+    cat > "$TEST_PROJECT/agents/plan.md" << 'EOF'
+# Custom Plan Agent
+Issue: #{{issue_number}}
+Branch: {{branch_name}}
+EOF
+    
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"# Custom Plan Agent"* ]]
+    [[ "$result" == *"Issue: #42"* ]]
+    [[ "$result" == *"Branch: feature/test"* ]]
+}
+
+# ====================
+# write_workflow_prompt テスト
+# ====================
+
+@test "write_workflow_prompt creates file" {
+    output_file="$BATS_TEST_TMPDIR/prompt.md"
+    write_workflow_prompt "$output_file" "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT"
+    
+    [ -f "$output_file" ]
+}
+
+@test "write_workflow_prompt file contains issue number" {
+    output_file="$BATS_TEST_TMPDIR/prompt.md"
+    write_workflow_prompt "$output_file" "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT"
+    
+    content="$(cat "$output_file")"
+    [[ "$content" == *"#42"* ]]
+}
+
+@test "write_workflow_prompt file contains workflow steps" {
+    output_file="$BATS_TEST_TMPDIR/prompt.md"
+    write_workflow_prompt "$output_file" "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT"
+    
+    content="$(cat "$output_file")"
+    [[ "$content" == *"### Step 1: Plan"* ]]
+    [[ "$content" == *"### Step 4: Merge"* ]]
+}
+
+@test "write_workflow_prompt file matches generate_workflow_prompt output" {
+    output_file="$BATS_TEST_TMPDIR/prompt.md"
+    write_workflow_prompt "$output_file" "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT"
+    
+    file_content="$(cat "$output_file")"
+    generated="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    
+    [ "$file_content" = "$generated" ]
+}
+
+@test "write_workflow_prompt creates parent directories" {
+    output_file="$BATS_TEST_TMPDIR/nested/dir/prompt.md"
+    mkdir -p "$(dirname "$output_file")"
+    write_workflow_prompt "$output_file" "default" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT"
+    
+    [ -f "$output_file" ]
+}
+
+# ====================
+# エッジケーステスト
+# ====================
+
+@test "generate_workflow_prompt handles empty issue body" {
+    result="$(generate_workflow_prompt "default" "42" "Title" "" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"## Description"* ]]
+}
+
+@test "generate_workflow_prompt handles multiline issue body" {
+    body="Line 1
+Line 2
+Line 3"
+    result="$(generate_workflow_prompt "default" "42" "Title" "$body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"Line 1"* ]]
+    [[ "$result" == *"Line 2"* ]]
+    [[ "$result" == *"Line 3"* ]]
+}
+
+@test "generate_workflow_prompt handles special characters in title" {
+    result="$(generate_workflow_prompt "default" "42" "Fix: handle & and < characters" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"Fix: handle & and < characters"* ]]
+}
+
+@test "generate_workflow_prompt uses default project_root when not specified" {
+    cd "$TEST_PROJECT"
+    result="$(generate_workflow_prompt "default" "42" "Title" "Body" "feature/test" "/path/wt")"
+    [[ "$result" == *"#42"* ]]
+}
+
+@test "generate_workflow_prompt capitalizes step names" {
+    cat > "$TEST_PROJECT/workflows/lowercase.yaml" << 'EOF'
+name: lowercase
+steps:
+  - mystep
+EOF
+    
+    result="$(generate_workflow_prompt "lowercase" "42" "Title" "Body" "feature/test" "/path/wt" "$TEST_PROJECT")"
+    [[ "$result" == *"### Step 1: Mystep"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #329

## Changes
-  を新規作成
  -  のテスト（優先順位検索、ビルトインフォールバック）
  -  のテスト（ファイル検索順序、ビルトインフォールバック）
-  を新規作成
  -  のテスト（ビルトイン/YAML読み込み）
  -  のテスト（テンプレート変数展開）
-  を新規作成
  -  のテスト（ヘッダー/ステップ/フッター生成）
  -  のテスト（ファイル書き出し）

## Testing
- `./scripts/test.sh` 全585テストがパス
- `./scripts/test.sh --shellcheck` パス
- 新規テスト計93テストケースを追加

## Notes
- 既存の `test/lib/*.bats` のパターンに従って実装
- `workflow.bats` との重複を避け、個別ライブラリの単体テストに集中