### PR TITLE
fix: install.sh に pi-force-complete が重複登録されている

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,6 @@ pi-improve:scripts/improve.sh
 pi-wait:scripts/wait-for-sessions.sh
 pi-watch:scripts/watch-session.sh
 pi-init:scripts/init.sh
-pi-force-complete:scripts/force-complete.sh
 "
 
 echo "Installing pi-issue-runner to $INSTALL_DIR..."


### PR DESCRIPTION
## Summary
Closes #502

## Changes
- Removed duplicate 'pi-force-complete:scripts/force-complete.sh' entry from COMMANDS variable in install.sh

## Testing
- Verified with grep -c that only 1 entry exists now
- Syntax check passed with bash -n install.sh
- ShellCheck passed for all files
- ./install.sh --help works correctly