### PR TITLE
docs: AGENTS.mdにlib/ci-classifier.sh, ci-monitor.sh, ci-retry.shを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,10 @@ pi-issue-runner/
 │   └── test.sh        # テスト一括実行
 ├── lib/               # 共通ライブラリ
 │   ├── agent.sh       # マルチエージェント対応
+│   ├── ci-classifier.sh  # CI失敗の分類
 │   ├── ci-fix.sh      # CI失敗検出・自動修正
+│   ├── ci-monitor.sh  # CI監視
+│   ├── ci-retry.sh    # CIリトライ処理
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定読み込み


### PR DESCRIPTION
## Summary

Closes #436

## Changes

AGENTS.mdのディレクトリ構造セクションに以下の3ファイルを追加：
- lib/ci-classifier.sh - CI失敗の分類
- lib/ci-monitor.sh - CI監視
- lib/ci-retry.sh - CIリトライ処理

## Testing

- grep検証：3ファイルが記載されていることを確認
- アルファベット順の検証