### PR TITLE
docs: AGENTS.md のディレクトリ構造に cleanup-orphans.sh と cleanup-plans.sh を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ pi-issue-runner/
 │   └── test.sh        # テスト一括実行
 ├── lib/               # 共通ライブラリ
 │   ├── agent.sh       # マルチエージェント対応
+│   ├── cleanup-orphans.sh  # 孤立ステータスクリーンアップ
+│   ├── cleanup-plans.sh    # 計画書クリーンアップ
 │   ├── config.sh      # 設定読み込み
 │   ├── github.sh      # GitHub CLI操作
 │   ├── hooks.sh       # Hook機能

--- a/docs/plans/issue-373-plan.md
+++ b/docs/plans/issue-373-plan.md
@@ -1,0 +1,24 @@
+# Issue #373 実装計画
+
+## 概要
+
+AGENTS.md のディレクトリ構造セクションに、欠落している `lib/cleanup-orphans.sh` と `lib/cleanup-plans.sh` の記載を追加する。
+
+## 影響範囲
+
+- `AGENTS.md` - ディレクトリ構造セクションの lib/ 部分のみ
+
+## 実装ステップ
+
+1. AGENTS.md の lib/ セクションに以下を追加（アルファベット順で agent.sh の後、config.sh の前）:
+   - `cleanup-orphans.sh  # 孤立ステータスクリーンアップ`
+   - `cleanup-plans.sh    # 計画書クリーンアップ`
+
+## テスト方針
+
+- ドキュメント変更のみのため、テストは不要
+- Markdown構文が正しいことを確認
+
+## リスクと対策
+
+- リスク: なし（ドキュメント変更のみ）


### PR DESCRIPTION
## Summary
Closes #373

## Changes
- AGENTS.md の lib/ セクションに欠落していた2ファイルを追加:
  - `cleanup-orphans.sh` - 孤立ステータスクリーンアップ
  - `cleanup-plans.sh` - 計画書クリーンアップ

## Testing
- ドキュメント変更のみのためテスト不要
- Markdown構文が正しいことを確認済み