### PR TITLE
fix: テンプレート変数{{pr_number}}をget_agent_promptに追加

### DIFF
--- a/lib/workflow-loader.sh
+++ b/lib/workflow-loader.sh
@@ -80,6 +80,7 @@ get_agent_prompt() {
     local worktree_path="${4:-}"
     local step_name="${5:-}"
     local issue_title="${6:-}"
+    local pr_number="${7:-}"
     
     local prompt
     
@@ -114,5 +115,5 @@ get_agent_prompt() {
     fi
     
     # テンプレート変数展開
-    render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "default" "$issue_title"
+    render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "default" "$issue_title" "$pr_number"
 }

--- a/lib/workflow-prompt.sh
+++ b/lib/workflow-prompt.sh
@@ -14,7 +14,7 @@ source "$_WORKFLOW_PROMPT_LIB_DIR/log.sh"
 # ===================
 
 # ワークフロープロンプトを生成する
-# Usage: generate_workflow_prompt <workflow_name> <issue_number> <issue_title> <issue_body> <branch_name> <worktree_path> [project_root] [issue_comments]
+# Usage: generate_workflow_prompt <workflow_name> <issue_number> <issue_title> <issue_body> <branch_name> <worktree_path> [project_root] [issue_comments] [pr_number]
 generate_workflow_prompt() {
     local workflow_name="${1:-default}"
     local issue_number="$2"
@@ -24,6 +24,7 @@ generate_workflow_prompt() {
     local worktree_path="$6"
     local project_root="${7:-.}"
     local issue_comments="${8:-}"
+    local pr_number="${9:-}"
     
     # ワークフローファイル検索
     local workflow_file
@@ -72,7 +73,7 @@ EOF
         agent_file=$(find_agent_file "$step" "$project_root")
         
         local agent_prompt
-        agent_prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step" "$issue_title")
+        agent_prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step" "$issue_title" "$pr_number")
         
         # ステップ名の最初を大文字に
         local step_name
@@ -125,7 +126,7 @@ EOF
 }
 
 # ワークフロープロンプトをファイルに書き出す
-# Usage: write_workflow_prompt <output_file> <workflow_name> <issue_number> <issue_title> <issue_body> <branch_name> <worktree_path> [project_root] [issue_comments]
+# Usage: write_workflow_prompt <output_file> <workflow_name> <issue_number> <issue_title> <issue_body> <branch_name> <worktree_path> [project_root] [issue_comments] [pr_number]
 write_workflow_prompt() {
     local output_file="$1"
     local workflow_name="$2"
@@ -136,8 +137,9 @@ write_workflow_prompt() {
     local worktree_path="$7"
     local project_root="${8:-.}"
     local issue_comments="${9:-}"
+    local pr_number="${10:-}"
     
-    generate_workflow_prompt "$workflow_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$worktree_path" "$project_root" "$issue_comments" > "$output_file"
+    generate_workflow_prompt "$workflow_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$worktree_path" "$project_root" "$issue_comments" "$pr_number" > "$output_file"
     
     log_debug "Workflow prompt written to: $output_file"
 }

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -54,6 +54,7 @@ run_step() {
     local worktree_path="${4:-}"
     local project_root="${5:-.}"
     local issue_title="${6:-}"
+    local pr_number="${7:-}"
     
     log_info "Running step: $step_name"
     
@@ -64,7 +65,7 @@ run_step() {
     
     # プロンプト取得
     local prompt
-    prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "$issue_title")
+    prompt=$(get_agent_prompt "$agent_file" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "$issue_title" "$pr_number")
     
     echo "$prompt"
 }


### PR DESCRIPTION
## Summary
Closes #596

## Problem
The `{{pr_number}}` template variable used in `agents/ci-fix.md` was not being passed through the function call chain, causing it to remain unexpanded in the generated prompts.

## Changes
- **lib/workflow-loader.sh**: Added `pr_number` parameter to `get_agent_prompt` function and passed it to `render_template`
- **lib/workflow-prompt.sh**: Added `pr_number` parameter to `generate_workflow_prompt` and `write_workflow_prompt` functions
- **lib/workflow.sh**: Added `pr_number` parameter to `run_step` function

All parameters use default empty values (`${N:-}`) to maintain backward compatibility.

## Testing
- ✅ All 598 unit tests pass
- ✅ ShellCheck passes with no warnings
- ✅ Template expansion verified with test script
- ✅ Backward compatible (empty pr_number handled correctly)

## Impact
- Enables proper `{{pr_number}}` expansion in ci-fix workflow
- No breaking changes (all parameters are optional with defaults)
- Improves code consistency and maintainability