### PR TITLE
docs: README.mdのディレクトリ構造でtest.mdが重複している問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,6 @@ pi-issue-runner/
 │   ├── implement.md        # 実装エージェント
 │   ├── test.md             # テストエージェント
 │   ├── review.md           # レビューエージェント
-│   ├── test.md             # テストエージェント
 │   └── merge.md            # マージエージェント
 ├── docs/                    # ドキュメント
 ├── test/                    # Batsテスト（*.bats形式）


### PR DESCRIPTION
## Summary
Closes #612

## Changes
- README.mdの`agents/`ディレクトリ構造セクションから重複した`test.md`エントリを削除
- ドキュメントを実際のファイル構成と一致させる

## Before
```
│   ├── test.md             # テストエージェント
│   ├── review.md           # レビューエージェント
│   ├── test.md             # テストエージェント  ← 重複
│   └── merge.md            # マージエージェント
```

## After
```
│   ├── test.md             # テストエージェント
│   ├── review.md           # レビューエージェント
│   └── merge.md            # マージエージェント
```

## Verification
- ✅ `agents/`配下に実際の`test.md`は1つのみ
- ✅ ドキュメント構造が実ファイルと一致
- ✅ ツリー構造のフォーマットが保持されている

## Testing
```bash
# 重複がないことを確認
grep -c "test.md.*テストエージェント" README.md
# 結果: 1

# 実際のファイル構成
ls agents/*.md | wc -l
# 結果: 6 (ci-fix, plan, implement, test, review, merge)
```