### PR TITLE
docs: AGENTS.mdのディレクトリ構造にlib/daemon.shとscripts/nudge.shを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ pi-issue-runner/
 │   ├── cleanup.sh     # クリーンアップ
 │   ├── force-complete.sh  # セッション強制完了
 │   ├── improve.sh     # 継続的改善スクリプト
+│   ├── nudge.sh       # セッションへメッセージ送信
 │   ├── wait-for-sessions.sh  # 複数セッション完了待機
 │   ├── watch-session.sh  # セッション監視
 │   └── test.sh        # テスト一括実行
@@ -44,6 +45,7 @@ pi-issue-runner/
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定読み込み
 │   ├── dependency.sh  # 依存関係解析・レイヤー計算
+│   ├── daemon.sh      # プロセスデーモン化
 │   ├── github.sh      # GitHub CLI操作
 │   ├── hooks.sh       # Hook機能
 │   ├── log.sh         # ログ出力

--- a/docs/plans/issue-558-plan.md
+++ b/docs/plans/issue-558-plan.md
@@ -1,0 +1,48 @@
+# Implementation Plan: Issue #558
+
+## 概要
+
+AGENTS.md のディレクトリ構造セクションに、実際に存在するが記載されていない2つのファイルを追加するドキュメント修正です。
+
+## 変更対象
+
+### 1. `lib/daemon.sh` の追加
+- **位置**: `lib/dependency.sh` の後
+- **追加内容**:
+```
+│   ├── daemon.sh      # プロセスデーモン化
+```
+
+### 2. `scripts/nudge.sh` の追加
+- **位置**: `scripts/improve.sh` の後
+- **追加内容**:
+```
+│   ├── nudge.sh       # セッションへメッセージ送信
+```
+
+## 実装ステップ
+
+1. AGENTS.md を編集して `lib/daemon.sh` を追加
+2. AGENTS.md を編集して `scripts/nudge.sh` を追加
+3. 検証コマンドで欠落がないことを確認
+
+## テスト方針
+
+Issue に記載されている検証コマンドを実行して、すべてのファイルが存在することを確認:
+
+```bash
+grep -E "^\s+[├└].*\.sh" AGENTS.md | sed "s/.*[├└]── //" | sed "s/ .*$//" | while read f; do
+  test -f "lib/$f" || test -f "scripts/$f" || echo "Missing: $f"
+done
+```
+
+## リスクと対策
+
+- **リスク**: なし（純粋なドキュメント修正）
+- **対策**: 検証コマンドで変更前後のファイル存在確認を実行
+
+## 完了条件
+
+- [ ] `lib/daemon.sh` をAGENTS.mdのlib/セクションに追加
+- [ ] `scripts/nudge.sh` をAGENTS.mdのscripts/セクションに追加
+- [ ] 検証コマンドで欠落なし


### PR DESCRIPTION
## Summary
Closes #558

## Changes
- AGENTS.mdのlib/セクションに`daemon.sh`を追加（プロセスデーモン化）
- AGENTS.mdのscripts/セクションに`nudge.sh`を追加（セッションへメッセージ送信）

## Testing
- 検証コマンドで全ファイルの存在を確認済み
- grepで記載されたファイルが実際に存在することを確認