### PR TITLE
test: lib/cleanup-orphans.sh と lib/cleanup-plans.sh のユニットテスト追加

### DIFF
--- a/docs/plans/issue-365-plan.md
+++ b/docs/plans/issue-365-plan.md
@@ -1,0 +1,61 @@
+# Issue #365 実装計画書
+
+## 概要
+
+`lib/cleanup-orphans.sh` と `lib/cleanup-plans.sh` のユニットテストを追加する。
+
+## 影響範囲
+
+- 新規ファイル:
+  - `test/lib/cleanup-orphans.bats`
+  - `test/lib/cleanup-plans.bats`
+
+## 実装ステップ
+
+### 1. cleanup-orphans.bats の作成
+
+テスト対象: `cleanup_orphaned_statuses` 関数
+
+#### テストケース:
+1. 孤立したステータスファイルがない場合
+2. 孤立したステータスファイルがある場合（削除実行）
+3. dry-run モードで削除せずに表示のみ
+4. age_days オプション指定時に古いファイルのみ対象
+
+#### 依存関係:
+- `lib/status.sh` の `find_orphaned_statuses`, `find_stale_statuses`, `remove_status`
+
+### 2. cleanup-plans.bats の作成
+
+テスト対象:
+- `cleanup_old_plans` 関数
+- `cleanup_closed_issue_plans` 関数
+
+#### cleanup_old_plans テストケース:
+1. 計画書がない場合
+2. 保持件数以下の場合（削除なし）
+3. 保持件数を超える場合（古いファイルを削除）
+4. dry-run モード
+5. keep_count=0 の場合（全て保持）
+
+#### cleanup_closed_issue_plans テストケース:
+1. 計画書がない場合
+2. クローズされたIssueの計画書を削除
+3. オープンなIssueの計画書は保持
+4. dry-run モード
+5. gh コマンドがない場合のエラー
+
+## テスト方針
+
+- 既存の `test/lib/status.bats` のパターンに従う
+- `test_helper.bash` のセットアップ/ティアダウンを利用
+- モック関数を使用してgh/gitコマンドをモック
+- 一時ディレクトリでファイル操作をテスト
+
+## リスクと対策
+
+- **リスク**: macOS/Linux でファイルの日付変更方法が異なる
+  - **対策**: `touch -t` コマンドを使用（POSIX互換）
+
+- **リスク**: gh CLIのモックが必要
+  - **対策**: `test_helper.bash` の `mock_gh` を拡張または再定義

