### PR TITLE
docs: AGENTS.mdのディレクトリ構造が実ファイルと不整合

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,6 @@ pi-issue-runner/
 │   │   ├── nudge.bats
 │   │   ├── run.bats
 │   │   ├── run-batch.bats        # run-batch.sh のテスト
-│   │   ├── run-watcher.bats
 │   │   ├── status.bats
 │   │   ├── stop.bats
 │   │   ├── test.bats


### PR DESCRIPTION
## Summary
Closes #569

## Changes
- Removed \ from AGENTS.md directory structure section

## Verification
- \ is already present in AGENTS.md (line 40)
- \ is already present in AGENTS.md (line 79)
- \ has been removed from AGENTS.md (the file does not exist in filesystem)

## Testing
- Verified the file no longer references the non-existent test file