### PR TITLE
fix: --sequential option not working in run-batch.sh

### DIFF
--- a/scripts/run-batch.sh
+++ b/scripts/run-batch.sh
@@ -46,18 +46,7 @@ Exit codes:
 EOF
 }
 
-# ライブラリ読み込み
-source "$SCRIPT_DIR/../lib/config.sh"
-source "$SCRIPT_DIR/../lib/log.sh"
-source "$SCRIPT_DIR/../lib/github.sh"
-source "$SCRIPT_DIR/../lib/dependency.sh"
-source "$SCRIPT_DIR/../lib/status.sh"
-source "$SCRIPT_DIR/../lib/batch.sh"    # バッチ処理コア機能
-
-# 設定ファイルの存在チェック（必須）
-require_config_file "pi-run-batch" || exit 1
-
-# グローバル設定（lib/batch.sh と共有）
+# グローバル設定（lib/batch.sh と共有）- sourceの前に定義
 DRY_RUN=false
 # shellcheck disable=SC2034
 SEQUENTIAL=false
@@ -72,6 +61,17 @@ WORKFLOW_NAME="default"
 # shellcheck disable=SC2034
 BASE_BRANCH="HEAD"
 QUIET=false
+
+# ライブラリ読み込み
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/github.sh"
+source "$SCRIPT_DIR/../lib/dependency.sh"
+source "$SCRIPT_DIR/../lib/status.sh"
+source "$SCRIPT_DIR/../lib/batch.sh"    # バッチ処理コア機能
+
+# 設定ファイルの存在チェック（必須）
+require_config_file "pi-run-batch" || exit 1
 
 # 統計情報（lib/batch.sh と共有）
 # shellcheck disable=SC2034


### PR DESCRIPTION
## 概要

`run-batch.sh --sequential` を指定しても並列実行されてしまうバグを修正しました。

## 原因

`scripts/run-batch.sh` で `SEQUENTIAL` などのグローバル変数が `lib/batch.sh` を source する**後**に定義されていたため、`lib/batch.sh` 内の関数から正しく参照できていませんでした。

## 修正内容

変数の初期化を `source` の**前**に移動しました：

```diff
+ # グローバル設定（lib/batch.sh と共有）
+ DRY_RUN=false
+ SEQUENTIAL=false
+ CONTINUE_ON_ERROR=false
+ ...

  # ライブラリ読み込み
  source "$SCRIPT_DIR/../lib/batch.sh"
-
- # グローバル設定（lib/batch.sh と共有）
- DRY_RUN=false
- SEQUENTIAL=false
- CONTINUE_ON_ERROR=false
- ...
```

## 動作確認

```bash
./scripts/run-batch.sh 42 43 --sequential
```

--sequential を指定すると、Issueが順次（1つずつ）実行されるようになります。

Closes #676