### PR TITLE
fix: worktree削除後にtmuxセッションがENOENTエラーで停止する

### DIFF
--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -128,6 +128,13 @@ kill_session() {
     fi
     
     log_info "Killing session: $session_name"
+    
+    # Fix for Issue #585: Move session to safe directory before killing
+    # This prevents ENOENT errors when worktree is deleted while session
+    # still has it as current working directory
+    tmux send-keys -t "$session_name" "cd /" Enter 2>/dev/null || true
+    sleep 0.5
+    
     tmux kill-session -t "$session_name"
     
     # セッションが完全に終了するまで待機

--- a/test/lib/tmux.bats
+++ b/test/lib/tmux.bats
@@ -9,6 +9,13 @@ setup() {
         export _CLEANUP_TMPDIR=1
     fi
     
+    # モックディレクトリをセットアップ
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
+    
+    # 元のPATHを保存
+    export ORIGINAL_PATH="$PATH"
+    
     # テスト用の空の設定ファイルパスを作成
     export TEST_CONFIG_FILE="${BATS_TEST_TMPDIR}/empty-config.yaml"
     touch "$TEST_CONFIG_FILE"
@@ -20,6 +27,11 @@ setup() {
 }
 
 teardown() {
+    # PATHを復元
+    if [[ -n "${ORIGINAL_PATH:-}" ]]; then
+        export PATH="$ORIGINAL_PATH"
+    fi
+    
     unset PI_RUNNER_TMUX_SESSION_PREFIX
     unset PI_RUNNER_PARALLEL_MAX_CONCURRENT
     
@@ -218,6 +230,59 @@ teardown() {
     # カスタム待機時間（1秒）を指定して存在しないセッションを終了
     run kill_session "nonexistent-session-name-xyz456" 1
     [ "$status" -eq 0 ]
+}
+
+@test "kill_session sends cd / before killing session (Issue #585 fix)" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/tmux.sh"
+    load_config "$TEST_CONFIG_FILE"
+    
+    # Create mock tmux command that records calls
+    mkdir -p "$MOCK_DIR"
+    cat > "$MOCK_DIR/tmux" << 'EOF'
+#!/bin/bash
+# Record the command for verification
+echo "$@" >> "${MOCK_DIR}/tmux_calls.log"
+
+# Mock behavior for different commands
+if [[ "$1" == "has-session" ]]; then
+    # First call returns success (session exists), second returns failure (killed)
+    if [[ ! -f "${MOCK_DIR}/session_killed" ]]; then
+        exit 0
+    else
+        exit 1
+    fi
+elif [[ "$1" == "send-keys" ]]; then
+    # Record that cd command was sent
+    if [[ "$*" == *"cd /"* ]]; then
+        touch "${MOCK_DIR}/cd_sent"
+    fi
+    exit 0
+elif [[ "$1" == "kill-session" ]]; then
+    touch "${MOCK_DIR}/session_killed"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/tmux"
+    
+    # Use mock tmux
+    export PATH="$MOCK_DIR:$PATH"
+    
+    # Run kill_session
+    run kill_session "test-session" 1
+    
+    # Verify cd command was sent before kill
+    [ -f "${MOCK_DIR}/cd_sent" ]
+    [ -f "${MOCK_DIR}/session_killed" ]
+    
+    # Verify the order: send-keys with cd should come before kill-session
+    local cd_line
+    local kill_line
+    cd_line=$(grep -n "send-keys.*cd /" "${MOCK_DIR}/tmux_calls.log" | head -1 | cut -d: -f1)
+    kill_line=$(grep -n "kill-session" "${MOCK_DIR}/tmux_calls.log" | head -1 | cut -d: -f1)
+    [[ "$cd_line" -lt "$kill_line" ]]
 }
 
 # ====================


### PR DESCRIPTION
## Summary
Closes #585

## Changes
- kill_session() でセッション終了前に `cd /` を実行するように修正
- これにより、worktree削除時にtmuxセッションが削除済みディレクトリをcwdとして保持する問題を解決
- テストを追加して動作を検証

## Root Cause
worktreeが削除された後も、tmuxセッションが削除済みディレクトリをカレントディレクトリとして保持していたため、次のコマンド実行時に ENOENT エラーが発生していた。

## Solution
セッションを終了する前に、セッション内で `cd /` を実行して安全なディレクトリに移動させる。

## Testing
- 既存の全てのテストがパスすることを確認
- 新しいテストケースを追加し、`cd /` がセッション終了前に実行されることを検証

Refs #585