--- a/test/lib/cleanup-orphans.bats
+++ b/test/lib/cleanup-orphans.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+# cleanup-orphans.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # テスト用worktreeディレクトリを設定
+    export TEST_WORKTREE_DIR="$BATS_TEST_TMPDIR/.worktrees"
+    mkdir -p "$TEST_WORKTREE_DIR/.status"
+    
+    # status.shを先に読み込み
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    # get_config をオーバーライド
+    get_config() {
+        case "$1" in
+            worktree_base_dir) echo "$TEST_WORKTREE_DIR" ;;
+            *) echo "" ;;
+        esac
+    }
+    
+    # cleanup-orphans.shを読み込み
+    source "$PROJECT_ROOT/lib/cleanup-orphans.sh"
+    
+    # ログを抑制
+    LOG_LEVEL="ERROR"
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# cleanup_orphaned_statuses テスト（孤立ファイルなし）
+# ====================
+
+@test "cleanup_orphaned_statuses returns 0 with no orphaned files" {
+    # ステータスファイルなし
+    init_status_dir
+    
+    run cleanup_orphaned_statuses "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No orphaned status files found"* ]]
+}
+
+@test "cleanup_orphaned_statuses handles empty status directory" {
+    init_status_dir
+    
+    run cleanup_orphaned_statuses "false"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# cleanup_orphaned_statuses テスト（孤立ファイルあり）
+# ====================
+
+@test "cleanup_orphaned_statuses removes orphaned status files" {
+    # 孤立したステータスファイルを作成（対応するworktreeなし）
+    save_status "100" "complete" "pi-issue-100"
+    save_status "101" "error" "pi-issue-101"
+    
+    # ファイルが存在することを確認
+    [ -f "$TEST_WORKTREE_DIR/.status/100.json" ]
+    [ -f "$TEST_WORKTREE_DIR/.status/101.json" ]
+    
+    run cleanup_orphaned_statuses "false"
+    [ "$status" -eq 0 ]
+    
+    # 孤立ファイルが削除されたことを確認
+    [ ! -f "$TEST_WORKTREE_DIR/.status/100.json" ]
+    [ ! -f "$TEST_WORKTREE_DIR/.status/101.json" ]
+}
+
+@test "cleanup_orphaned_statuses reports count of removed files" {
+    save_status "200" "complete" "pi-issue-200"
+    save_status "201" "complete" "pi-issue-201"
+    
+    run cleanup_orphaned_statuses "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Removed 2 orphaned status file(s)"* ]]
+}
+
+@test "cleanup_orphaned_statuses preserves files with worktree" {
+    # worktreeディレクトリを作成
+    mkdir -p "$TEST_WORKTREE_DIR/issue-300-with-worktree"
+    
+    # 対応するworktreeがあるステータスファイル
+    save_status "300" "running" "pi-issue-300"
+    
+    # 孤立したステータスファイル（worktreeなし）
+    save_status "301" "complete" "pi-issue-301"
+    
+    run cleanup_orphaned_statuses "false"
+    [ "$status" -eq 0 ]
+    
+    # worktreeがあるファイルは保持
+    [ -f "$TEST_WORKTREE_DIR/.status/300.json" ]
+    # 孤立ファイルは削除
+    [ ! -f "$TEST_WORKTREE_DIR/.status/301.json" ]
+}
+
+# ====================
+# cleanup_orphaned_statuses dry-run テスト
+# ====================
+
+@test "cleanup_orphaned_statuses dry-run does not delete files" {
+    save_status "400" "complete" "pi-issue-400"
+    
+    run cleanup_orphaned_statuses "true"
+    [ "$status" -eq 0 ]
+    
+    # dry-runなのでファイルは残っている
+    [ -f "$TEST_WORKTREE_DIR/.status/400.json" ]
+}
+
+@test "cleanup_orphaned_statuses dry-run outputs DRY-RUN message" {
+    save_status "401" "complete" "pi-issue-401"
+    
+    run cleanup_orphaned_statuses "true"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN]"* ]]
+}
+
+@test "cleanup_orphaned_statuses dry-run reports would-remove count" {
+    save_status "402" "complete" "pi-issue-402"
+    save_status "403" "complete" "pi-issue-403"
+    
+    run cleanup_orphaned_statuses "true"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Would remove"* ]] || [[ "$output" == *"Would remove 2 orphaned status file(s)"* ]]
+}
+
+# ====================
+# cleanup_orphaned_statuses age_days テスト
+# ====================
+
+@test "cleanup_orphaned_statuses with age_days filters new files" {
+    # 新しいステータスファイルを作成
+    save_status "500" "complete" "pi-issue-500"
+    
+    # 7日より古いファイルを対象（新しいファイルは対象外）
+    run cleanup_orphaned_statuses "false" "7"
+    [ "$status" -eq 0 ]
+    
+    # 新しいファイルは削除されない
+    [ -f "$TEST_WORKTREE_DIR/.status/500.json" ]
+}
+
+@test "cleanup_orphaned_statuses with age_days removes old files" {
+    # 古いステータスファイルを作成
+    save_status "501" "complete" "pi-issue-501"
+    # ファイルのタイムスタンプを過去に変更（2020年1月1日）
+    touch -t 202001010000 "$TEST_WORKTREE_DIR/.status/501.json"
+    
+    # 1日より古いファイルを対象
+    run cleanup_orphaned_statuses "false" "1"
+    [ "$status" -eq 0 ]
+    
+    # 古いファイルは削除される
+    [ ! -f "$TEST_WORKTREE_DIR/.status/501.json" ]
+}
+
+@test "cleanup_orphaned_statuses with age_days shows appropriate message" {
+    init_status_dir
+    
+    run cleanup_orphaned_statuses "false" "30"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"older than 30 days"* ]] || [[ "$output" == *"No orphaned status files"* ]]
+}
+
+@test "cleanup_orphaned_statuses with age_days dry-run preserves files" {
+    save_status "502" "complete" "pi-issue-502"
+    touch -t 202001010000 "$TEST_WORKTREE_DIR/.status/502.json"
+    
+    run cleanup_orphaned_statuses "true" "1"
+    [ "$status" -eq 0 ]
+    
+    # dry-runなのでファイルは残っている
+    [ -f "$TEST_WORKTREE_DIR/.status/502.json" ]
+}
+
+# ====================
+# エッジケーステスト
+# ====================
+
+@test "cleanup_orphaned_statuses handles default parameters" {
+    save_status "600" "complete" "pi-issue-600"
+    
+    # パラメータなし（デフォルト: dry_run=false, age_days未指定）
+    run cleanup_orphaned_statuses
+    [ "$status" -eq 0 ]
+    
+    # 孤立ファイルは削除される
+    [ ! -f "$TEST_WORKTREE_DIR/.status/600.json" ]
+}
+
+@test "cleanup_orphaned_statuses handles single orphan" {
+    save_status "700" "complete" "pi-issue-700"
+    
+    run cleanup_orphaned_statuses "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Removed 1 orphaned status file(s)"* ]]
+}

