### PR TITLE
docs: Add missing agents/ci-fix.md and agents/test.md to SPECIFICATION.md

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -91,9 +91,11 @@ project-root/
 │   ├── default.yaml         # 完全ワークフロー
 │   └── simple.yaml          # 簡易ワークフロー
 ├── agents/                  # エージェントテンプレート
+│   ├── ci-fix.md            # CI修正エージェント
 │   ├── plan.md              # 計画エージェント
 │   ├── implement.md         # 実装エージェント
 │   ├── review.md            # レビューエージェント
+│   ├── test.md              # テストエージェント
 │   └── merge.md             # マージエージェント
 ├── lib/                     # シェルスクリプトライブラリ
 │   ├── config.sh            # 設定管理


### PR DESCRIPTION
## Summary
Closes #532

## Changes
- Added `ci-fix.md` (CI修正エージェント) to the agents directory structure in SPECIFICATION.md
- Added `test.md` (テストエージェント) to the agents directory structure in SPECIFICATION.md

## Verification
- Verified all agents files exist in the agents/ directory:
  - ci-fix.md
  - plan.md
  - implement.md
  - review.md
  - test.md
  - merge.md
- All 858 tests pass

## Related
- Fixes documentation inconsistency between SPECIFICATION.md and actual file structure