### PR TITLE
docs: cleanup-improve-logs のディレクトリ構造追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ pi-issue-runner/
 │   ├── ci-monitor.sh      # CI状態監視
 │   ├── ci-retry.sh        # CI自動修正リトライ管理
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
+│   ├── cleanup-improve-logs.sh  # improve-logsのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定読み込み
 │   ├── dependency.sh  # 依存関係解析・レイヤー計算
@@ -82,6 +83,7 @@ pi-issue-runner/
 │   │   ├── ci-monitor.bats     # ci-monitor.sh のテスト
 │   │   ├── ci-retry.bats       # ci-retry.sh のテスト
 │   │   ├── cleanup-orphans.bats
+│   │   ├── cleanup-improve-logs.bats  # cleanup-improve-logs.sh のテスト
 │   │   ├── cleanup-plans.bats
 │   │   ├── config.bats
 │   │   ├── daemon.bats

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ pi-issue-runner/
 │   ├── ci-monitor.sh       # CI状態監視
 │   ├── ci-retry.sh         # CI自動修正リトライ管理
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
+│   ├── cleanup-improve-logs.sh  # improve-logsのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh           # 設定読み込み
 │   ├── daemon.sh           # プロセスデーモン化
@@ -502,6 +503,7 @@ pi-issue-runner/
 │   │   ├── ci-monitor.bats      # ci-monitor.sh のテスト
 │   │   ├── ci-retry.bats        # ci-retry.sh のテスト
 │   │   ├── cleanup-orphans.bats  # cleanup-orphans.sh のテスト
+│   │   ├── cleanup-improve-logs.bats  # cleanup-improve-logs.sh のテスト
 │   │   ├── cleanup-plans.bats    # cleanup-plans.sh のテスト
 │   │   ├── config.bats      # config.sh のテスト
 │   │   ├── daemon.bats      # daemon.sh のテスト

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,6 +73,7 @@ pi-issue-runner/
 │   ├── ci-monitor.sh      # CI状態監視
 │   ├── ci-retry.sh        # CI自動修正リトライ管理
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
+│   ├── cleanup-improve-logs.sh  # improve-logsのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定管理
 │   ├── daemon.sh      # プロセスデーモン化


### PR DESCRIPTION
## Summary
Closes #651

## Changes
- AGENTS.md の lib/ セクションに cleanup-improve-logs.sh を追加
- AGENTS.md の test/lib/ セクションに cleanup-improve-logs.bats を追加
- README.md の lib/ セクションに cleanup-improve-logs.sh を追加
- README.md の test/lib/ セクションに cleanup-improve-logs.bats を追加
- docs/architecture.md の lib/ セクションに cleanup-improve-logs.sh を追加

## Testing
- 全テストがパス (1006 tests)
- ファイル数の検証が完了 (lib: 25, test/lib: 25)
- 各ドキュメントに正しく追加されたことを grep で確認