### PR TITLE
docs: README.mdからテスト用コメントを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,5 +729,3 @@ gh auth login
 ## ライセンス
 
 MIT License - [LICENSE](LICENSE) を参照
-
-<!-- Test comment for auto-cleanup feature verification (Issue #129) -->


### PR DESCRIPTION
## Summary
Closes #625

## Changes
- README.md末尾のテスト用HTMLコメントを削除
- Issue #129の検証用に追加されたコメントのクリーンアップ

## Testing
- `grep -n "Test comment" README.md` → 出力なし（コメントが削除されたことを確認）
- 全991個の既存テストがパス

## Review Notes
- 機能への影響なし（ドキュメントのクリーンアップのみ）
- 最小限の変更（1行のみ削除）
- リスクレベル: 最小