### PR TITLE
docs: ディレクトリ構造にcleanup-improve-logs.shと対応テストを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ pi-issue-runner/
 │   ├── ci-fix.sh      # CI失敗検出・自動修正
 │   ├── ci-monitor.sh      # CI状態監視
 │   ├── ci-retry.sh        # CI自動修正リトライ管理
+│   ├── cleanup-improve-logs.sh  # improve-logsのクリーンアップ
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定読み込み
@@ -81,6 +82,7 @@ pi-issue-runner/
 │   │   ├── ci-fix.bats
 │   │   ├── ci-monitor.bats     # ci-monitor.sh のテスト
 │   │   ├── ci-retry.bats       # ci-retry.sh のテスト
+│   │   ├── cleanup-improve-logs.bats
 │   │   ├── cleanup-orphans.bats
 │   │   ├── cleanup-plans.bats
 │   │   ├── config.bats

--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ pi-issue-runner/
 │   ├── ci-fix.sh           # CI失敗検出・自動修正
 │   ├── ci-monitor.sh       # CI状態監視
 │   ├── ci-retry.sh         # CI自動修正リトライ管理
+│   ├── cleanup-improve-logs.sh  # improve-logsクリーンアップ
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh           # 設定読み込み
@@ -501,6 +502,7 @@ pi-issue-runner/
 │   │   ├── ci-fix.bats      # ci-fix.sh のテスト
 │   │   ├── ci-monitor.bats      # ci-monitor.sh のテスト
 │   │   ├── ci-retry.bats        # ci-retry.sh のテスト
+│   │   ├── cleanup-improve-logs.bats  # cleanup-improve-logs.sh のテスト
 │   │   ├── cleanup-orphans.bats  # cleanup-orphans.sh のテスト
 │   │   ├── cleanup-plans.bats    # cleanup-plans.sh のテスト
 │   │   ├── config.bats      # config.sh のテスト

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,23 +17,26 @@
 │  │    ci-fix.sh       │  ci-monitor.sh     │  ci-retry.sh │ │
 │  │  - CI自動修正      │  - CI状態監視      │  - リトライ  │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │ cleanup-orphans.sh │ cleanup-plans.sh   │  config.sh   │ │
-│  │  - 孤立削除        │  - 計画ローテーション│ - 設定読込 │ │
+│  │cleanup-improve-logs│ cleanup-orphans.sh │cleanup-plans │ │
+│  │  - improve-logs削除│  - 孤立削除        │ - 計画ローテ │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │    daemon.sh       │  dependency.sh     │  github.sh   │ │
-│  │  - デーモン化      │  - 依存関係解析    │  - GitHub CLI│ │
+│  │    config.sh       │   daemon.sh        │dependency.sh │ │
+│  │  - 設定読込        │  - デーモン化      │  - 依存解析  │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │    hooks.sh        │     log.sh         │  notify.sh   │ │
-│  │  - Hook機能        │  - ログ出力        │  - 通知機能  │ │
+│  │    github.sh       │     hooks.sh       │    log.sh    │ │
+│  │  - GitHub CLI      │  - Hook機能        │  - ログ出力  │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │    status.sh       │   template.sh      │   tmux.sh    │ │
-│  │  - 状態管理        │  - テンプレート    │  - セッション│ │
+│  │    notify.sh       │    status.sh       │ template.sh  │ │
+│  │  - 通知機能        │  - 状態管理        │  - テンプレ  │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │   workflow.sh      │ workflow-finder.sh │workflow-loader│ │
-│  │  - ワークフロー    │  - ワークフロー検索│  - 読み込み  │ │
+│  │    tmux.sh         │   workflow.sh      │workflow-finder│ │
+│  │  - セッション      │  - ワークフロー    │  - WF検索    │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │workflow-prompt.sh  │   worktree.sh      │   yaml.sh    │ │
-│  │  - プロンプト      │  - worktree操作    │  - YAMLパーサ│ │
+│  │ workflow-loader.sh │workflow-prompt.sh  │ worktree.sh  │ │
+│  │  - WF読み込み      │  - プロンプト      │  - worktree  │ │
+│  ├────────────────────┼────────────────────┼──────────────┤ │
+│  │    yaml.sh         │                    │              │ │
+│  │  - YAMLパーサ      │                    │              │ │
 │  └────────────────────┴────────────────────┴──────────────┘ │
 └──────────────────────────────────────────────────────────────┘
          │                    │                    │
@@ -72,6 +75,7 @@ pi-issue-runner/
 │   ├── ci-fix.sh      # CI失敗検出・自動修正
 │   ├── ci-monitor.sh      # CI状態監視
 │   ├── ci-retry.sh        # CI自動修正リトライ管理
+│   ├── cleanup-improve-logs.sh  # improve-logsのクリーンアップ
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定管理


### PR DESCRIPTION
## Summary
Closes #656

プロジェクトレビューで発見されたドキュメント不整合を修正。実際に存在する `cleanup-improve-logs.sh` と `cleanup-improve-logs.bats` がドキュメントに記載されていなかったため、各ドキュメントのディレクトリ構造に追加しました。

## Changes
- ✅ AGENTS.mdのlib/セクションに `cleanup-improve-logs.sh` を追加
- ✅ AGENTS.mdのtest/lib/セクションに `cleanup-improve-logs.bats` を追加
- ✅ README.mdのlib/セクションに `cleanup-improve-logs.sh` を追加
- ✅ README.mdのtest/lib/セクションに `cleanup-improve-logs.bats` を追加
- ✅ docs/architecture.mdのlib/セクションに `cleanup-improve-logs.sh` を追加
- ✅ docs/architecture.mdのASCII図を整理してエントリを追加

## Testing
- 全1006テストがパス
- ドキュメントのみの変更のため機能への影響なし
- アルファベット順が正しく保たれていることを確認

## Verification
```bash
# 各ドキュメントに2回ずつ記載されている（lib/とtest/lib/）
grep -c "cleanup-improve-logs" AGENTS.md  # => 2
grep -c "cleanup-improve-logs" README.md  # => 2
grep -c "cleanup-improve-logs" docs/architecture.md  # => 2
```