### PR TITLE
docs: clarify that settings are handled by multiple modules

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -475,7 +475,18 @@ workflow:
 
 ## 設定の実装詳細
 
-設定は `lib/config.sh` でBashスクリプトとして実装されています。
+設定は複数のモジュールで処理されます:
+
+### 基本設定: lib/config.sh
+
+以下の設定は `lib/config.sh` で処理されます:
+- `worktree.*` - worktreeのベースディレクトリ、コピーするファイル
+- `tmux.*` - セッション名のプレフィックス、セッション内起動設定
+- `pi.*` - piコマンドのパス、追加引数（後方互換性）
+- `agent.*` - エージェントプリセット、カスタムコマンド、引数、テンプレート
+- `parallel.*` - 並列実行の最大同時実行数
+- `plans.*` - 計画書の保持数、ディレクトリ
+- `github.*` - Issueコメントの取り込み設定
 
 ### 主要な関数
 
@@ -511,6 +522,14 @@ echo "Worktree directory: $base_dir"
 # デバッグ: 全設定を表示
 show_config
 ```
+
+### ワークフロー設定: lib/workflow-loader.sh
+
+以下の設定は `lib/workflow-loader.sh` で処理されます:
+- `.pi-runner.yaml` 内の `workflow.steps` - 実行するステップの定義
+- `workflows/*.yaml` ファイル - カスタムワークフロー定義ファイル
+
+ワークフロー設定の詳細は [ワークフロードキュメント](workflows.md) を参照してください。
 
 ## トラブルシューティング
 


### PR DESCRIPTION
## Summary
Closes #381

## Changes
- Updated docs/configuration.md to clarify that settings are not managed solely by lib/config.sh
- Added explicit section listing settings handled by lib/config.sh:
  - worktree.*, tmux.*, pi.*, agent.*, parallel.*, plans.*, github.*
- Added new section documenting settings handled by lib/workflow-loader.sh:
  - workflow.steps in .pi-runner.yaml
  - workflows/*.yaml files
- Added cross-reference to workflows.md

## Why
The previous documentation stated "設定は lib/config.sh でBashスクリプトとして実装されています" which was misleading since workflow-related settings are actually handled by lib/workflow-loader.sh. This could cause confusion for developers who might modify only lib/config.sh while overlooking lib/workflow-loader.sh.

## Testing
- Verified the documentation changes render correctly
- All existing tests pass (bats test/lib/config.bats)