### PR TITLE
docs: scripts/ディレクトリ構造にnudge.shとrun-batch.shを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,16 +438,18 @@ pi-issue-runner/
 ├── README.md                # このファイル
 ├── scripts/
 │   ├── run.sh              # Issue実行
+│   ├── run-batch.sh        # 複数Issueを依存関係順にバッチ実行
+│   ├── init.sh             # プロジェクト初期化
 │   ├── list.sh             # セッション一覧
 │   ├── status.sh           # 状態確認
 │   ├── attach.sh           # セッションアタッチ
 │   ├── stop.sh             # セッション停止
 │   ├── cleanup.sh          # クリーンアップ
 │   ├── force-complete.sh   # セッション強制完了
-│   ├── watch-session.sh    # セッション監視と自動クリーンアップ
+│   ├── nudge.sh            # セッションにメッセージ送信
 │   ├── wait-for-sessions.sh # 複数セッション完了待機
+│   ├── watch-session.sh    # セッション監視と自動クリーンアップ
 │   ├── improve.sh          # 継続的改善スクリプト
-│   ├── init.sh             # プロジェクト初期化
 │   └── test.sh             # テスト一括実行
 ├── lib/
 │   ├── agent.sh            # マルチエージェント対応


### PR DESCRIPTION
## Summary
Closes #598

## Changes
README.mdのディレクトリ構造図に以下のスクリプトエントリを追加しました：
- `nudge.sh`: セッションにメッセージ送信
- `run-batch.sh`: 複数Issueを依存関係順にバッチ実行

また、スクリプトの配置順序をAGENTS.mdと一致させ、機能的なグループ化を明確にしました。

## Testing
- [x] 実際のファイルが存在することを確認
- [x] README.mdに両エントリが追加されたことを確認
- [x] AGENTS.mdとの整合性を確認
- [x] ドキュメント構造が崩れていないことを確認