### PR TITLE
docs: AGENTS.mdに未記載のライブラリファイル3件を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,10 @@ pi-issue-runner/
 │   └── test.sh        # テスト一括実行
 ├── lib/               # 共通ライブラリ
 │   ├── agent.sh       # マルチエージェント対応
+│   ├── ci-classifier.sh  # CI失敗の分類
 │   ├── ci-fix.sh      # CI失敗検出・自動修正
+│   ├── ci-monitor.sh  # CI監視
+│   ├── ci-retry.sh    # CIリトライ処理
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定読み込み


### PR DESCRIPTION
## Summary
Closes #454

## Changes
- `lib/ci-classifier.sh` - CI失敗の分類
- `lib/ci-monitor.sh` - CI監視
- `lib/ci-retry.sh` - CIリトライ処理

## Testing
- 検証コマンド実行済み：すべてのlib/*.shファイルがAGENTS.mdに記載されていることを確認
- `git diff`で変更内容を確認済み