### PR TITLE
feat: add force-complete.sh script for manual session completion

### DIFF
--- a/docs/plans/issue-431-plan.md
+++ b/docs/plans/issue-431-plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Issue #431
+
+## 概要
+
+AIが完了マーカーを出力しない場合に、セッションを強制的に完了させるスクリプト `scripts/force-complete.sh` を追加します。
+
+## 要件分析
+
+### ユースケース
+1. AIがPR作成・マージ後に完了マーカーを出力し忘れた
+2. AIが途中で停止して応答しなくなった
+3. 手動でタスク完了を判断し、cleanupを実行したい
+
+### 機能要件
+- Issue番号またはセッション名を引数に受け取る
+- セッションの存在確認
+- 完了マーカー `###TASK_COMPLETE_${issue_number}###` をセッションに送信
+- `--error` オプションでエラーマーカーを送信
+- `--message` オプションでカスタムメッセージを追加
+- watch-session.shがマーカーを検出して自動cleanupを実行
+
+## 影響範囲
+
+### 新規作成ファイル
+- `scripts/force-complete.sh` - メインスクリプト
+- `test/scripts/force-complete.bats` - Batsテスト
+
+### 関連ファイル（参照のみ）
+- `scripts/watch-session.sh` - マーカー検出とcleanup実行
+- `lib/tmux.sh` - セッション操作関数
+- `lib/log.sh` - ログ出力関数
+
+## 実装ステップ
+
+1. **スクリプト作成**
+   - ヘッダ（shebang, set -euo pipefail）
+   - ライブラリ読み込み（config.sh, log.sh, tmux.sh）
+   - usage関数
+   - main関数
+     - 引数パース（issue number/session name, --error, --message）
+     - セッション名解決
+     - セッション存在確認
+     - マーカー送信（tmux send-keys）
+
+2. **テスト作成**
+   - ヘルプオプションテスト
+   - エラーケーステスト（引数なし、無効なオプション）
+   - スクリプト構造テスト
+   - オプション処理テスト
+
+3. **動作確認**
+   - シェルチェック
+   - テスト実行
+   - 手動テスト
+
+## テスト方針
+
+### 単体テスト（Bats）
+- ヘルプ表示（-h, --help）
+- 引数なしでのエラー
+- 無効なオプションでのエラー
+- スクリプト構造（syntax, source, function存在）
+- オプション処理（--error, --message）
+
+### 手動テスト
+```bash
+# 完了マーカーの送信
+./scripts/force-complete.sh 42
+
+# エラーマーカーの送信
+./scripts/force-complete.sh 42 --error
+
+# カスタムメッセージ付き
+./scripts/force-complete.sh 42 --message "Manual completion"
+```
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| 存在しないセッションを指定 | tmux has-sessionで確認し、エラーメッセージを表示 |
+| 無効なIssue番号 | 数値チェックを実施 |
+| メッセージに特殊文字が含まれる | 適切なクォーティング |
+| tmuxがインストールされていない | lib/tmux.shのcheck_tmuxで検出 |
+
+## 実装方針
+
+### コードスタイル
+- 既存スクリプト（stop.sh, attach.sh）に準拠
+- 関数構成: usage(), main()
+- エラーハンドリング: set -euo pipefail
+- ログ出力: lib/log.shを使用
+
+### マーカー形式
+- 完了マーカー: `###TASK_COMPLETE_${issue_number}###`
+- エラーマーカー: `###TASK_ERROR_${issue_number}###`
+- watch-session.shと完全に互換性のある形式
+
+### 引数仕様
+```
+Usage: force-complete.sh <session-name|issue-number> [options]
+
+Options:
+    --error         エラーマーカーを送信
+    --message <msg> カスタムメッセージを追加
+    -h, --help      ヘルプ表示
+```

