### PR TITLE
feat: 複数コーディングエージェント対応（pi, Claude Code, OpenCode等）

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ GitHub Issueを入力として、Git worktreeを作成し、tmuxセッション�
 
 ## 特徴
 
+- **マルチエージェント対応**: Pi、Claude Code、OpenCode、カスタムエージェントに対応
 - **自動worktree作成**: Issue番号からブランチ名を自動生成
-- **tmux統合**: バックグラウンドでpiを実行、いつでもアタッチ可能
+- **tmux統合**: バックグラウンドでエージェントを実行、いつでもアタッチ可能
 - **並列作業**: 複数のIssueを同時に処理
 - **簡単なクリーンアップ**: セッションとworktreeを一括削除
 - **自動クリーンアップ**: タスク完了時に `###TASK_COMPLETE_<issue_number>###` マーカーを出力すると、外部プロセスが自動的にworktreeとセッションをクリーンアップします
@@ -127,7 +128,9 @@ scripts/run.sh 42 --reattach
 # 既存セッション/worktreeを削除して再作成
 scripts/run.sh 42 --force
 
-# piに追加の引数を渡す
+# エージェントに追加の引数を渡す
+scripts/run.sh 42 --agent-args "--verbose"
+# または従来のオプション（後方互換性）
 scripts/run.sh 42 --pi-args "--verbose"
 ```
 
@@ -167,10 +170,44 @@ tmux:
   session_prefix: "pi"
   start_in_session: true
 
-# pi設定
+# pi設定（後方互換性あり）
 pi:
   command: "pi"
   args: []
+
+# エージェント設定（複数エージェント対応）
+agent:
+  type: pi  # pi, claude, opencode, custom
+  # command: /custom/path/pi
+  # args:
+  #   - --verbose
+```
+
+### 複数エージェント対応
+
+Pi以外のコーディングエージェントを使用できます：
+
+```yaml
+# Claude Codeを使用
+agent:
+  type: claude
+
+# OpenCodeを使用
+agent:
+  type: opencode
+
+# カスタムエージェント
+agent:
+  type: custom
+  command: my-agent
+  template: '{{command}} {{args}} --file "{{prompt_file}}"'
+```
+
+環境変数でも設定可能：
+
+```bash
+# Claude Codeを一時的に使用
+PI_RUNNER_AGENT_TYPE=claude scripts/run.sh 42
 ```
 
 ## ワークフロー例

