### PR TITLE
docs: README.mdとSKILL.mdにforce-complete.shコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-improve` | 継続的改善 |
 | `pi-wait` | 完了待機 |
 | `pi-watch` | セッション監視 |
+| `pi-force-complete` | セッション強制完了 |
 | `pi-init` | プロジェクト初期化 |
 
 カスタムインストール先を指定する場合:

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,11 +26,13 @@ Options:
   --pi-args <args>       piへの追加引数
 
 # セッション管理
-scripts/list.sh              # セッション一覧
-scripts/attach.sh <session>  # セッションにアタッチ
-scripts/status.sh <session>  # 状態確認
-scripts/stop.sh <session>    # セッション停止
-scripts/cleanup.sh <session> # 手動クリーンアップ
+scripts/list.sh                          # セッション一覧
+scripts/attach.sh <session>              # セッションにアタッチ
+scripts/status.sh <session>              # 状態確認
+scripts/stop.sh <session>                # セッション停止
+scripts/cleanup.sh <session>             # 手動クリーンアップ
+scripts/force-complete.sh <session>      # セッション強制完了
+scripts/force-complete.sh 42 --error     # エラーとして完了
 
 # 継続的改善
 scripts/improve.sh                    # レビュー→Issue作成→実行→待機のループ


### PR DESCRIPTION
## Summary
Closes #463

## Changes
- README.mdにpi-force-completeコマンドをインストールコマンド表に追加
- SKILL.mdにforce-complete.shの使い方をクイックリファレンスに追加
  - セッション強制完了の基本使い方
  - --errorフラグを使用したエラーとしての完了

## Testing
- grep検証で両ファイルにforce-completeコマンドが記載されていることを確認
README.md:| `pi-force-complete` | セッション強制完了 |
SKILL.md:scripts/force-complete.sh <session>      # セッション強制完了
SKILL.md:scripts/force-complete.sh 42 --error     # エラーとして完了

Refs #463