### PR TITLE
fix: context.sh add/add-project output not captured in stdout causing test failures

### DIFF
--- a/scripts/context.sh
+++ b/scripts/context.sh
@@ -120,7 +120,7 @@ cmd_add() {
     fi
     
     append_issue_context "$issue_number" "$text"
-    log_info "Added context to issue #$issue_number"
+    echo "Added context to issue #$issue_number"
 }
 
 # add-project サブコマンド
@@ -133,7 +133,7 @@ cmd_add_project() {
     fi
     
     append_project_context "$text"
-    log_info "Added context to project"
+    echo "Added context to project"
 }
 
 # edit サブコマンド
@@ -207,14 +207,14 @@ cmd_clean() {
         esac
     done
     
-    log_info "Cleaning contexts older than $days days..."
+    echo "Cleaning contexts older than $days days..."
     local count
     count="$(clean_old_contexts "$days")"
     
     if [[ "$count" -eq 0 ]]; then
-        log_info "No old contexts found"
+        echo "No old contexts found"
     else
-        log_info "Removed $count old context(s)"
+        echo "Removed $count old context(s)"
     fi
 }
 
@@ -292,7 +292,6 @@ cmd_init() {
     
     init_issue_context "$issue_number" "$issue_title"
     echo "Initialized context for issue #$issue_number"
-    log_info "Initialized context for issue #$issue_number"
 }
 
 # init-project サブコマンド
@@ -305,7 +304,6 @@ cmd_init_project() {
     
     init_project_context
     echo "Initialized project context"
-    log_info "Initialized project context"
 }
 
 main() {


### PR DESCRIPTION
## Summary
Closes #675

## Changes
- Changed `log_info` to `echo` in user-facing success messages to output to stdout instead of stderr
- Fixed functions:
  - `cmd_add()`: 'Added context to issue #N' now uses `echo`
  - `cmd_add_project()`: 'Added context to project' now uses `echo`
  - `cmd_clean()`: All status messages now use `echo`
  - `cmd_init()`: Removed duplicate `log_info` line (already had `echo`)
  - `cmd_init_project()`: Removed duplicate `log_info` line (already had `echo`)

## Problem
The `log_info` function outputs to stderr (`>&2`), but tests capture stdout (`$output`). This caused tests to fail because they couldn't find expected output.

## Testing
- Manual testing confirms output now appears in stdout
- Tests that were failing due to this issue now pass:
  - `context.sh add appends to issue context`
  - `context.sh add-project appends to project context`
  - `context.sh clean accepts --days option`

## Notes
Some tests still fail due to a pre-existing test isolation issue (contexts created by one test persist and interfere with subsequent tests), but this is unrelated to the log_info/echo fix.