### PR TITLE
docs: README.mdのディレクトリ構造でtest.mdの重複を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,6 @@ pi-issue-runner/
 │   ├── implement.md        # 実装エージェント
 │   ├── test.md             # テストエージェント
 │   ├── review.md           # レビューエージェント
-│   ├── test.md             # テストエージェント
 │   └── merge.md            # マージエージェント
 ├── docs/                    # ドキュメント
 ├── test/                    # Batsテスト（*.bats形式）


### PR DESCRIPTION
## Summary
Closes #616

## Changes
- README.mdのagentsセクションで重複していた`test.md`を削除

## Details
- 行488と490で同じファイル（test.md）が重複して記載されていた問題を修正
- 実際のagentsディレクトリ構造と一致するように修正

## Testing
- `grep -n 'test.md' README.md`でtest.mdが1回のみ出現することを確認済み
- ドキュメント変更のため、実行コードへの影響なし