### PR TITLE
docs: SKILL.mdに--agent-argsオプションを追加

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -23,7 +23,8 @@ Options:
   --force                強制再作成
   -b, --branch <name>    カスタムブランチ名
   --base <branch>        ベースブランチ
-  --pi-args <args>       piへの追加引数
+  --agent-args <args>    エージェントに渡す追加の引数
+  --pi-args <args>       --agent-args のエイリアス（後方互換性）
   --ignore-blockers      依存関係チェックをスキップして強制実行
 
 # バッチ実行（依存関係順）


### PR DESCRIPTION
## Summary
Closes #617

## Changes
- SKILL.mdのOptionsセクションに`--agent-args`オプションを追加
- `--pi-args`は後方互換性のためのエイリアスであることを明記
- README.md、run.shの実装との整合性を確保

## Testing
- ✅ SKILL.mdに`--agent-args`が正しく記載されていることを確認
- ✅ README.md、run.shとの整合性を確認
- ✅ ドキュメント変更のみのため、機能テストは不要