### PR TITLE
fix: add jq dependency check to prevent silent failures

### DIFF
--- a/lib/dependency.sh
+++ b/lib/dependency.sh
@@ -13,6 +13,8 @@ source "$_DEPENDENCY_LIB_DIR/github.sh"
 get_issue_blockers_numbers() {
     local issue_number="$1"
     
+    check_jq || return 1
+    
     local blockers_json
     if ! blockers_json="$(get_issue_blockers "$issue_number")"; then
         log_warn "Failed to get blockers for issue #$issue_number"
@@ -21,7 +23,8 @@ get_issue_blockers_numbers() {
     fi
     
     # OPENまたはCLOSEDのブロッカー番号を抽出（完了していないブロッカーは実行順序に影響）
-    echo "$blockers_json" | jq -r '[.[].number] | map(tostring) | join(" ")' 2>/dev/null || echo ""
+    # jqエラーは表示してデバッグを容易に
+    echo "$blockers_json" | jq -r '[.[].number] | map(tostring) | join(" ")' || echo ""
 }
 
 # 依存関係グラフを構築

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -492,8 +492,8 @@ create_label_if_not_exists() {
     
     check_gh_cli || return 1
     
-    # ラベルが存在するかチェック（エラー出力を抑制）
-    if gh label list --search "$label" --json name 2>/dev/null | jq -e --arg name "$label" '.[] | select(.name == $name)' > /dev/null 2>&1; then
+    # ラベルが存在するかチェック（jqエラーは表示してデバッグを容易に）
+    if gh label list --search "$label" --json name 2>/dev/null | jq -e --arg name "$label" '.[] | select(.name == $name)' > /dev/null; then
         log_debug "Label '$label' already exists"
         return 0
     fi

--- a/test/lib/github.bats
+++ b/test/lib/github.bats
@@ -179,6 +179,44 @@ MOCK_EOF
     fi
 }
 
+@test "check_jq function structure is correct" {
+    source "$PROJECT_ROOT/lib/github.sh"
+    
+    # 関数定義を確認
+    func_def=$(declare -f check_jq)
+    
+    # 'command -v jq' を使用してチェックしていることを確認
+    [[ "$func_def" == *'command -v jq'* ]]
+    
+    # エラーメッセージを含むことを確認
+    [[ "$func_def" == *'jq is not installed'* ]]
+    
+    # インストール手順を含むことを確認
+    [[ "$func_def" == *'brew install jq'* ]]
+    [[ "$func_def" == *'apt install jq'* ]]
+}
+
+@test "check_dependencies function exists" {
+    source "$PROJECT_ROOT/lib/github.sh"
+    declare -f check_dependencies > /dev/null
+}
+
+@test "check_dependencies calls check_jq" {
+    source "$PROJECT_ROOT/lib/github.sh"
+    
+    # 関数定義を確認
+    func_def=$(declare -f check_dependencies)
+    [[ "$func_def" == *"check_jq"* ]]
+}
+
+@test "check_dependencies calls check_gh_cli" {
+    source "$PROJECT_ROOT/lib/github.sh"
+    
+    # 関数定義を確認
+    func_def=$(declare -f check_dependencies)
+    [[ "$func_def" == *"check_gh_cli"* ]]
+}
+
 # ====================
 # get_issues_created_after テスト
 # ====================


### PR DESCRIPTION
## Summary
Closes #12

## Changes
- Remove 2>/dev/null error suppression from jq commands in lib/github.sh for better debugging
- Add check_jq call in get_issue_blockers_numbers() in lib/dependency.sh to validate dependency first
- Remove 2>/dev/null error suppression from jq command in lib/dependency.sh
- Add test cases for check_jq and check_dependencies functions

## Testing
- All existing tests pass
- New tests added for check_jq and check_dependencies functions
- Verified with bats test/lib/github.bats and bats test/lib/dependency.bats