--- a/docs/plans/issue-328-plan.md
+++ b/docs/plans/issue-328-plan.md
@@ -1,0 +1,196 @@
+# 実装計画: Issue #328 - 複数コーディングエージェント対応
+
+## 概要
+
+現在 `pi` コマンド専用の実行ロジックを汎用化し、Claude Code、OpenCode等の他のコーディングエージェントでも動作するようにする。
+
+## 影響範囲
+
+### 変更が必要なファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `lib/agent.sh` | **新規作成** - エージェント実行ロジック |
+| `lib/config.sh` | `agent` セクションのパース追加 |
+| `scripts/run.sh` | コマンド生成を `agent.sh` に委譲 |
+| `docs/configuration.md` | `agent` 設定の説明追加 |
+| `README.md` | マルチエージェント対応の説明追加 |
+| `test/lib/agent.bats` | **新規作成** - agent.sh のテスト |
+| `test/lib/config.bats` | agent設定のテスト追加 |
+
+### 新規作成ファイル
+
+| ファイル | 目的 |
+|---------|------|
+| `lib/agent.sh` | エージェント実行コマンドの生成 |
+| `test/lib/agent.bats` | agent.sh のBatsテスト |
+
+## 実装ステップ
+
+### Step 1: lib/agent.sh の作成
+
+1. プリセット定義（pi, claude, opencode）
+2. コマンド生成関数 `build_agent_command`
+3. プリセット取得関数 `get_agent_preset`
+4. 設定からエージェント情報を取得する関数
+
+**プリセット定義:**
+```bash
+# pi プリセット
+AGENT_PRESET_PI_COMMAND="pi"
+AGENT_PRESET_PI_PROMPT_STYLE="@file"
+AGENT_PRESET_PI_TEMPLATE='{{command}} {{args}} @"{{prompt_file}}"'
+
+# claude プリセット
+AGENT_PRESET_CLAUDE_COMMAND="claude"
+AGENT_PRESET_CLAUDE_PROMPT_STYLE="positional"
+AGENT_PRESET_CLAUDE_TEMPLATE='{{command}} {{args}} --print "{{prompt_file}}"'
+
+# opencode プリセット
+AGENT_PRESET_OPENCODE_COMMAND="opencode"
+AGENT_PRESET_OPENCODE_PROMPT_STYLE="stdin"
+AGENT_PRESET_OPENCODE_TEMPLATE='cat "{{prompt_file}}" | {{command}} {{args}}'
+```
+
+**主要関数:**
+```bash
+# エージェント実行コマンドを構築
+build_agent_command() {
+    local prompt_file="$1"
+    local extra_args="$2"
+    # 設定からテンプレートを取得し、変数を置換
+}
+
+# プリセット情報を取得
+get_agent_preset() {
+    local preset_name="$1"
+    # プリセット情報を返す
+}
+```
+
+### Step 2: lib/config.sh の拡張
+
+1. `agent` セクションのパース追加
+2. 新しい設定変数の追加:
+   - `CONFIG_AGENT_TYPE` (pi | claude | opencode | custom)
+   - `CONFIG_AGENT_COMMAND`
+   - `CONFIG_AGENT_PROMPT_STYLE`
+   - `CONFIG_AGENT_TEMPLATE`
+   - `CONFIG_AGENT_ARGS`
+3. 既存の `pi` セクションを後方互換として維持
+
+**設定の優先順位:**
+1. `agent` セクションが設定されている場合、それを使用
+2. `agent` セクションがない場合、`pi` セクションにフォールバック
+
+### Step 3: scripts/run.sh の修正
+
+1. `lib/agent.sh` の読み込み追加
+2. コマンド生成を `build_agent_command` に委譲
+3. 既存の pi 固有コード削除
+
+**変更前:**
+```bash
+local full_command="$pi_command $pi_args $extra_pi_args @\"$prompt_file\""
+```
+
+**変更後:**
+```bash
+local full_command
+full_command="$(build_agent_command "$prompt_file" "$extra_pi_args")"
+```
+
+### Step 4: テスト作成
+
+1. `test/lib/agent.bats` 新規作成
+   - プリセット取得テスト
+   - コマンド生成テスト
+   - カスタムテンプレートテスト
+2. `test/lib/config.bats` 拡張
+   - agent設定のパーステスト
+
+### Step 5: ドキュメント更新
+
+1. `docs/configuration.md` に `agent` セクションの説明追加
+2. `README.md` にマルチエージェント対応の概要追加
+
+## テスト方針
+
+### ユニットテスト
+
+| テストケース | 説明 |
+|------------|------|
+| `build_agent_command returns pi preset command` | piプリセットのコマンド生成 |
+| `build_agent_command returns claude preset command` | claudeプリセットのコマンド生成 |
+| `build_agent_command returns opencode preset command` | opencodeプリセットのコマンド生成 |
+| `build_agent_command uses custom template` | カスタムテンプレートの使用 |
+| `get_agent_preset returns correct values` | プリセット値の取得 |
+| `config parses agent section` | agent設定のパース |
+| `config falls back to pi section` | pi設定へのフォールバック |
+
+### 統合テスト
+
+| テストケース | 説明 |
+|------------|------|
+| `run.sh uses agent config` | run.shでagent設定が反映される |
+| `run.sh falls back to pi when no agent config` | agent設定なし時のフォールバック |
+
+## リスクと対策
+
+### リスク1: 後方互換性の破壊
+
+**対策:** 
+- `pi` セクションの既存設定を維持
+- `agent` セクションが未設定の場合は従来どおり `pi` セクションを使用
+- テストで後方互換性を検証
+
+### リスク2: 各エージェントの実際のコマンド構文が不明確
+
+**対策:**
+- プリセットは一般的な構文で定義
+- `custom` タイプで任意のテンプレートを指定可能
+- ドキュメントに調査結果と注意事項を記載
+
+### リスク3: 完了マーカーの互換性
+
+**対策:**
+- 完了マーカーはプロンプトで指示する形式なので、どのエージェントでも対応可能と想定
+- 動作確認ができない場合はドキュメントに制限事項を記載
+
+## 設定例
+
+### 最小構成（後方互換）
+
+```yaml
+# 既存の設定のまま動作
+pi:
+  command: pi
+```
+
+### 新規構成（agent セクション使用）
+
+```yaml
+# Claude Code を使用
+agent:
+  type: claude
+
+# OpenCode を使用
+agent:
+  type: opencode
+
+# カスタムエージェント
+agent:
+  type: custom
+  command: my-agent
+  template: '{{command}} --prompt "{{prompt_file}}" {{args}}'
+```
+
+## 完了条件
+
+- [ ] `lib/agent.sh` が作成され、全プリセットが定義されている
+- [ ] `lib/config.sh` で `agent` セクションがパースできる
+- [ ] `scripts/run.sh` が `agent.sh` を使用してコマンドを生成する
+- [ ] 既存の `pi` 設定のみの場合も正常に動作する（後方互換）
+- [ ] Batsテストが全てパスする
+- [ ] ドキュメントが更新されている
+- [ ] ShellCheckでエラーがない