--- a/test/scripts/force-complete.bats
+++ b/test/scripts/force-complete.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# force-complete.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    export ORIGINAL_PATH="$PATH"
+}
+
+teardown() {
+    if [[ -n "${ORIGINAL_PATH:-}" ]]; then
+        export PATH="$ORIGINAL_PATH"
+    fi
+    
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# ヘルプオプションテスト
+# ====================
+
+@test "force-complete.sh --help returns success" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "force-complete.sh --help shows usage" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --help
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "force-complete.sh --help shows session-name argument" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --help
+    [[ "$output" == *"session-name"* ]] || [[ "$output" == *"issue-number"* ]]
+}
+
+@test "force-complete.sh --help shows --error option" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --help
+    [[ "$output" == *"--error"* ]]
+}
+
+@test "force-complete.sh --help shows --message option" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --help
+    [[ "$output" == *"--message"* ]]
+}
+
+@test "force-complete.sh --help shows examples" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --help
+    [[ "$output" == *"Examples:"* ]]
+}
+
+@test "force-complete.sh --help shows pi-issue-42 example" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --help
+    [[ "$output" == *"pi-issue-42"* ]] || [[ "$output" == *"42"* ]]
+}
+
+@test "force-complete.sh -h returns success" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" -h
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# エラーケーステスト
+# ====================
+
+@test "force-complete.sh without argument fails" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh"
+    [ "$status" -ne 0 ]
+}
+
+@test "force-complete.sh without argument shows error message" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh"
+    [[ "$output" == *"required"* ]] || [[ "$output" == *"Usage:"* ]]
+}
+
+@test "force-complete.sh with unknown option fails" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" --unknown-option
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown option"* ]] || [[ "$output" == *"unknown"* ]]
+}
+
+@test "force-complete.sh with --message but no value fails" {
+    run "$PROJECT_ROOT/scripts/force-complete.sh" 42 --message
+    [ "$status" -ne 0 ]
+}
+
+# ====================
+# スクリプト構造テスト
+# ====================
+
+@test "force-complete.sh has valid bash syntax" {
+    run bash -n "$PROJECT_ROOT/scripts/force-complete.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "force-complete.sh sources config.sh" {
+    grep -q "lib/config.sh" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh sources log.sh" {
+    grep -q "lib/log.sh" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh sources tmux.sh" {
+    grep -q "lib/tmux.sh" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh has main function" {
+    grep -q "main()" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh has usage function" {
+    grep -q "usage()" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh calls generate_session_name" {
+    grep -q "generate_session_name" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh calls extract_issue_number" {
+    grep -q "extract_issue_number" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh calls session_exists" {
+    grep -q "session_exists" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh handles numeric issue number" {
+    grep -q '\[0-9\]' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh sends completion marker" {
+    grep -q "TASK_COMPLETE" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh sends error marker" {
+    grep -q "TASK_ERROR" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh uses tmux send-keys" {
+    grep -q "tmux send-keys" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+# ====================
+# オプション処理テスト
+# ====================
+
+@test "force-complete.sh has --error flag handling" {
+    grep -q '\-\-error' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh has --message flag handling" {
+    grep -q '\-\-message' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh completion marker format is correct" {
+    grep -q 'TASK_COMPLETE_.*issue_number' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh error marker format is correct" {
+    grep -q 'TASK_ERROR_.*issue_number' "$PROJECT_ROOT/scripts/force-complete.sh"
+}


### PR DESCRIPTION
## Summary
Closes #431

## Changes
- Add `scripts/force-complete.sh` to manually send completion markers to sessions
- Supports both issue number and session name as arguments
- `--error` flag to send error marker instead of completion marker
- `--message` flag to add custom message

## Features
- Sends `###TASK_COMPLETE_${issue_number}###` marker to trigger watch-session.sh cleanup
- Can send error marker `###TASK_ERROR_${issue_number}###` with `--error` flag
- Custom message support with `--message` flag

## Testing
- 29 Bats tests added (all passing)
- ShellCheck validation passed
- Manual testing verified

## Usage Examples
```bash
# Complete session for issue #42
./scripts/force-complete.sh 42

# Send error marker
./scripts/force-complete.sh 42 --error

# With custom message
./scripts/force-complete.sh 42 --message "Manual completion"
```