### PR TITLE
feat: install.shにforce-complete.shのラッパーコマンドを追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,6 +139,7 @@ pi-improve:scripts/improve.sh
 pi-wait:scripts/wait-for-sessions.sh
 pi-watch:scripts/watch-session.sh
 pi-init:scripts/init.sh
+pi-force-complete:scripts/force-complete.sh
 "
 
 echo "Installing pi-issue-runner to $INSTALL_DIR..."


### PR DESCRIPTION
## Summary
Closes #457

## Changes
- Added `pi-force-complete:scripts/force-complete.sh` to the COMMANDS variable in `install.sh`
- This enables global installation of the `pi-force-complete` command

## Testing
- Verified that `grep "force-complete" install.sh` returns the expected mapping
- All existing tests pass
- ShellCheck passes with no issues