### PR TITLE
docs: add test.md to AGENTS.md directory structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ pi-issue-runner/
 │   ├── plan.md        # 計画エージェント
 │   ├── implement.md   # 実装エージェント
 │   ├── review.md      # レビューエージェント
+│   ├── test.md        # テストエージェント
 │   └── merge.md       # マージエージェント
 ├── docs/              # ドキュメント
 ├── test/              # Batsテスト（*.bats形式）


### PR DESCRIPTION
## Summary
Closes #530

## Changes
- Added missing `agents/test.md` entry to the directory structure in AGENTS.md
- Maintains workflow order (plan → implement → review → test → merge)

## Testing
- Verified the file exists: `agents/test.md`
- Checked that the entry follows the existing format with proper comment
- Directory structure now matches actual file system