### PR TITLE
fix: bug: {{pr_number}} テンプレート変数が render_template で未サポート

### DIFF
--- a/lib/template.sh
+++ b/lib/template.sh
@@ -28,6 +28,7 @@ Push changes and create a pull request.'
 #   {{worktree_path}} - ワークツリーパス
 #   {{step_name}} - 現在のステップ名
 #   {{workflow_name}} - ワークフロー名
+#   {{pr_number}} - PR番号
 render_template() {
     local template="$1"
     local issue_number="${2:-}"
@@ -36,6 +37,7 @@ render_template() {
     local step_name="${5:-}"
     local workflow_name="${6:-default}"
     local issue_title="${7:-}"
+    local pr_number="${8:-}"
     
     local result="$template"
     
@@ -46,6 +48,7 @@ render_template() {
     result="${result//\{\{worktree_path\}\}/$worktree_path}"
     result="${result//\{\{step_name\}\}/$step_name}"
     result="${result//\{\{workflow_name\}\}/$workflow_name}"
+    result="${result//\{\{pr_number\}\}/$pr_number}"
     
     echo "$result"
 }

--- a/test/lib/template.bats
+++ b/test/lib/template.bats
@@ -117,3 +117,21 @@ teardown() {
     result="$(render_template "$template" "" "feature/add-special")"
     [ "$result" = "Branch: feature/add-special" ]
 }
+
+@test "render_template renders pr_number" {
+    template="PR #{{pr_number}}"
+    result="$(render_template "$template" "" "" "" "" "" "" "123")"
+    [ "$result" = "PR #123" ]
+}
+
+@test "render_template handles pr_number with issue_number" {
+    template="Issue #{{issue_number}}, PR #{{pr_number}}"
+    result="$(render_template "$template" "42" "" "" "" "" "" "123")"
+    [ "$result" = "Issue #42, PR #123" ]
+}
+
+@test "render_template renders all variables including pr_number" {
+    template="Issue #{{issue_number}}: {{issue_title}} on {{branch_name}} at {{worktree_path}}, step {{step_name}} of {{workflow_name}}, PR #{{pr_number}}"
+    result="$(render_template "$template" "99" "fix/bug" "/tmp/wt" "implement" "default" "Fix Bug" "555")"
+    [ "$result" = "Issue #99: Fix Bug on fix/bug at /tmp/wt, step implement of default, PR #555" ]
+}


### PR DESCRIPTION
## Summary
Closes #401

## Changes
- Add `pr_number` parameter to `render_template` function in `lib/template.sh`
- Add variable expansion for `{{pr_number}}` template variable
- Add 3 new test cases for `pr_number` rendering

## Testing
- All 21 tests in `test/lib/template.bats` pass
- New tests verify:
  - Basic `pr_number` rendering
  - `pr_number` with `issue_number` combined
  - All variables including `pr_number` together