### PR TITLE
docs: ディレクトリ構造の記載が実際のファイルと不一致

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ pi-issue-runner/
 │   ├── watch-session.sh  # セッション監視
 │   └── test.sh        # テスト一括実行
 ├── lib/               # 共通ライブラリ
+│   ├── agent.sh       # マルチエージェント対応
 │   ├── config.sh      # 設定読み込み
 │   ├── github.sh      # GitHub CLI操作
 │   ├── hooks.sh       # Hook機能
@@ -58,6 +59,7 @@ pi-issue-runner/
 ├── docs/              # ドキュメント
 ├── test/              # Batsテスト（*.bats形式）
 │   ├── lib/           # ライブラリのユニットテスト
+│   │   ├── agent.bats
 │   │   ├── config.bats
 │   │   ├── github.bats
 │   │   ├── hooks.bats
@@ -67,6 +69,9 @@ pi-issue-runner/
 │   │   ├── template.bats
 │   │   ├── tmux.bats
 │   │   ├── workflow.bats
+│   │   ├── workflow-finder.bats
+│   │   ├── workflow-loader.bats
+│   │   ├── workflow-prompt.bats
 │   │   ├── worktree.bats
 │   │   └── yaml.bats
 │   ├── scripts/       # スクリプトの統合テスト

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ pi-issue-runner/
 │   ├── init.sh             # プロジェクト初期化
 │   └── test.sh             # テスト一括実行
 ├── lib/
+│   ├── agent.sh            # マルチエージェント対応
 │   ├── config.sh           # 設定読み込み
 │   ├── github.sh           # GitHub API操作
 │   ├── hooks.sh            # イベントhook機能
@@ -368,6 +369,9 @@ pi-issue-runner/
 │   ├── status.sh           # ステータスファイル管理
 │   ├── template.sh         # テンプレート処理
 │   ├── tmux.sh             # tmux操作
+│   ├── workflow-finder.sh  # ワークフロー検索
+│   ├── workflow-loader.sh  # ワークフロー読み込み
+│   ├── workflow-prompt.sh  # プロンプト処理
 │   ├── workflow.sh         # ワークフローエンジン
 │   ├── worktree.sh         # Git worktree操作
 │   └── yaml.sh             # YAMLパーサー
@@ -427,6 +431,7 @@ bats --tap test/lib/*.bats
 ```
 test/
 ├── lib/                         # ライブラリのユニットテスト
+│   ├── agent.bats               # agent.sh のテスト
 │   ├── config.bats              # config.sh のテスト
 │   ├── github.bats              # github.sh のテスト
 │   ├── hooks.bats               # hooks.sh のテスト
@@ -435,6 +440,9 @@ test/
 │   ├── status.bats              # status.sh のテスト
 │   ├── template.bats            # template.sh のテスト
 │   ├── tmux.bats                # tmux.sh のテスト
+│   ├── workflow-finder.bats     # workflow-finder.sh のテスト
+│   ├── workflow-loader.bats     # workflow-loader.sh のテスト
+│   ├── workflow-prompt.bats     # workflow-prompt.sh のテスト
 │   ├── workflow.bats            # workflow.sh のテスト
 │   ├── worktree.bats            # worktree.sh のテスト
 │   └── yaml.bats                # yaml.sh のテスト

--- a/docs/plans/issue-337-plan.md
+++ b/docs/plans/issue-337-plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Issue #337
+
+## 概要
+
+README.md と AGENTS.md のディレクトリ構造の記載を実際のファイル構造と一致させる。
+
+## 発見された不一致
+
+### 実際のファイル構造（lib/）
+
+```
+lib/
+├── agent.sh              # ← ドキュメントに記載なし
+├── config.sh
+├── github.sh
+├── hooks.sh
+├── log.sh
+├── notify.sh
+├── status.sh
+├── template.sh
+├── tmux.sh
+├── workflow-finder.sh    # ← README.md に記載なし
+├── workflow-loader.sh    # ← README.md に記載なし
+├── workflow-prompt.sh    # ← README.md に記載なし
+├── workflow.sh
+├── worktree.sh
+└── yaml.sh
+```
+
+### 実際のファイル構造（test/lib/）
+
+```
+test/lib/
+├── agent.bats            # ← ドキュメントに記載なし
+├── config.bats
+├── github.bats
+├── hooks.bats
+├── log.bats
+├── notify.bats
+├── status.bats
+├── template.bats
+├── tmux.bats
+├── workflow-finder.bats  # ← ドキュメントに記載なし
+├── workflow-loader.bats  # ← ドキュメントに記載なし
+├── workflow-prompt.bats  # ← ドキュメントに記載なし
+├── workflow.bats
+├── worktree.bats
+└── yaml.bats
+```
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|----------|----------|
+| README.md | lib/ に4ファイル追加、test/lib/ に4ファイル追加 |
+| AGENTS.md | lib/ に1ファイル追加、test/lib/ に4ファイル追加 |
+
+## 実装ステップ
+
+1. **README.md の修正**
+   - lib/ セクションに `agent.sh`, `workflow-finder.sh`, `workflow-loader.sh`, `workflow-prompt.sh` を追加
+   - test/lib/ セクションに `agent.bats`, `workflow-finder.bats`, `workflow-loader.bats`, `workflow-prompt.bats` を追加
+
+2. **AGENTS.md の修正**
+   - lib/ セクションに `agent.sh` を追加
+   - test/lib/ セクションに `agent.bats`, `workflow-finder.bats`, `workflow-loader.bats`, `workflow-prompt.bats` を追加
+
+3. **ファイル順序**
+   - アルファベット順を維持（既存のスタイルに合わせる）
+
+## テスト方針
+
+- ドキュメント変更のみのため、自動テストは不要
+- 変更後のディレクトリ構造が実際のファイルと一致することを手動で確認
+
+## リスクと対策
+
+- **リスク**: 将来的に同様の不整合が発生する可能性
+- **対策**: Issue内で提案された通り、将来的にファイル構造チェックスクリプトの追加を検討（本Issueの範囲外）


### PR DESCRIPTION
## Summary
Closes #337

## Changes
- README.md の lib/ セクションに agent.sh, workflow-finder.sh, workflow-loader.sh, workflow-prompt.sh を追加
- README.md の test/lib/ セクションに agent.bats, workflow-finder.bats, workflow-loader.bats, workflow-prompt.bats を追加
- AGENTS.md の lib/ セクションに agent.sh を追加
- AGENTS.md の test/lib/ セクションに agent.bats, workflow-finder.bats, workflow-loader.bats, workflow-prompt.bats を追加

## Testing
- 変更後のディレクトリ構造記載と実際のファイル構造の一致を手動確認
- 全ての lib/*.sh と test/lib/*.bats が README.md と AGENTS.md に記載されていることを確認