### PR TITLE
docs: add test.md to agents directory structure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ pi-issue-runner/
 │   ├── ci-fix.md           # CI修正エージェント
 │   ├── plan.md             # 計画エージェント
 │   ├── implement.md        # 実装エージェント
+│   ├── test.md             # テストエージェント
 │   ├── review.md           # レビューエージェント
 │   └── merge.md            # マージエージェント
 ├── docs/                    # ドキュメント


### PR DESCRIPTION
## Summary
Closes #599

## Changes
- Added `test.md` entry to the agents directory structure in README.md
- Positioned between `implement.md` and `review.md` to maintain logical order

## Context
- The `agents/test.md` file exists and is used by the `test` step in `workflows/thorough.yaml`
- However, it was missing from the README.md directory structure documentation

## Verification
- ✅ File exists: `agents/test.md`
- ✅ Used in workflow: `workflows/thorough.yaml`
- ✅ Formatting consistent with existing entries
- ✅ Positioned correctly in alphabetical/logical order