### PR TITLE
docs: AGENTS.md と README.md の workflows/ セクションに thorough.yaml と ci-fix.yaml が未記載

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,10 @@ pi-issue-runner/
 │   ├── worktree.sh    # Git worktree操作
 │   └── yaml.sh        # YAMLパーサー
 ├── workflows/         # ビルトインワークフロー定義
+│   ├── ci-fix.yaml    # CI修正ワークフロー
 │   ├── default.yaml   # 完全ワークフロー
-│   └── simple.yaml    # 簡易ワークフロー
+│   ├── simple.yaml    # 簡易ワークフロー
+│   └── thorough.yaml  # 徹底ワークフロー
 ├── agents/            # エージェントテンプレート
 │   ├── ci-fix.md      # CI修正エージェント
 │   ├── plan.md        # 計画エージェント

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ scripts/wait-for-sessions.sh 140 141 --fail-fast
 
 - **default**: 完全ワークフロー（計画→実装→レビュー→マージ）
 - **simple**: 簡易ワークフロー（実装→マージのみ）
+- **thorough**: 徹底ワークフロー（計画→実装→テスト→レビュー→マージ）
+- **ci-fix**: CI修正ワークフロー（CI失敗の自動修正）
 
 ```bash
 # デフォルトワークフロー
@@ -379,8 +381,10 @@ pi-issue-runner/
 │   ├── worktree.sh         # Git worktree操作
 │   └── yaml.sh             # YAMLパーサー
 ├── workflows/               # ビルトインワークフロー定義
+│   ├── ci-fix.yaml         # CI修正ワークフロー
 │   ├── default.yaml        # 完全ワークフロー
-│   └── simple.yaml         # 簡易ワークフロー
+│   ├── simple.yaml         # 簡易ワークフロー
+│   └── thorough.yaml       # 徹底ワークフロー
 ├── agents/                  # エージェントテンプレート
 │   ├── ci-fix.md           # CI修正エージェント
 │   ├── plan.md             # 計画エージェント


### PR DESCRIPTION
## Summary
Closes #438

## Changes
- Updated AGENTS.md workflows/ section to include ci-fix.yaml and thorough.yaml
- Updated README.md workflows/ section to include ci-fix.yaml and thorough.yaml
- Added descriptions for thorough and ci-fix workflows in the built-in workflows section

## Testing
- Verified both files now contain all 4 workflow YAML files in the directory structure
- Verified grep returns expected hits for ci-fix.yaml and thorough.yaml