### PR TITLE
docs: README.md のインストールコマンド表に force-complete が記載されていない

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-status` | 状態確認 |
 | `pi-stop` | セッション停止 |
 | `pi-cleanup` | クリーンアップ |
+| `pi-force-complete` | セッション強制完了 |
 | `pi-improve` | 継続的改善 |
 | `pi-wait` | 完了待機 |
 | `pi-watch` | セッション監視 |

--- a/docs/plans/issue-448-plan.md
+++ b/docs/plans/issue-448-plan.md
@@ -1,0 +1,20 @@
+# Issue #448 Implementation Plan
+
+## 概要
+README.md のグローバルインストールセクションにあるコマンド一覧表に `pi-force-complete` コマンドが記載されていません。また、install.sh にも `pi-force-complete` のインストール定義がありません。
+
+## 影響範囲
+- `README.md` - コマンド表の更新
+- `install.sh` - COMMANDS変数に `pi-force-complete` を追加
+
+## 実装ステップ
+1. install.sh の COMMANDS 変数に `pi-force-complete:scripts/force-complete.sh` を追加
+2. README.md のコマンド表に `pi-force-complete` の行を追加（pi-cleanup と pi-improve の間に配置）
+
+## テスト方針
+- README.md の grep で `pi-force-complete` が含まれていることを確認
+- install.sh の grep で `force-complete` が含まれていることを確認
+
+## リスクと対策
+- リスク: なし（ドキュメントとインストールスクリプトの更新のみ）
+- 対策: 特になし

--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,7 @@ pi-attach:scripts/attach.sh
 pi-status:scripts/status.sh
 pi-stop:scripts/stop.sh
 pi-cleanup:scripts/cleanup.sh
+pi-force-complete:scripts/force-complete.sh
 pi-improve:scripts/improve.sh
 pi-wait:scripts/wait-for-sessions.sh
 pi-watch:scripts/watch-session.sh


### PR DESCRIPTION
## Summary
Closes #448

## Changes
- install.sh の COMMANDS 変数に `pi-force-complete:scripts/force-complete.sh` を追加
- README.md のグローバルインストールコマンド表に `pi-force-complete` を追加

## Verification
- `grep "force-complete" install.sh` でインストール定義を確認
- `grep "pi-force-complete" README.md` でドキュメント記載を確認