### PR TITLE
docs: README.md のテスト用コメントを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,5 +729,3 @@ gh auth login
 ## ライセンス
 
 MIT License - [LICENSE](LICENSE) を参照
-
-<!-- Test comment for auto-cleanup feature verification (Issue #129) -->


### PR DESCRIPTION
## Summary
Closes #640

## Changes
- README.md の末尾からテスト用HTMLコメントを削除
- Issue #129 の自動クリーンアップ機能のテスト用に追加されていたコメントを本番ドキュメントから除去

## Testing
- `grep -n "Test comment" README.md` で出力がないことを確認済み
- README.md が正しくライセンスセクションで終わることを確認済み