### PR TITLE
docs: update cleanup documentation for improve-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,16 +640,19 @@ test/
 
 # クローズ済みIssueの計画書を削除
 ./scripts/cleanup.sh --delete-plans
+
+# improve-logsディレクトリのクリーンアップ
+./scripts/cleanup.sh --improve-logs
+
+# 日数指定でクリーンアップ
+./scripts/cleanup.sh --improve-logs --age 7
 ```
 
 ### 手動削除が必要なもの
 
-以下のディレクトリは必要に応じて手動で削除してください：
+以下は必要に応じて手動で削除してください：
 
 ```bash
-# improve.sh のログ
-rm -rf .improve-logs/
-
 # 監視プロセスのログ
 rm -f /tmp/pi-watcher-*.log
 ```


### PR DESCRIPTION
## Summary
Closes #657

## Changes
- Added `--improve-logs` option to the "Individual Cleanup" section with examples
- Removed `.improve-logs/` from the "Manual Deletion" section
- Updated documentation to reflect that improve-logs can now be cleaned up automatically using `./scripts/cleanup.sh --improve-logs`

## Testing
- ✅ Verified `cleanup.sh --improve-logs` functionality exists in the script
- ✅ Confirmed documentation formatting is consistent with existing style
- ✅ Validated that users now have accurate guidance for automated cleanup

## Impact
- Users can now use automated cleanup instead of manual deletion
- Documentation is now consistent with actual tool capabilities