### PR TITLE
fix: README.mdのpi-force-complete重複記載を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-improve` | 継続的改善 |
 | `pi-wait` | 完了待機 |
 | `pi-watch` | セッション監視 |
-| `pi-force-complete` | セッション強制完了 |
 | `pi-init` | プロジェクト初期化 |
 
 | オプション | 説明 |


### PR DESCRIPTION
## Summary
Closes #497

## Changes
- README.mdのインストールコマンド一覧で重複していた`pi-force-complete`の行を削除

## Testing
- `grep -c "pi-force-complete" README.md` が 1 を返すことを確認済み
- テーブル構造が正しく維持されていることを確認