### PR TITLE
fix: test/ci-fix ステップの設定ファイルサポートが未実装

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,8 @@ agents:
   implement: agents/implement.md
   review: agents/review.md
   merge: agents/merge.md
+  test: agents/test.md
+  ci-fix: agents/ci-fix.md
 ```
 
 ## 設定項目詳細
@@ -267,6 +269,8 @@ parallel:
 | `implement` | コードを実装 |
 | `review` | コードレビュー |
 | `merge` | PRを作成してマージ |
+| `test` | テストを実行 |
+| `ci-fix` | CI失敗を修正 |
 
 #### デフォルトワークフローのカスタマイズ例
 
@@ -396,6 +400,8 @@ GitHub Issue #{{issue_number}} の実装計画を作成します。
 | `PI_RUNNER_AGENTS_IMPLEMENT` | `agents.implement` |
 | `PI_RUNNER_AGENTS_REVIEW` | `agents.review` |
 | `PI_RUNNER_AGENTS_MERGE` | `agents.merge` |
+| `PI_RUNNER_AGENTS_TEST` | `agents.test` |
+| `PI_RUNNER_AGENTS_CI_FIX` | `agents.ci-fix` |
 | `PI_RUNNER_PARALLEL_MAX_CONCURRENT` | `parallel.max_concurrent` |
 
 ### 例: CI環境での使用

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -35,6 +35,8 @@ CONFIG_AGENTS_PLAN="${CONFIG_AGENTS_PLAN:-}"         # planステップのエー
 CONFIG_AGENTS_IMPLEMENT="${CONFIG_AGENTS_IMPLEMENT:-}" # implementステップのエージェントファイルパス
 CONFIG_AGENTS_REVIEW="${CONFIG_AGENTS_REVIEW:-}"     # reviewステップのエージェントファイルパス
 CONFIG_AGENTS_MERGE="${CONFIG_AGENTS_MERGE:-}"       # mergeステップのエージェントファイルパス
+CONFIG_AGENTS_TEST="${CONFIG_AGENTS_TEST:-}"         # testステップのエージェントファイルパス
+CONFIG_AGENTS_CI_FIX="${CONFIG_AGENTS_CI_FIX:-}"     # ci-fixステップのエージェントファイルパス
 
 # 設定ファイルを探す
 find_config_file() {
@@ -210,6 +212,16 @@ _parse_config_file() {
         CONFIG_AGENTS_MERGE="$value"
     fi
     
+    value="$(yaml_get "$config_file" ".agents.test" "")"
+    if [[ -n "$value" ]]; then
+        CONFIG_AGENTS_TEST="$value"
+    fi
+    
+    value="$(yaml_get "$config_file" ".agents.ci-fix" "")"
+    if [[ -n "$value" ]]; then
+        CONFIG_AGENTS_CI_FIX="$value"
+    fi
+    
     # 配列値の取得
     _parse_array_configs "$config_file"
 }
@@ -329,6 +341,12 @@ _apply_env_overrides() {
     if [[ -n "${PI_RUNNER_AGENTS_MERGE:-}" ]]; then
         CONFIG_AGENTS_MERGE="$PI_RUNNER_AGENTS_MERGE"
     fi
+    if [[ -n "${PI_RUNNER_AGENTS_TEST:-}" ]]; then
+        CONFIG_AGENTS_TEST="$PI_RUNNER_AGENTS_TEST"
+    fi
+    if [[ -n "${PI_RUNNER_AGENTS_CI_FIX:-}" ]]; then
+        CONFIG_AGENTS_CI_FIX="$PI_RUNNER_AGENTS_CI_FIX"
+    fi
 }
 
 # 設定値を取得
@@ -392,6 +410,12 @@ get_config() {
         agents_merge)
             echo "$CONFIG_AGENTS_MERGE"
             ;;
+        agents_test)
+            echo "$CONFIG_AGENTS_TEST"
+            ;;
+        agents_ci_fix)
+            echo "$CONFIG_AGENTS_CI_FIX"
+            ;;
         *)
             echo ""
             ;;
@@ -426,4 +450,6 @@ show_config() {
     echo "agents_implement: $CONFIG_AGENTS_IMPLEMENT"
     echo "agents_review: $CONFIG_AGENTS_REVIEW"
     echo "agents_merge: $CONFIG_AGENTS_MERGE"
+    echo "agents_test: $CONFIG_AGENTS_TEST"
+    echo "agents_ci_fix: $CONFIG_AGENTS_CI_FIX"
 }

--- a/lib/workflow-finder.sh
+++ b/lib/workflow-finder.sh
@@ -74,6 +74,12 @@ find_agent_file() {
         merge)
             config_path="$(get_config agents_merge)"
             ;;
+        test)
+            config_path="$(get_config agents_test)"
+            ;;
+        ci-fix)
+            config_path="$(get_config agents_ci_fix)"
+            ;;
     esac
     
     # 1. 設定ファイルで指定されたパス（相対パスの場合はproject_rootから解決）

--- a/test/lib/config.bats
+++ b/test/lib/config.bats
@@ -24,6 +24,8 @@ setup() {
     unset CONFIG_AGENTS_IMPLEMENT
     unset CONFIG_AGENTS_REVIEW
     unset CONFIG_AGENTS_MERGE
+    unset CONFIG_AGENTS_TEST
+    unset CONFIG_AGENTS_CI_FIX
     unset CONFIG_GITHUB_INCLUDE_COMMENTS
     unset CONFIG_GITHUB_MAX_COMMENTS
     unset PI_RUNNER_WORKTREE_BASE_DIR
@@ -36,6 +38,8 @@ setup() {
     unset PI_RUNNER_AGENTS_IMPLEMENT
     unset PI_RUNNER_AGENTS_REVIEW
     unset PI_RUNNER_AGENTS_MERGE
+    unset PI_RUNNER_AGENTS_TEST
+    unset PI_RUNNER_AGENTS_CI_FIX
     unset PI_RUNNER_GITHUB_INCLUDE_COMMENTS
     unset PI_RUNNER_GITHUB_MAX_COMMENTS
     
@@ -353,6 +357,20 @@ EOF
     [ -z "$result" ]
 }
 
+@test "get_config returns empty agents_test by default" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    result="$(get_config agents_test)"
+    [ -z "$result" ]
+}
+
+@test "get_config returns empty agents_ci_fix by default" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    result="$(get_config agents_ci_fix)"
+    [ -z "$result" ]
+}
+
 @test "load_config parses agents section from YAML" {
     local test_config="${BATS_TEST_TMPDIR}/agents-config.yaml"
     cat > "$test_config" << 'EOF'
@@ -361,6 +379,8 @@ agents:
   implement: custom/agents/my-implement.md
   review: custom/agents/my-review.md
   merge: custom/agents/my-merge.md
+  test: custom/agents/my-test.md
+  ci-fix: custom/agents/my-ci-fix.md
 EOF
 
     source "$PROJECT_ROOT/lib/config.sh"
@@ -370,6 +390,8 @@ EOF
     [ "$(get_config agents_implement)" = "custom/agents/my-implement.md" ]
     [ "$(get_config agents_review)" = "custom/agents/my-review.md" ]
     [ "$(get_config agents_merge)" = "custom/agents/my-merge.md" ]
+    [ "$(get_config agents_test)" = "custom/agents/my-test.md" ]
+    [ "$(get_config agents_ci_fix)" = "custom/agents/my-ci-fix.md" ]
 }
 
 @test "load_config parses partial agents section from YAML" {
@@ -387,6 +409,8 @@ EOF
     [ -z "$(get_config agents_implement)" ]
     [ "$(get_config agents_review)" = "custom/review.md" ]
     [ -z "$(get_config agents_merge)" ]
+    [ -z "$(get_config agents_test)" ]
+    [ -z "$(get_config agents_ci_fix)" ]
 }
 
 @test "environment variable overrides agents_plan" {
@@ -419,6 +443,22 @@ EOF
     load_config "$TEST_CONFIG_FILE"
     result="$(get_config agents_merge)"
     [ "$result" = "env/custom-merge.md" ]
+}
+
+@test "environment variable overrides agents_test" {
+    export PI_RUNNER_AGENTS_TEST="env/custom-test.md"
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    result="$(get_config agents_test)"
+    [ "$result" = "env/custom-test.md" ]
+}
+
+@test "environment variable overrides agents_ci_fix" {
+    export PI_RUNNER_AGENTS_CI_FIX="env/custom-ci-fix.md"
+    source "$PROJECT_ROOT/lib/config.sh"
+    load_config "$TEST_CONFIG_FILE"
+    result="$(get_config agents_ci_fix)"
+    [ "$result" = "env/custom-ci-fix.md" ]
 }
 
 @test "environment variable overrides YAML config for agents" {

--- a/test/lib/workflow-finder.bats
+++ b/test/lib/workflow-finder.bats
@@ -18,6 +18,8 @@ setup() {
     unset CONFIG_AGENTS_IMPLEMENT
     unset CONFIG_AGENTS_REVIEW
     unset CONFIG_AGENTS_MERGE
+    unset CONFIG_AGENTS_TEST
+    unset CONFIG_AGENTS_CI_FIX
     
     source "$PROJECT_ROOT/lib/workflow-finder.sh"
     
@@ -159,6 +161,16 @@ EOF
     [ "$result" = "builtin:merge" ]
 }
 
+@test "find_agent_file returns builtin for test step" {
+    result="$(find_agent_file "test" "$TEST_DIR")"
+    [ "$result" = "builtin:test" ]
+}
+
+@test "find_agent_file returns builtin for ci-fix step" {
+    result="$(find_agent_file "ci-fix" "$TEST_DIR")"
+    [ "$result" = "builtin:ci-fix" ]
+}
+
 @test "find_agent_file returns agents/plan.md when exists" {
     echo "# Custom Plan Agent" > "$TEST_DIR/agents/plan.md"
     
@@ -292,6 +304,8 @@ EOF
     echo "# Custom Implement" > "$TEST_DIR/custom/implement.md"
     echo "# Custom Review" > "$TEST_DIR/custom/review.md"
     echo "# Custom Merge" > "$TEST_DIR/custom/merge.md"
+    echo "# Custom Test" > "$TEST_DIR/custom/test.md"
+    echo "# Custom CI Fix" > "$TEST_DIR/custom/ci-fix.md"
     
     cat > "$TEST_DIR/.pi-runner.yaml" << 'EOF'
 agents:
@@ -299,6 +313,8 @@ agents:
   implement: custom/implement.md
   review: custom/review.md
   merge: custom/merge.md
+  test: custom/test.md
+  ci-fix: custom/ci-fix.md
 EOF
     
     # テストディレクトリに移動して設定を読み込む
@@ -309,6 +325,8 @@ EOF
     [ "$(find_agent_file "implement" "$TEST_DIR")" = "$TEST_DIR/custom/implement.md" ]
     [ "$(find_agent_file "review" "$TEST_DIR")" = "$TEST_DIR/custom/review.md" ]
     [ "$(find_agent_file "merge" "$TEST_DIR")" = "$TEST_DIR/custom/merge.md" ]
+    [ "$(find_agent_file "test" "$TEST_DIR")" = "$TEST_DIR/custom/test.md" ]
+    [ "$(find_agent_file "ci-fix" "$TEST_DIR")" = "$TEST_DIR/custom/ci-fix.md" ]
 }
 
 @test "find_agent_file handles absolute path in config" {


### PR DESCRIPTION
## Summary
Closes #529

## Changes
- Added CONFIG_AGENTS_TEST and CONFIG_AGENTS_CI_FIX configuration options to lib/config.sh
- Added test and ci-fix cases to find_agent_file() in lib/workflow-finder.sh
- Updated docs/configuration.md with documentation for the new options
- Added comprehensive tests for the new configuration options

## Testing
- All 72 tests pass (bats test/lib/config.bats test/lib/workflow-finder.bats)
- Verified that test and ci-fix steps can now be customized via .pi-runner.yaml
- Verified environment variable overrides work correctly

## Example Usage
agents:
  test: custom/test.md
  ci-fix: custom/ci-fix.md