--- a/lib/agent.sh
+++ b/lib/agent.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# agent.sh - エージェント実行ロジック
+# 複数のコーディングエージェント（pi, Claude Code, OpenCode等）に対応
+
+# Note: set -euo pipefail はsource先の環境に影響するため、
+# このファイルでは設定しない（呼び出し元で設定）
+
+_AGENT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_AGENT_LIB_DIR/config.sh"
+source "$_AGENT_LIB_DIR/log.sh"
+
+# ======================
+# プリセット定義（Bash 3.x互換）
+# ======================
+
+# プリセット情報を取得
+# 引数:
+#   $1 - preset_name: プリセット名 (pi | claude | opencode)
+#   $2 - key: 取得するキー (command | prompt_style | template)
+# 出力: 対応する値
+get_agent_preset() {
+    local preset_name="$1"
+    local key="$2"
+    
+    case "$preset_name" in
+        pi)
+            case "$key" in
+                command)
+                    echo "pi"
+                    ;;
+                prompt_style)
+                    echo "@file"
+                    ;;
+                template)
+                    echo '{{command}} {{args}} @"{{prompt_file}}"'
+                    ;;
+            esac
+            ;;
+        claude)
+            case "$key" in
+                command)
+                    echo "claude"
+                    ;;
+                prompt_style)
+                    echo "print"
+                    ;;
+                template)
+                    echo '{{command}} {{args}} --print "{{prompt_file}}"'
+                    ;;
+            esac
+            ;;
+        opencode)
+            case "$key" in
+                command)
+                    echo "opencode"
+                    ;;
+                prompt_style)
+                    echo "stdin"
+                    ;;
+                template)
+                    echo 'cat "{{prompt_file}}" | {{command}} {{args}}'
+                    ;;
+            esac
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+# プリセットが存在するか確認
+# 引数:
+#   $1 - preset_name: プリセット名
+# 戻り値: 0=存在する, 1=存在しない
+preset_exists() {
+    local preset_name="$1"
+    
+    case "$preset_name" in
+        pi|claude|opencode)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# ======================
+# エージェント設定取得
+# ======================
+
+# エージェントタイプを取得
+# 設定の優先順位:
+#   1. agent.type が設定されている場合、それを使用
+#   2. agent セクションがない場合、"pi" にフォールバック
+get_agent_type() {
+    local agent_type
+    agent_type="$(get_config agent_type)"
+    
+    if [[ -n "$agent_type" ]]; then
+        echo "$agent_type"
+    else
+        # フォールバック: デフォルトは "pi"
+        echo "pi"
+    fi
+}
+
+# エージェントコマンドを取得
+# 設定の優先順位:
+#   1. agent.command が設定されている場合、それを使用
+#   2. agent.type が明示的に設定されている場合、プリセットを使用
+#   3. pi.command にフォールバック
+get_agent_command() {
+    local agent_command
+    agent_command="$(get_config agent_command)"
+    
+    if [[ -n "$agent_command" ]]; then
+        echo "$agent_command"
+    else
+        # agent.type が明示的に設定されているかチェック
+        local agent_type_config
+        agent_type_config="$(get_config agent_type)"
+        
+        if [[ -n "$agent_type_config" ]]; then
+            # agent.type が明示的に設定されている場合、プリセットを使用
+            if [[ "$agent_type_config" != "custom" ]] && preset_exists "$agent_type_config"; then
+                get_agent_preset "$agent_type_config" "command"
+            else
+                # custom タイプだが command が未設定の場合、pi.command にフォールバック
+                get_config pi_command
+            fi
+        else
+            # agent.type が未設定の場合、pi.command にフォールバック
+            get_config pi_command
+        fi
+    fi
+}
+
+# エージェントの追加引数を取得
+# 設定の優先順位:
+#   1. agent.args が設定されている場合、それを使用
+#   2. pi.args にフォールバック
+get_agent_args() {
+    local agent_args
+    agent_args="$(get_config agent_args)"
+    
+    if [[ -n "$agent_args" ]]; then
+        echo "$agent_args"
+    else
+        # フォールバック: pi.args
+        get_config pi_args
+    fi
+}
+
+# エージェントのテンプレートを取得
+# 設定の優先順位:
+#   1. agent.template が設定されている場合、それを使用
+#   2. agent.type が明示的に設定されている場合、プリセットを使用
+#   3. pi プリセットにフォールバック（後方互換性）
+get_agent_template() {
+    local agent_template
+    agent_template="$(get_config agent_template)"
+    
+    if [[ -n "$agent_template" ]]; then
+        echo "$agent_template"
+    else
+        # agent.type が明示的に設定されているかチェック
+        local agent_type_config
+        agent_type_config="$(get_config agent_type)"
+        
+        if [[ -n "$agent_type_config" ]] && preset_exists "$agent_type_config"; then
+            get_agent_preset "$agent_type_config" "template"
+        else
+            # agent.type が未設定または不明な場合、pi プリセットにフォールバック
+            get_agent_preset "pi" "template"
+        fi
+    fi
+}
+
+# ======================
+# コマンド生成関数
+# ======================
+
+# テンプレート変数を置換
+# 引数:
+#   $1 - template: テンプレート文字列
+#   $2 - command: コマンド
+#   $3 - args: 引数
+#   $4 - prompt_file: プロンプトファイルパス
+# 出力: 置換後の文字列
+_substitute_template() {
+    local template="$1"
+    local command="$2"
+    local args="$3"
+    local prompt_file="$4"
+    
+    local result="$template"
+    result="${result//\{\{command\}\}/$command}"
+    result="${result//\{\{args\}\}/$args}"
+    result="${result//\{\{prompt_file\}\}/$prompt_file}"
+    
+    echo "$result"
+}
+
+# エージェント実行コマンドを構築
+# 引数:
+#   $1 - prompt_file: プロンプトファイルのパス
+#   $2 - extra_args: 追加の引数（オプション）
+# 出力: 実行コマンド文字列
+build_agent_command() {
+    local prompt_file="$1"
+    local extra_args="${2:-}"
+    
+    local command
+    command="$(get_agent_command)"
+    
+    local args
+    args="$(get_agent_args)"
+    
+    # extra_args を追加
+    if [[ -n "$extra_args" ]]; then
+        if [[ -n "$args" ]]; then
+            args="$args $extra_args"
+        else
+            args="$extra_args"
+        fi
+    fi
+    
+    local template
+    template="$(get_agent_template)"
+    
+    local full_command
+    full_command="$(_substitute_template "$template" "$command" "$args" "$prompt_file")"
+    
+    log_debug "Agent type: $(get_agent_type)"
+    log_debug "Agent command: $command"
+    log_debug "Agent args: $args"
+    log_debug "Agent template: $template"
+    log_debug "Full command: $full_command"
+    
+    echo "$full_command"
+}
+
+# ======================
+# ユーティリティ関数
+# ======================
+
+# 利用可能なプリセット一覧を表示
+list_agent_presets() {
+    echo "Available agent presets:"
+    echo "  pi       - Pi coding agent (@file syntax)"
+    echo "  claude   - Claude Code (--print option)"
+    echo "  opencode - OpenCode (stdin)"
+    echo "  custom   - Custom agent (requires template)"
+}
+
+# エージェント設定を表示（デバッグ用）
+show_agent_config() {
+    echo "=== Agent Configuration ==="
+    echo "type: $(get_agent_type)"
+    echo "command: $(get_agent_command)"
+    echo "args: $(get_agent_args)"
+    echo "template: $(get_agent_template)"
+}

