### PR TITLE
refactor: remove duplicate show_execution_plan() from batch.sh

### DIFF
--- a/lib/batch.sh
+++ b/lib/batch.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 _BATCH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_BATCH_LIB_DIR/log.sh"
 source "$_BATCH_LIB_DIR/status.sh"
+source "$_BATCH_LIB_DIR/dependency.sh"
 
 # Issueを実行（同期的）
 # 引数: issue_number
@@ -222,44 +223,6 @@ process_layer() {
     fi
 
     return 0
-}
-
-# 実行計画を表示
-# 引数: Issue番号の配列（可変長）
-# 出力: フォーマット済み実行計画
-# shellcheck disable=SC2034
-show_execution_plan() {
-    local -a issues=("$@")
-
-    log_info "Execution plan:"
-
-    # 依存関係からレイヤーを計算（将来の拡張用に変数を定義）
-    # shellcheck disable=SC2034
-    local -A layer_map
-    # shellcheck disable=SC2034
-    local -A dependencies
-
-    # ブロッカー取得とレイヤー計算（簡易版）
-    for issue in "${issues[@]}"; do
-        # 依存関係がない場合はレイヤー0
-        layer_map[$issue]=0
-    done
-
-    # 単純なレイヤー表示（issue番号順）
-    local current_layer=0
-    local layer_issues=""
-
-    for issue in "${issues[@]}"; do
-        if [[ -z "$layer_issues" ]]; then
-            layer_issues="#${issue}"
-        else
-            layer_issues="${layer_issues}, #${issue}"
-        fi
-    done
-
-    if [[ -n "$layer_issues" ]]; then
-        log_info "  Layer ${current_layer}: $layer_issues"
-    fi
 }
 
 # 結果サマリーを表示して終了

--- a/test/scripts/run-batch.bats
+++ b/test/scripts/run-batch.bats
@@ -206,7 +206,9 @@ MOCK_EOF
 }
 
 @test "lib/batch.sh has show_execution_plan function" {
-    grep -q "^show_execution_plan() {" "$PROJECT_ROOT/lib/batch.sh"
+    # show_execution_plan is provided by lib/dependency.sh (sourced in batch.sh)
+    source "$PROJECT_ROOT/lib/batch.sh"
+    type show_execution_plan &>/dev/null
 }
 
 @test "lib/batch.sh has show_summary_and_exit function" {


### PR DESCRIPTION
## Summary
Closes #659

## Changes
- Removed duplicate `show_execution_plan()` function from `lib/batch.sh`
- Added `source "$_BATCH_LIB_DIR/dependency.sh"` to use the comprehensive implementation
- The `dependency.sh` version includes full dependency analysis with `compute_layers()`
- Updated test in `test/scripts/run-batch.bats` to verify function availability via `dependency.sh`

## Benefits
- **Eliminated code duplication**: Single source of truth for `show_execution_plan()`
- **Improved functionality**: Uses the comprehensive version with full dependency resolution
- **Better maintainability**: Only one function to maintain

## Testing
- All 1006 tests pass ✅
- ShellCheck passes with 0 warnings ✅
- Test updated to verify function is available after sourcing `batch.sh`

## Files Changed
- `lib/batch.sh`: +1 line (source statement), -38 lines (duplicate function)
- `test/scripts/run-batch.bats`: Updated test to verify function availability