### PR TITLE
docs: add force-complete.bats to README.md test/scripts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ test/
 ├── scripts/                     # スクリプトの統合テスト
 │   ├── attach.bats              # attach.sh のテスト
 │   ├── cleanup.bats             # cleanup.sh のテスト
+│   ├── force-complete.bats      # force-complete.sh のテスト
 │   ├── improve.bats             # improve.sh のテスト
 │   ├── init.bats                # init.sh のテスト
 │   ├── list.bats                # list.sh のテスト


### PR DESCRIPTION
## Summary
Closes #474

## Changes
- Added missing `test/scripts/force-complete.bats` entry to README.md
- Now consistent with AGENTS.md documentation

## Testing
- Verified the file exists: `test/scripts/force-complete.bats`
- Confirmed README.md now matches AGENTS.md