### PR TITLE
docs: Add comments explaining .yml examples are for Rails projects

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,8 +32,8 @@ worktree:
     - .env
     - .env.local
     - .envrc
-    - config/database.yml
-    - config/secrets.yml
+    - config/database.yml    # 例: Railsプロジェクトの場合
+    - config/secrets.yml     # 例: Railsプロジェクトの場合
 
 # =====================================
 # tmux設定


### PR DESCRIPTION
## Summary
Closes #506

## Changes
- Added comments to config/database.yml and config/secrets.yml examples in docs/configuration.md
- Clarifies that these .yml files are examples for Rails projects
- Addresses documentation consistency concern while maintaining Rails convention

## Details
This change implements Option B from the issue, adding comments to explain that the .yml file extensions in the examples follow Rails conventions, while the project itself uses .yaml extension (as seen in .pi-runner.yaml).

## Testing
- Verified the documentation renders correctly
- Confirmed the comments don't break YAML syntax