### PR TITLE
feat: tmuxセッションが停止した場合に続行を促すsend-keysスクリプトの追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,7 @@ pi-improve:scripts/improve.sh
 pi-wait:scripts/wait-for-sessions.sh
 pi-watch:scripts/watch-session.sh
 pi-init:scripts/init.sh
+pi-nudge:scripts/nudge.sh
 "
 
 echo "Installing pi-issue-runner to $INSTALL_DIR..."

--- a/scripts/nudge.sh
+++ b/scripts/nudge.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# nudge.sh - tmuxセッションに続行を促すメッセージを送信
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/tmux.sh"
+
+# デフォルトメッセージ
+DEFAULT_MESSAGE="続けてください"
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") <session-name|issue-number> [options]
+
+Arguments:
+    session-name    tmuxセッション名（例: pi-issue-42）
+    issue-number    GitHub Issue番号（例: 42）
+
+Options:
+    -m, --message TEXT  送信するメッセージ（デフォルト: "$DEFAULT_MESSAGE"）
+    -s, --session NAME  セッション名を明示的に指定
+    -h, --help          このヘルプを表示
+
+Examples:
+    $(basename "$0") 42
+    $(basename "$0") pi-issue-42
+    $(basename "$0") 42 --message "続きをお願いします"
+    $(basename "$0") --session pi-issue-42 --message "完了しましたか？"
+EOF
+}
+
+# メッセージをセッションに送信
+send_nudge() {
+    local session_name="$1"
+    local message="$2"
+    
+    check_tmux || return 1
+    
+    if ! session_exists "$session_name"; then
+        log_error "Session not found: $session_name"
+        return 1
+    fi
+    
+    log_info "Sending nudge to session: $session_name"
+    log_info "Message: $message"
+    
+    # メッセージを送信してEnterキーを押す
+    tmux send-keys -t "$session_name" "$message" Enter
+    
+    log_info "Nudge sent successfully"
+}
+
+main() {
+    local target=""
+    local message="$DEFAULT_MESSAGE"
+    local session_name=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -m|--message)
+                if [[ -z "${2:-}" ]]; then
+                    log_error "Message cannot be empty"
+                    usage >&2
+                    exit 1
+                fi
+                message="$2"
+                shift 2
+                ;;
+            -s|--session)
+                if [[ -z "${2:-}" ]]; then
+                    log_error "Session name cannot be empty"
+                    usage >&2
+                    exit 1
+                fi
+                session_name="$2"
+                shift 2
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage >&2
+                exit 1
+                ;;
+            *)
+                if [[ -z "$target" ]]; then
+                    target="$1"
+                else
+                    log_error "Unexpected argument: $1"
+                    usage >&2
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    # セッション名が明示的に指定された場合
+    if [[ -n "$session_name" ]]; then
+        # targetが指定されている場合はエラー
+        if [[ -n "$target" ]]; then
+            log_error "Cannot specify both session name and issue number"
+            usage >&2
+            exit 1
+        fi
+    else
+        # targetが必要
+        if [[ -z "$target" ]]; then
+            log_error "Session name or issue number is required"
+            usage >&2
+            exit 1
+        fi
+        
+        # Issue番号かセッション名か判定
+        if [[ "$target" =~ ^[0-9]+$ ]]; then
+            # Issue番号からセッション名を生成
+            load_config
+            session_name="$(generate_session_name "$target")"
+        else
+            session_name="$target"
+        fi
+    fi
+
+    send_nudge "$session_name" "$message"
+}
+
+main "$@"

