### PR TITLE
feat: add pi-batch global command to install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-watch` | セッション監視 |
 | `pi-force-complete` | セッション強制完了 |
 | `pi-init` | プロジェクト初期化 |
+| `pi-batch` | 複数Issueを依存関係順にバッチ実行 |
 
 | オプション | 説明 |
 |-----------|------|

--- a/docs/plans/issue-503-plan.md
+++ b/docs/plans/issue-503-plan.md
@@ -1,0 +1,26 @@
+# Issue #503 実装計画
+
+## 概要
+`scripts/run-batch.sh` のグローバルコマンド (`pi-batch`) を `install.sh` に追加し、ドキュメントを更新する。
+
+## 影響範囲
+- `install.sh` - コマンドマッピングに `pi-batch` を追加
+- `README.md` - コマンド一覧表に `pi-batch` を追加
+
+## 実装ステップ
+1. `install.sh` の `COMMANDS` 変数に `pi-batch:scripts/run-batch.sh` を追加
+2. `README.md` のコマンド一覧表に `pi-batch` の行を追加
+
+## テスト方針
+- `install.sh` の構文チェック
+- `run-batch.sh` が存在することを確認
+- 変更後のファイルの目視確認
+
+## リスクと対策
+- **リスク**: 既存のコマンドリストに重複がある可能性
+- **対策**: 実装前に既存リストを確認し、重複があれば合わせて修正
+
+## 備考
+- `install.sh` には `pi-force-complete` が2回登録されている重複がある
+- `README.md` でも `pi-force-complete` が2回表示されている
+- 本Issueでは `pi-batch` の追加のみを行い、重複の修正は別途対応

--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,7 @@ pi-wait:scripts/wait-for-sessions.sh
 pi-watch:scripts/watch-session.sh
 pi-init:scripts/init.sh
 pi-force-complete:scripts/force-complete.sh
+pi-batch:scripts/run-batch.sh
 "
 
 echo "Installing pi-issue-runner to $INSTALL_DIR..."


### PR DESCRIPTION
## Summary
Closes #503

## Changes
- Add `pi-batch:scripts/run-batch.sh` to COMMANDS variable in `install.sh`
- Add `pi-batch` command to README.md command list table

## Testing
- Verified `install.sh` syntax with `bash -n`
- ShellCheck passed
- Confirmed `scripts/run-batch.sh` exists and is executable

## Notes
- `pi-batch` command allows users to run multiple issues in dependency order via global installation
- Maintains consistency with other global commands like `pi-run`, `pi-list`, etc.