### PR TITLE
docs: AGENTS.md の test/lib/ セクションに ci-classifier.bats, ci-monitor.bats, ci-retry.bats が未記載

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,10 @@ pi-issue-runner/
 ├── test/              # Batsテスト（*.bats形式）
 │   ├── lib/           # ライブラリのユニットテスト
 │   │   ├── agent.bats
+│   │   ├── ci-classifier.bats  # ci-classifier.sh のテスト
 │   │   ├── ci-fix.bats
+│   │   ├── ci-monitor.bats     # ci-monitor.sh のテスト
+│   │   ├── ci-retry.bats       # ci-retry.sh のテスト
 │   │   ├── cleanup-orphans.bats
 │   │   ├── cleanup-plans.bats
 │   │   ├── config.bats


### PR DESCRIPTION
## Summary
Closes #439

## Changes
- Added ci-classifier.bats to test/lib/ section
- Added ci-monitor.bats to test/lib/ section
- Added ci-retry.bats to test/lib/ section
- Files are listed in alphabetical order

## Testing
- Verified all 3 files are now listed in AGENTS.md
- Confirmed alphabetical ordering is maintained
- Run: grep -E "ci-classifier.bats|ci-monitor.bats|ci-retry.bats" AGENTS.md