### PR TITLE
fix: require .pi-runner.yaml to prevent cross-project execution

### DIFF
--- a/scripts/run-batch.sh
+++ b/scripts/run-batch.sh
@@ -47,6 +47,9 @@ source "$SCRIPT_DIR/../lib/github.sh"
 source "$SCRIPT_DIR/../lib/dependency.sh"
 source "$SCRIPT_DIR/../lib/status.sh"
 
+# 設定ファイルの存在チェック（必須）
+require_config_file "pi-run-batch" || exit 1
+
 # グローバル設定
 DRY_RUN=false
 SEQUENTIAL=false

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -69,6 +69,9 @@ source "$SCRIPT_DIR/../lib/workflow.sh"
 source "$SCRIPT_DIR/../lib/hooks.sh"
 source "$SCRIPT_DIR/../lib/agent.sh"
 
+# 設定ファイルの存在チェック（必須）
+require_config_file "pi-run" || exit 1
+
 # 依存関係チェック
 check_dependencies || exit 1
 

--- a/test/lib/config.bats
+++ b/test/lib/config.bats
@@ -436,3 +436,66 @@ EOF
     [ "$(get_config agents_plan)" = "env/plan.md" ]
     [ "$(get_config agents_implement)" = "yaml/implement.md" ]
 }
+
+# ===================
+# config_file_found / require_config_file tests
+# ===================
+
+@test "config_file_found returns false when no config file" {
+    unset _CONFIG_LOADED
+    unset _CONFIG_FILE_FOUND
+    source "$PROJECT_ROOT/lib/config.sh"
+    
+    # 設定ファイルがないディレクトリで実行
+    cd "$BATS_TEST_TMPDIR"
+    git init -q
+    
+    load_config
+    
+    run config_file_found
+    [ "$status" -eq 1 ]
+}
+
+@test "config_file_found returns true when config file exists" {
+    unset _CONFIG_LOADED
+    unset _CONFIG_FILE_FOUND
+    source "$PROJECT_ROOT/lib/config.sh"
+    
+    # 設定ファイルがあるディレクトリで実行
+    cd "$BATS_TEST_TMPDIR"
+    git init -q
+    touch .pi-runner.yaml
+    
+    load_config
+    
+    run config_file_found
+    [ "$status" -eq 0 ]
+    [[ "$output" == *".pi-runner.yaml" ]]
+}
+
+@test "require_config_file fails when no config file" {
+    unset _CONFIG_LOADED
+    unset _CONFIG_FILE_FOUND
+    source "$PROJECT_ROOT/lib/config.sh"
+    
+    cd "$BATS_TEST_TMPDIR"
+    git init -q
+    
+    run require_config_file "test-command"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Configuration file '.pi-runner.yaml' not found"* ]]
+    [[ "$output" == *"test-command"* ]]
+}
+
+@test "require_config_file succeeds when config file exists" {
+    unset _CONFIG_LOADED
+    unset _CONFIG_FILE_FOUND
+    source "$PROJECT_ROOT/lib/config.sh"
+    
+    cd "$BATS_TEST_TMPDIR"
+    git init -q
+    touch .pi-runner.yaml
+    
+    run require_config_file "test-command"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

`.pi-runner.yaml` が存在しないプロジェクトで `pi-run` や `pi-run-batch` を実行した際に、別プロジェクトのIssueが処理されてしまうバグを修正。

## 問題

- 設定ファイルがないプロジェクトでスクリプトを実行すると、エラーなく実行が進む
- その結果、意図しないリポジトリのIssueが処理される可能性があった

## 修正内容

- `lib/config.sh` に以下の関数を追加:
  - `config_file_found()` - 設定ファイルが見つかったかどうかを確認
  - `require_config_file()` - 設定ファイルが必須であることを検証

- `scripts/run.sh` と `scripts/run-batch.sh` の冒頭で `require_config_file` を呼び出し

## 動作

設定ファイルがない場合、明確なエラーメッセージを表示して終了:

```
[ERROR] Configuration file '.pi-runner.yaml' not found.

This project has not been initialized for pi-run.
Please run the following command to initialize:

    pi-init

Or create '.pi-runner.yaml' manually in your project root.
```

## テスト

- `test/lib/config.bats` に新しいテストケースを追加
- 全テスト通過確認済み