--- a/test/lib/agent.bats
+++ b/test/lib/agent.bats
@@ -1,0 +1,335 @@
+#!/usr/bin/env bats
+# agent.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    # TMPDIRセットアップ
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # 設定をリセット
+    unset _CONFIG_LOADED
+    unset CONFIG_AGENT_TYPE
+    unset CONFIG_AGENT_COMMAND
+    unset CONFIG_AGENT_ARGS
+    unset CONFIG_AGENT_TEMPLATE
+    unset CONFIG_PI_COMMAND
+    unset CONFIG_PI_ARGS
+    unset PI_RUNNER_AGENT_TYPE
+    unset PI_RUNNER_AGENT_COMMAND
+    unset PI_RUNNER_AGENT_ARGS
+    unset PI_RUNNER_AGENT_TEMPLATE
+    
+    # テスト用の空の設定ファイルパスを作成
+    export TEST_CONFIG_FILE="${BATS_TEST_TMPDIR}/empty-config.yaml"
+    touch "$TEST_CONFIG_FILE"
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# プリセット取得テスト
+# ====================
+
+@test "get_agent_preset returns pi command" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_preset "pi" "command")"
+    [ "$result" = "pi" ]
+}
+
+@test "get_agent_preset returns pi template" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_preset "pi" "template")"
+    [[ "$result" == *'@"{{prompt_file}}"'* ]]
+}
+
+@test "get_agent_preset returns claude command" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_preset "claude" "command")"
+    [ "$result" = "claude" ]
+}
+
+@test "get_agent_preset returns claude template with --print" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_preset "claude" "template")"
+    [[ "$result" == *'--print'* ]]
+}
+
+@test "get_agent_preset returns opencode command" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_preset "opencode" "command")"
+    [ "$result" = "opencode" ]
+}
+
+@test "get_agent_preset returns opencode template with stdin" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_preset "opencode" "template")"
+    [[ "$result" == *'cat'* ]]
+}
+
+@test "get_agent_preset returns empty for unknown preset" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_preset "unknown" "command")"
+    [ -z "$result" ]
+}
+
+# ====================
+# preset_exists テスト
+# ====================
+
+@test "preset_exists returns 0 for pi" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    preset_exists "pi"
+}
+
+@test "preset_exists returns 0 for claude" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    preset_exists "claude"
+}
+
+@test "preset_exists returns 0 for opencode" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    preset_exists "opencode"
+}
+
+@test "preset_exists returns 1 for unknown" {
+    source "$PROJECT_ROOT/lib/agent.sh"
+    ! preset_exists "unknown"
+}
+
+# ====================
+# get_agent_type テスト
+# ====================
+
+@test "get_agent_type returns pi as default" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_type)"
+    [ "$result" = "pi" ]
+}
+
+@test "get_agent_type returns configured type" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: claude
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_type)"
+    [ "$result" = "claude" ]
+}
+
+# ====================
+# get_agent_command テスト
+# ====================
+
+@test "get_agent_command returns pi for default" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_command)"
+    [ "$result" = "pi" ]
+}
+
+@test "get_agent_command returns claude preset command" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: claude
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_command)"
+    [ "$result" = "claude" ]
+}
+
+@test "get_agent_command returns custom command" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: custom
+  command: my-agent
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_command)"
+    [ "$result" = "my-agent" ]
+}
+
+@test "get_agent_command falls back to pi.command" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+pi:
+  command: /usr/local/bin/pi
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_command)"
+    [ "$result" = "/usr/local/bin/pi" ]
+}
+
+# ====================
+# get_agent_template テスト
+# ====================
+
+@test "get_agent_template returns pi template by default" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_template)"
+    [[ "$result" == *'@"{{prompt_file}}"'* ]]
+}
+
+@test "get_agent_template returns claude template" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: claude
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_template)"
+    [[ "$result" == *'--print'* ]]
+}
+
+@test "get_agent_template returns custom template" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: custom
+  template: '{{command}} --custom {{prompt_file}}'
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_template)"
+    [[ "$result" == *'--custom'* ]]
+}
+
+# ====================
+# build_agent_command テスト
+# ====================
+
+@test "build_agent_command generates pi command" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(build_agent_command "/path/to/prompt.md" "")"
+    [[ "$result" == *'pi'* ]]
+    [[ "$result" == *'@"/path/to/prompt.md"'* ]]
+}
+
+@test "build_agent_command generates claude command" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: claude
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(build_agent_command "/path/to/prompt.md" "")"
+    [[ "$result" == *'claude'* ]]
+    [[ "$result" == *'--print'* ]]
+}
+
+@test "build_agent_command generates opencode command" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: opencode
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(build_agent_command "/path/to/prompt.md" "")"
+    [[ "$result" == *'cat'* ]]
+    [[ "$result" == *'opencode'* ]]
+}
+
+@test "build_agent_command includes extra args" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(build_agent_command "/path/to/prompt.md" "--verbose")"
+    [[ "$result" == *'--verbose'* ]]
+}
+
+@test "build_agent_command includes config args and extra args" {
+    local test_config="${BATS_TEST_TMPDIR}/agent-config.yaml"
+    cat > "$test_config" << 'EOF'
+agent:
+  type: pi
+  args:
+    - "--model"
+    - "gpt-4"
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(build_agent_command "/path/to/prompt.md" "--verbose")"
+    [[ "$result" == *'--model'* ]]
+    [[ "$result" == *'gpt-4'* ]]
+    [[ "$result" == *'--verbose'* ]]
+}
+
+# ====================
+# 後方互換性テスト
+# ====================
+
+@test "pi.command is used when agent section is not configured" {
+    local test_config="${BATS_TEST_TMPDIR}/pi-only-config.yaml"
+    cat > "$test_config" << 'EOF'
+pi:
+  command: /custom/pi
+  args:
+    - "--custom-arg"
+EOF
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$test_config"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    
+    # コマンドがpi.commandにフォールバックする
+    result="$(get_agent_command)"
+    [ "$result" = "/custom/pi" ]
+    
+    # 引数がpi.argsにフォールバックする
+    args="$(get_agent_args)"
+    [ "$args" = "--custom-arg" ]
+}
+
+# ====================
+# 環境変数オーバーライドテスト
+# ====================
+
+@test "environment variable overrides agent_type" {
+    export PI_RUNNER_AGENT_TYPE="opencode"
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_type)"
+    [ "$result" = "opencode" ]
+}
+
+@test "environment variable overrides agent_command" {
+    export PI_RUNNER_AGENT_COMMAND="/custom/agent"
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    source "$PROJECT_ROOT/lib/agent.sh"
+    result="$(get_agent_command)"
+    [ "$result" = "/custom/agent" ]
+}


