### PR TITLE
docs: add cleanup-orphans.sh and cleanup-plans.sh to lib/ directory structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ pi-issue-runner/
 │   └── test.sh        # テスト一括実行
 ├── lib/               # 共通ライブラリ
 │   ├── agent.sh       # マルチエージェント対応
+│   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
+│   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定読み込み
 │   ├── github.sh      # GitHub CLI操作
 │   ├── hooks.sh       # Hook機能

--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ pi-issue-runner/
 │   └── test.sh             # テスト一括実行
 ├── lib/
 │   ├── agent.sh            # マルチエージェント対応
+│   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
+│   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh           # 設定読み込み
 │   ├── github.sh           # GitHub API操作
 │   ├── hooks.sh            # イベントhook機能

--- a/docs/plans/issue-354-plan.md
+++ b/docs/plans/issue-354-plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: Issue #354
+
+## 概要
+
+AGENTS.md および README.md の lib/ ディレクトリ構造セクションに、欠落している2つのファイル（`cleanup-orphans.sh` と `cleanup-plans.sh`）の記載を追加する。
+
+## 影響範囲
+
+- `AGENTS.md` - ディレクトリ構造セクション（35行目付近）
+- `README.md` - ディレクトリ構造セクション（362行目付近）
+
+## 実装ステップ
+
+### 1. AGENTS.md の修正
+
+lib/ セクション内で、`agent.sh` の後、`config.sh` の前に以下の2行を追加:
+```
+│   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
+│   ├── cleanup-plans.sh    # 計画書のローテーション
+```
+
+### 2. README.md の修正
+
+lib/ セクション内で、`agent.sh` の後、`config.sh` の前に以下の2行を追加:
+```
+│   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
+│   ├── cleanup-plans.sh    # 計画書のローテーション
+```
+
+## テスト方針
+
+- ドキュメントの変更のみのため、単体テストは不要
+- 視覚的な確認でフォーマットの一貫性を確認
+
+## リスクと対策
+
+- **リスク**: 他のドキュメントにも同様の構造がある可能性
+- **対策**: grep で確認済み、AGENTS.md と README.md のみが対象
+
+## 見積もり
+
+約15分


### PR DESCRIPTION
## Summary
Closes #354

## Changes
- Added `cleanup-orphans.sh` to lib/ directory structure in AGENTS.md and README.md
- Added `cleanup-plans.sh` to lib/ directory structure in AGENTS.md and README.md
- Each file has an accurate description of its role

## Testing
- Documentation changes only - verified format consistency with existing entries
- Verified that both files exist in lib/ directory