### PR TITLE
docs: SKILL.md にエラーマーカーの説明を追加する

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -67,15 +67,22 @@ scripts/wait-for-sessions.sh 42 43    # 複数セッション完了待機
 
 ## 自動クリーンアップ
 
-タスク完了時にAIが `###TASK_COMPLETE_<issue_number>###` マーカーを出力すると、
-`watch-session.sh` が検出して自動的にクリーンアップを実行します。
+タスク完了時またはエラー発生時にAIが特定のマーカーを出力すると、
+`watch-session.sh` が検出して適切な処理を実行します。
+
+### マーカー形式
+
+| マーカー | 説明 | 動作 |
+|----------|------|------|
+| `###TASK_COMPLETE_<issue_number>###` | 正常完了 | 自動クリーンアップ実行 |
+| `###TASK_ERROR_<issue_number>###` | エラー発生 | 通知送信、手動対応待ち |
 
 ### 動作フロー
 
 1. `run.sh` がバックグラウンドで `watch-session.sh` を起動
 2. `watch-session.sh` がtmuxセッションの出力を監視
-3. 完了マーカー（例: `###TASK_COMPLETE_42###`）を検出
-4. 自動的に `cleanup.sh` を実行してworktreeとセッションを削除
+3. マーカー（例: `###TASK_COMPLETE_42###` または `###TASK_ERROR_42###`）を検出
+4. 完了マーカーの場合は自動的に `cleanup.sh` を実行、エラーマーカーの場合は通知を送信
 
 ### 自動クリーンアップの無効化
 


### PR DESCRIPTION
## Summary
Closes #641

## Changes
- SKILL.md の「自動クリーンアップ」セクションにエラーマーカーの説明を追加
- マーカー形式を表形式で追加（TASK_COMPLETE と TASK_ERROR の両方）
- 動作フローを更新して、完了時とエラー時の処理を明記

## Details

### Before
- 完了マーカー（`###TASK_COMPLETE_<issue_number>###`）のみ説明
- エラーマーカーについての言及なし

### After
- 完了マーカーとエラーマーカーの両方を表形式で明記
- 各マーカーの動作を明確化：
  - `TASK_COMPLETE`: 自動クリーンアップ実行
  - `TASK_ERROR`: 通知送信、手動対応待ち

## Testing
```bash
# SKILL.mdにエラーマーカーの説明があることを確認
grep -c "TASK_ERROR" SKILL.md
# 結果: 2（期待: 1以上）✅
```

## Documentation Consistency
他のドキュメントとの整合性を確認：
- ✅ docs/parallel-execution.md - エラーマーカー検出の実装例
- ✅ docs/tmux-integration.md - watch-session.sh の監視内容
- ✅ agents/plan.md, agents/implement.md 等 - エージェントテンプレートでの使用例