### PR TITLE
docs: README.md に pi-nudge コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-improve` | 継続的改善 |
 | `pi-wait` | 完了待機 |
 | `pi-watch` | セッション監視 |
+| `pi-nudge` | セッションにメッセージ送信 |
 | `pi-init` | プロジェクト初期化 |
 
 | オプション | 説明 |


### PR DESCRIPTION
## Summary
Closes #560

## Changes
- README.md の「インストールされるコマンド」テーブルに `pi-nudge` コマンドを追加
- 説明: 「セッションにメッセージ送信」

## Testing
- 検証コマンドを実行し、install.sh と README.md のコマンド一覧が一致することを確認
```bash
comm -23 \
  <( grep -E "^pi-[a-z-]+:" install.sh | cut -d: -f1 | sort) \
  <( grep -E "^\| \" README.md | sed 's/.*\`\(pi-[a-z-]*\)\`.*/\1/' | sort)
# 出力なし（一致確認）
```