--- a/test/scripts/nudge.bats
+++ b/test/scripts/nudge.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bats
+# nudge.sh のBatsテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    export ORIGINAL_PATH="$PATH"
+}
+
+teardown() {
+    if [[ -n "${ORIGINAL_PATH:-}" ]]; then
+        export PATH="$ORIGINAL_PATH"
+    fi
+    
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# ヘルプオプションテスト
+# ====================
+
+@test "nudge.sh --help returns success" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "nudge.sh --help shows usage" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" --help
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "nudge.sh --help shows session-name argument" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" --help
+    [[ "$output" == *"session-name"* ]] || [[ "$output" == *"issue-number"* ]]
+}
+
+@test "nudge.sh --help shows message option" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" --help
+    [[ "$output" == *"--message"* ]] || [[ "$output" == *"-m"* ]]
+}
+
+@test "nudge.sh --help shows session option" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" --help
+    [[ "$output" == *"--session"* ]] || [[ "$output" == *"-s"* ]]
+}
+
+@test "nudge.sh --help shows examples" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" --help
+    [[ "$output" == *"Examples:"* ]] || [[ "$output" == *"example"* ]]
+}
+
+@test "nudge.sh -h returns success" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" -h
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# エラーケーステスト
+# ====================
+
+@test "nudge.sh without argument fails" {
+    run "$PROJECT_ROOT/scripts/nudge.sh"
+    [ "$status" -ne 0 ]
+}
+
+@test "nudge.sh without argument shows error message" {
+    run "$PROJECT_ROOT/scripts/nudge.sh"
+    [[ "$output" == *"required"* ]] || [[ "$output" == *"Usage:"* ]]
+}
+
+@test "nudge.sh with unknown option fails" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" --unknown-option
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown option"* ]] || [[ "$output" == *"unknown"* ]]
+}
+
+@test "nudge.sh with empty message fails" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" 42 --message ""
+    [ "$status" -ne 0 ]
+}
+
+@test "nudge.sh with both target and --session fails" {
+    run "$PROJECT_ROOT/scripts/nudge.sh" 42 --session pi-issue-42
+    [ "$status" -ne 0 ]
+}
+
+# ====================
+# スクリプト構造テスト
+# ====================
+
+@test "nudge.sh has valid bash syntax" {
+    run bash -n "$PROJECT_ROOT/scripts/nudge.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "nudge.sh sources config.sh" {
+    grep -q "lib/config.sh" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh sources log.sh" {
+    grep -q "lib/log.sh" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh sources tmux.sh" {
+    grep -q "lib/tmux.sh" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh has main function" {
+    grep -q "main()" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh has usage function" {
+    grep -q "usage()" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh has send_nudge function" {
+    grep -q "send_nudge()" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh uses generate_session_name" {
+    grep -q "generate_session_name" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh handles numeric issue number" {
+    grep -q '\[0-9\]' "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh has default message" {
+    grep -q "DEFAULT_MESSAGE" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+@test "nudge.sh uses tmux send-keys" {
+    grep -q "tmux send-keys" "$PROJECT_ROOT/scripts/nudge.sh"
+}
+
+# ====================
+# 機能テスト（モック使用）
+# ====================
+
+@test "nudge.sh sends message to session by issue number" {
+    # tmuxコマンドのモック
+    cat > "$MOCK_DIR/tmux" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 0  # セッションが存在する
+        ;;
+    "send-keys")
+        echo "tmux send-keys called: $*"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$MOCK_DIR/tmux"
+    enable_mocks
+    
+    run "$PROJECT_ROOT/scripts/nudge.sh" 42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Sending nudge"* ]]
+}
+
+@test "nudge.sh sends message to session by session name" {
+    # tmuxコマンドのモック
+    cat > "$MOCK_DIR/tmux" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 0  # セッションが存在する
+        ;;
+    "send-keys")
+        echo "tmux send-keys called: $*"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$MOCK_DIR/tmux"
+    enable_mocks
+    
+    run "$PROJECT_ROOT/scripts/nudge.sh" pi-issue-42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Sending nudge"* ]]
+}
+
+@test "nudge.sh sends custom message" {
+    # tmuxコマンドのモック
+    cat > "$MOCK_DIR/tmux" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 0  # セッションが存在する
+        ;;
+    "send-keys")
+        echo "tmux send-keys called: $*"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$MOCK_DIR/tmux"
+    enable_mocks
+    
+    run "$PROJECT_ROOT/scripts/nudge.sh" 42 --message "カスタムメッセージ"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"カスタムメッセージ"* ]]
+}
+
+@test "nudge.sh fails when session does not exist" {
+    # tmuxコマンドのモック（セッションが存在しない）
+    cat > "$MOCK_DIR/tmux" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 1  # セッションが存在しない
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$MOCK_DIR/tmux"
+    enable_mocks
+    
+    run "$PROJECT_ROOT/scripts/nudge.sh" 42
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not found"* ]] || [[ "$output" == *"Session not found"* ]]
+}
+
+@test "nudge.sh works with --session option" {
+    # tmuxコマンドのモック
+    cat > "$MOCK_DIR/tmux" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 0  # セッションが存在する
+        ;;
+    "send-keys")
+        echo "tmux send-keys called: $*"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$MOCK_DIR/tmux"
+    enable_mocks
+    
+    run "$PROJECT_ROOT/scripts/nudge.sh" --session pi-issue-42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Sending nudge"* ]]
+}
+
+@test "nudge.sh sends default message when no --message specified" {
+    # tmuxコマンドのモック（実際に送信されるメッセージを検証）
+    cat > "$MOCK_DIR/tmux" << 'MOCK_EOF'
+#!/usr/bin/env bash
+case "$1" in
+    "has-session")
+        exit 0  # セッションが存在する
+        ;;
+    "send-keys")
+        # デフォルトメッセージが含まれているか確認
+        if [[ "$*" == *"続けてください"* ]]; then
+            exit 0
+        else
+            echo "Expected default message not found in: $*"
+            exit 1
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+    chmod +x "$MOCK_DIR/tmux"
+    enable_mocks
+    
+    run "$PROJECT_ROOT/scripts/nudge.sh" 42
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
Closes #556

## Changes
- Add `scripts/nudge.sh` - Send continue prompts to tmux sessions
- Support targeting by Issue number or session name
- Support custom messages via `--message` option
- Support explicit session name via `--session` option
- Default message: "続けてください"
- Add comprehensive Bats tests in `test/scripts/nudge.bats`
- Add `pi-nudge` command to `install.sh`

## Testing
- All 29 Bats tests pass
- ShellCheck passes with no warnings
- Manual testing verified with mock tmux commands

## Usage Examples
```bash
# By issue number
./scripts/nudge.sh 42

# By session name
./scripts/nudge.sh pi-issue-42

# With custom message
./scripts/nudge.sh 42 --message "続きをお願いします"

# With explicit session option
./scripts/nudge.sh --session pi-issue-42 --message "完了しましたか？"
```