### PR DESCRIPTION
## Summary
Closes #328

## Changes

### 新機能: マルチエージェント対応
pi以外のコーディングエージェント（Claude Code, OpenCode, カスタム）にも対応しました。

### 追加ファイル
- `lib/agent.sh`: エージェント実行ロジック（プリセット定義、コマンド生成）
- `test/lib/agent.bats`: agent.shのテスト（28テストケース）

### 変更ファイル
- `lib/config.sh`: `agent` セクションのパース追加
- `scripts/run.sh`: `agent.sh`を使用したコマンド生成に変更
- `docs/configuration.md`: エージェント設定のドキュメント追加
- `README.md`: マルチエージェント対応の説明追加

### 設定例
```yaml
# Claude Codeを使用
agent:
  type: claude

# OpenCodeを使用
agent:
  type: opencode

# カスタムエージェント
agent:
  type: custom
  command: my-agent
  template: '{{command}} {{args}} --file "{{prompt_file}}"'
```

### 後方互換性
- `agent` セクションが未設定の場合、従来どおり `pi` セクションの設定を使用
- `--pi-args` オプションは `--agent-args` のエイリアスとして引き続き動作

## Testing
- 新規テスト28件追加（test/lib/agent.bats）
- 既存テスト17件拡張（test/lib/config.bats）
- ShellCheck警告なし
- 全テストパス

## Checklist
- [x] コードは既存のスタイルに従っている
- [x] 適切なテストが追加されている
- [x] ドキュメントが更新されている
- [x] 後方互換性が維持されている