### PR TITLE
fix: README.mdとinstall.shでpi-force-completeが重複している

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-improve` | 継続的改善 |
 | `pi-wait` | 完了待機 |
 | `pi-watch` | セッション監視 |
-| `pi-force-complete` | セッション強制完了 |
 | `pi-init` | プロジェクト初期化 |
 
 | オプション | 説明 |

--- a/docs/plans/issue-514-plan.md
+++ b/docs/plans/issue-514-plan.md
@@ -1,0 +1,33 @@
+# Implementation Plan for Issue #514
+
+## 概要
+README.md と install.sh で `pi-force-complete` コマンドが重複して定義されている問題を修正します。
+
+## 影響範囲
+- `README.md` - コマンド一覧表から重複行を削除
+- `install.sh` - COMMANDS変数から重複マッピングを削除
+
+## 実装ステップ
+
+### 1. README.md の修正
+- 行68-70付近（`pi-watch` と `pi-init` の間）にある重複した `pi-force-complete` の行を削除
+- 正確な位置: `| \`pi-force-complete\` | セッション強制完了 |` （2回目の出現）
+
+### 2. install.sh の修正
+- COMMANDS変数内の `pi-force-complete:scripts/force-complete.sh` の重複エントリを削除
+- 正確な位置: `pi-init:scripts/init.sh` の次の行
+
+## テスト方針
+- grep で各ファイル内の `pi-force-complete` の出現回数を確認
+- 期待値: 各ファイルで1回のみ出現
+
+## リスクと対策
+- リスク: 誤って別の行を削除する
+- 対策: 修正前に該当行を確認し、正確に重複行のみを削除する
+
+## 検証手順
+```bash
+grep "pi-force-complete" README.md | wc -l
+grep "pi-force-complete" install.sh | wc -l
+```
+両方とも結果が1であることを確認する。

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,6 @@ pi-improve:scripts/improve.sh
 pi-wait:scripts/wait-for-sessions.sh
 pi-watch:scripts/watch-session.sh
 pi-init:scripts/init.sh
-pi-force-complete:scripts/force-complete.sh
 "
 
 echo "Installing pi-issue-runner to $INSTALL_DIR..."


### PR DESCRIPTION
## Summary
Closes #514

## Changes
- Removed duplicate `pi-force-complete` row from README.md command table
- Removed duplicate `pi-force-complete` mapping from install.sh COMMANDS variable

## Testing
- Verified that `pi-force-complete` appears exactly once in README.md
- Verified that `pi-force-complete` appears exactly once in install.sh

## Verification
```bash
grep "pi-force-complete" README.md | wc -l
# Result: 1

grep "pi-force-complete" install.sh | wc -l  
# Result: 1
```