--- a/test/lib/cleanup-plans.bats
+++ b/test/lib/cleanup-plans.bats
@@ -1,0 +1,400 @@
+#!/usr/bin/env bats
+# cleanup-plans.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # テスト用ディレクトリ設定
+    export TEST_PLANS_DIR="$BATS_TEST_TMPDIR/docs/plans"
+    mkdir -p "$TEST_PLANS_DIR"
+    
+    # cleanup_closed_issue_plans用のハードコードされたパス（docs/plans）
+    # カレントディレクトリをBATSTESTTMPDIRに変更してテスト
+    export TEST_CWD="$BATS_TEST_TMPDIR"
+    
+    # モックディレクトリ
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    export ORIGINAL_PATH="$PATH"
+    
+    # config.shを読み込み
+    source "$PROJECT_ROOT/lib/config.sh"
+    
+    # get_config をオーバーライド
+    get_config() {
+        case "$1" in
+            plans_dir) echo "$TEST_PLANS_DIR" ;;
+            plans_keep_recent) echo "5" ;;
+            *) echo "" ;;
+        esac
+    }
+    
+    # load_config をオーバーライド（何もしない）
+    load_config() {
+        :
+    }
+    
+    # cleanup-plans.shを読み込み
+    source "$PROJECT_ROOT/lib/cleanup-plans.sh"
+    
+    # ログを抑制
+    LOG_LEVEL="ERROR"
+}
+
+teardown() {
+    # PATHを復元
+    if [[ -n "${ORIGINAL_PATH:-}" ]]; then
+        export PATH="$ORIGINAL_PATH"
+    fi
+    
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# cleanup_old_plans テスト（計画書なし）
+# ====================
+
+@test "cleanup_old_plans returns 0 with no plans" {
+    run cleanup_old_plans "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No plan files found"* ]]
+}
+
+@test "cleanup_old_plans handles non-existent directory" {
+    rm -rf "$TEST_PLANS_DIR"
+    
+    run cleanup_old_plans "false"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# cleanup_old_plans テスト（保持件数以下）
+# ====================
+
+@test "cleanup_old_plans keeps all when under limit" {
+    # 3件の計画書を作成（保持件数5より少ない）
+    touch "$TEST_PLANS_DIR/issue-1-plan.md"
+    touch "$TEST_PLANS_DIR/issue-2-plan.md"
+    touch "$TEST_PLANS_DIR/issue-3-plan.md"
+    
+    run cleanup_old_plans "false"
+    [ "$status" -eq 0 ]
+    
+    # すべてのファイルが保持されている
+    [ -f "$TEST_PLANS_DIR/issue-1-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-2-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-3-plan.md" ]
+}
+
+@test "cleanup_old_plans shows keeping message when under limit" {
+    touch "$TEST_PLANS_DIR/issue-1-plan.md"
+    touch "$TEST_PLANS_DIR/issue-2-plan.md"
+    
+    run cleanup_old_plans "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"keeping all"* ]]
+}
+
+# ====================
+# cleanup_old_plans テスト（保持件数超過）
+# ====================
+
+@test "cleanup_old_plans removes old files when over limit" {
+    # 7件の計画書を作成（時間差をつける）
+    for i in 1 2 3 4 5 6 7; do
+        local file="$TEST_PLANS_DIR/issue-$i-plan.md"
+        echo "Plan $i" > "$file"
+        # タイムスタンプを変えて順序をつける（小さいほど古い）
+        touch -t "20200101000$i" "$file"
+    done
+    
+    # keep_count=3 で実行
+    run cleanup_old_plans "false" "3"
+    [ "$status" -eq 0 ]
+    
+    # 最新3件（issue-5, issue-6, issue-7）は保持
+    [ -f "$TEST_PLANS_DIR/issue-5-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-6-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-7-plan.md" ]
+    
+    # 古い4件（issue-1〜4）は削除
+    [ ! -f "$TEST_PLANS_DIR/issue-1-plan.md" ]
+    [ ! -f "$TEST_PLANS_DIR/issue-2-plan.md" ]
+    [ ! -f "$TEST_PLANS_DIR/issue-3-plan.md" ]
+    [ ! -f "$TEST_PLANS_DIR/issue-4-plan.md" ]
+}
+
+@test "cleanup_old_plans reports deleted count" {
+    for i in 1 2 3 4 5; do
+        local file="$TEST_PLANS_DIR/issue-$i-plan.md"
+        echo "Plan $i" > "$file"
+        touch -t "20200101000$i" "$file"
+    done
+    
+    run cleanup_old_plans "false" "2"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Deleted 3 old plan(s)"* ]]
+}
+
+# ====================
+# cleanup_old_plans dry-run テスト
+# ====================
+
+@test "cleanup_old_plans dry-run does not delete files" {
+    for i in 1 2 3 4 5; do
+        local file="$TEST_PLANS_DIR/issue-$i-plan.md"
+        echo "Plan $i" > "$file"
+        touch -t "20200101000$i" "$file"
+    done
+    
+    run cleanup_old_plans "true" "2"
+    [ "$status" -eq 0 ]
+    
+    # dry-runなので全てのファイルが残っている
+    [ -f "$TEST_PLANS_DIR/issue-1-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-2-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-3-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-4-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-5-plan.md" ]
+}
+
+@test "cleanup_old_plans dry-run outputs DRY-RUN message" {
+    for i in 1 2 3; do
+        local file="$TEST_PLANS_DIR/issue-$i-plan.md"
+        echo "Plan $i" > "$file"
+        touch -t "20200101000$i" "$file"
+    done
+    
+    run cleanup_old_plans "true" "1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN]"* ]]
+}
+
+# ====================
+# cleanup_old_plans keep_count=0 テスト
+# ====================
+
+@test "cleanup_old_plans with keep_count=0 keeps all" {
+    touch "$TEST_PLANS_DIR/issue-1-plan.md"
+    touch "$TEST_PLANS_DIR/issue-2-plan.md"
+    touch "$TEST_PLANS_DIR/issue-3-plan.md"
+    
+    run cleanup_old_plans "false" "0"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"keeping all plans"* ]]
+    
+    # すべてのファイルが保持されている
+    [ -f "$TEST_PLANS_DIR/issue-1-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-2-plan.md" ]
+    [ -f "$TEST_PLANS_DIR/issue-3-plan.md" ]
+}
+
+# ====================
+# cleanup_closed_issue_plans テスト
+# ====================
+
+# ghコマンドのモック（クローズされたIssue）
+mock_gh_closed_issue() {
+    local mock_script="$MOCK_DIR/gh"
+    cat > "$mock_script" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$*" in
+    "issue view 100 --json state -q .state"*)
+        echo "CLOSED"
+        ;;
+    "issue view 101 --json state -q .state"*)
+        echo "OPEN"
+        ;;
+    "issue view 102 --json state -q .state"*)
+        echo "CLOSED"
+        ;;
+    "issue view"*"--json state"*)
+        echo "OPEN"
+        ;;
+    *)
+        echo "OPEN"
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$mock_script"
+}
+
+# cleanup_closed_issue_plans は hardcoded された "docs/plans" を使用
+# テスト用にカレントディレクトリを変更してテスト
+
+@test "cleanup_closed_issue_plans returns 0 with no plans" {
+    mock_gh_closed_issue
+    export PATH="$MOCK_DIR:$PATH"
+    
+    # docs/plans ディレクトリを一時ディレクトリに作成
+    mkdir -p "$BATS_TEST_TMPDIR/docs/plans"
+    
+    cd "$BATS_TEST_TMPDIR"
+    run cleanup_closed_issue_plans "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No plan files found"* ]]
+}
+
+@test "cleanup_closed_issue_plans removes closed issue plans" {
+    mock_gh_closed_issue
+    export PATH="$MOCK_DIR:$PATH"
+    
+    mkdir -p "$BATS_TEST_TMPDIR/docs/plans"
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-100-plan.md"  # CLOSED
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-101-plan.md"  # OPEN
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-102-plan.md"  # CLOSED
+    
+    cd "$BATS_TEST_TMPDIR"
+    run cleanup_closed_issue_plans "false"
+    [ "$status" -eq 0 ]
+    
+    # CLOSEDのIssueの計画書は削除
+    [ ! -f "$BATS_TEST_TMPDIR/docs/plans/issue-100-plan.md" ]
+    [ ! -f "$BATS_TEST_TMPDIR/docs/plans/issue-102-plan.md" ]
+    
+    # OPENのIssueの計画書は保持
+    [ -f "$BATS_TEST_TMPDIR/docs/plans/issue-101-plan.md" ]
+}
+
+@test "cleanup_closed_issue_plans dry-run preserves files" {
+    mock_gh_closed_issue
+    export PATH="$MOCK_DIR:$PATH"
+    
+    mkdir -p "$BATS_TEST_TMPDIR/docs/plans"
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-100-plan.md"  # CLOSED
+    
+    cd "$BATS_TEST_TMPDIR"
+    run cleanup_closed_issue_plans "true"
+    [ "$status" -eq 0 ]
+    
+    # dry-runなのでファイルは残っている
+    [ -f "$BATS_TEST_TMPDIR/docs/plans/issue-100-plan.md" ]
+    [[ "$output" == *"[DRY-RUN]"* ]]
+}
+
+@test "cleanup_closed_issue_plans reports count" {
+    mock_gh_closed_issue
+    export PATH="$MOCK_DIR:$PATH"
+    
+    mkdir -p "$BATS_TEST_TMPDIR/docs/plans"
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-100-plan.md"  # CLOSED
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-102-plan.md"  # CLOSED
+    
+    cd "$BATS_TEST_TMPDIR"
+    run cleanup_closed_issue_plans "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Deleted 2 plan file(s)"* ]]
+}
+
+@test "cleanup_closed_issue_plans shows no closed message" {
+    mock_gh_closed_issue
+    export PATH="$MOCK_DIR:$PATH"
+    
+    mkdir -p "$BATS_TEST_TMPDIR/docs/plans"
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-101-plan.md"  # OPEN
+    
+    cd "$BATS_TEST_TMPDIR"
+    run cleanup_closed_issue_plans "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No closed issue plans found"* ]]
+}
+
+# ====================
+# cleanup_closed_issue_plans gh CLI エラーテスト
+# ====================
+
+@test "cleanup_closed_issue_plans fails without gh CLI" {
+    # command -v gh で gh が見つからないようにする
+    # ghという名前のシェル関数で上書きし、command -vで検出されないようにする
+    
+    mkdir -p "$BATS_TEST_TMPDIR/docs/plans"
+    touch "$BATS_TEST_TMPDIR/docs/plans/issue-100-plan.md"
+    
+    cd "$BATS_TEST_TMPDIR"
+    
+    # cleanup_closed_issue_plansを再定義してghチェックをテスト
+    # command -v gh が失敗するように環境を作る
+    # PATH を基本コマンドのみにする
+    local minimal_path="/usr/bin:/bin"
+    
+    # ghがこのパスに存在しないことを確認
+    if ! PATH="$minimal_path" command -v gh &>/dev/null; then
+        PATH="$minimal_path" run cleanup_closed_issue_plans "false"
+        [ "$status" -eq 1 ]
+        [[ "$output" == *"GitHub CLI (gh) is not installed"* ]]
+    else
+        skip "gh is available in minimal PATH, cannot test gh absence"
+    fi
+}
+
+# ====================
+# cleanup_closed_issue_plans handles non-existent directory
+# ====================
+
+@test "cleanup_closed_issue_plans handles non-existent plans directory" {
+    mock_gh_closed_issue
+    export PATH="$MOCK_DIR:$PATH"
+    
+    # docs/plans が存在しないことを確認
+    rm -rf "$BATS_TEST_TMPDIR/docs/plans"
+    
+    cd "$BATS_TEST_TMPDIR"
+    run cleanup_closed_issue_plans "false"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No plans directory found"* ]]
+}
+
+# ====================
+# エッジケーステスト
+# ====================
+
+@test "cleanup_old_plans ignores non-matching files" {
+    # 計画書パターンに合わないファイル
+    touch "$TEST_PLANS_DIR/readme.md"
+    touch "$TEST_PLANS_DIR/notes.txt"
+    touch "$TEST_PLANS_DIR/issue-plan.md"  # 番号がない
+    
+    # 正しいパターンのファイル
+    for i in 1 2 3; do
+        local file="$TEST_PLANS_DIR/issue-$i-plan.md"
+        echo "Plan $i" > "$file"
+        touch -t "20200101000$i" "$file"
+    done
+    
+    run cleanup_old_plans "false" "1"
+    [ "$status" -eq 0 ]
+    
+    # 非計画書ファイルは残っている
+    [ -f "$TEST_PLANS_DIR/readme.md" ]
+    [ -f "$TEST_PLANS_DIR/notes.txt" ]
+    [ -f "$TEST_PLANS_DIR/issue-plan.md" ]
+}
+
+@test "cleanup_old_plans uses default keep_count from config" {
+    # 設定からの保持件数（5件）を使用
+    for i in 1 2 3 4 5 6 7; do
+        local file="$TEST_PLANS_DIR/issue-$i-plan.md"
+        echo "Plan $i" > "$file"
+        touch -t "20200101000$i" "$file"
+    done
+    
+    # keep_countパラメータなし
+    run cleanup_old_plans "false"
+    [ "$status" -eq 0 ]
+    
+    # 7件中2件が削除され、5件が保持
+    local count=0
+    for i in 1 2 3 4 5 6 7; do
+        if [ -f "$TEST_PLANS_DIR/issue-$i-plan.md" ]; then
+            count=$((count + 1))
+        fi
+    done
+    [ "$count" -eq 5 ]
+}


### PR DESCRIPTION
## Summary
Closes #365

## Changes
- `test/lib/cleanup-orphans.bats` を追加: `cleanup_orphaned_statuses` 関数のユニットテスト
  - 孤立ファイルなし/ありのケース
  - dry-run モードのテスト
  - age_days オプションのテスト
  - worktree存在時の保持確認

- `test/lib/cleanup-plans.bats` を追加: `cleanup_old_plans` と `cleanup_closed_issue_plans` 関数のユニットテスト
  - 保持件数以下/超過のケース
  - dry-run モードのテスト
  - keep_count=0 の場合（全て保持）
  - クローズ済みIssueの計画書削除テスト
  - gh CLI未インストール時のエラーテスト

## Testing
- 全32件の新規テストが追加され、パス
- 全692件のテストがパス
- ShellCheckもパス