### PR TITLE
docs: add test and ci-fix to agents configuration examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,8 @@ agents:
   implement: agents/implement.md
   review: agents/review.md
   merge: agents/merge.md
+  test: agents/test.md
+  ci-fix: agents/ci-fix.md
 ```
 
 ## 設定項目詳細
@@ -396,6 +398,8 @@ GitHub Issue #{{issue_number}} の実装計画を作成します。
 | `PI_RUNNER_AGENTS_IMPLEMENT` | `agents.implement` |
 | `PI_RUNNER_AGENTS_REVIEW` | `agents.review` |
 | `PI_RUNNER_AGENTS_MERGE` | `agents.merge` |
+| `PI_RUNNER_AGENTS_TEST` | `agents.test` |
+| `PI_RUNNER_AGENTS_CI_FIX` | `agents.ci-fix` |
 | `PI_RUNNER_PARALLEL_MAX_CONCURRENT` | `parallel.max_concurrent` |
 
 ### 例: CI環境での使用


### PR DESCRIPTION
## Summary
Closes #533

## Changes
- Add `test: agents/test.md` to agents configuration example
- Add `ci-fix: agents/ci-fix.md` to agents configuration example  
- Add `PI_RUNNER_AGENTS_TEST` to environment variable table
- Add `PI_RUNNER_AGENTS_CI_FIX` to environment variable table

## Testing
- Verified changes with `grep -n "test\|ci-fix" docs/configuration.md`
- Confirmed 4 additions: 2 in config example, 2 in env var table