### PR TITLE
feat: install.sh に force-complete.sh のマッピングを追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,7 @@ pi-attach:scripts/attach.sh
 pi-status:scripts/status.sh
 pi-stop:scripts/stop.sh
 pi-cleanup:scripts/cleanup.sh
+pi-force-complete:scripts/force-complete.sh
 pi-improve:scripts/improve.sh
 pi-wait:scripts/wait-for-sessions.sh
 pi-watch:scripts/watch-session.sh


### PR DESCRIPTION
## Summary
Closes #449

## Changes
- Added `pi-force-complete:scripts/force-complete.sh` to the COMMANDS variable in `install.sh`
- This allows the `pi-force-complete` command to be created during global installation

## Testing
- Verified ShellCheck passes with no issues
- Library tests pass (499 tests)
- Confirmed `scripts/force-complete.sh` exists and is functional

## Notes
The `force-complete.sh` script was already present in the repository but was missing from the install mapping, making it unavailable after global installation. This change ensures consistency with other commands.