### PR TITLE
docs: fix duplicate pi-batch entry in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | コマンド | 説明 |
 |----------|------|
 | `pi-run` | Issue実行 |
-| `pi-batch` | 複数Issue一括実行 |
 | `pi-list` | セッション一覧 |
 | `pi-attach` | セッションアタッチ |
 | `pi-status` | 状態確認 |


### PR DESCRIPTION
## Summary
Closes #537

## Changes
- Remove duplicate 'pi-batch' entry from the command list table in README.md
- Keep only the detailed description line: '複数Issueを依存関係順にバッチ実行'

## Verification
- Verified that 'pi-batch' now appears only once in the command table
- The table now properly lists each command exactly once

## Testing
- Manual verification with: grep -n 'pi-batch.*|' README.md
- Result: Only 1 line found (as expected)