### PR TITLE
docs: README.md の test/lib/ セクションに不足しているテストファイルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,10 @@ bats --tap test/lib/*.bats
 test/
 ├── lib/                         # ライブラリのユニットテスト
 │   ├── agent.bats               # agent.sh のテスト
+│   ├── ci-classifier.bats       # ci-classifier.sh のテスト
 │   ├── ci-fix.bats              # ci-fix.sh のテスト
+│   ├── ci-monitor.bats          # ci-monitor.sh のテスト
+│   ├── ci-retry.bats            # ci-retry.sh のテスト
 │   ├── cleanup-orphans.bats     # cleanup-orphans.sh のテスト
 │   ├── cleanup-plans.bats       # cleanup-plans.sh のテスト
 │   ├── config.bats              # config.sh のテスト


### PR DESCRIPTION
## Summary
Closes #473

## Changes
- test/lib/ci-classifier.bats（ci-classifier.sh のテスト）を追加
- test/lib/ci-monitor.bats（ci-monitor.sh のテスト）を追加
- test/lib/ci-retry.bats（ci-retry.sh のテスト）を追加

## Testing
- 実ファイルの存在を確認済み（ls -la test/lib/ci-*.bats）
- README.md の変更内容を確認済み