### PR TITLE
docs: standardize header comment format for skill scripts

### DIFF
--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,222 @@
+# Coding Standards for pi-issue-runner
+
+## Shell Script Header Format
+
+All shell scripts (`.sh` files) in this project should follow this standardized header format:
+
+### Template
+
+```bash
+#!/usr/bin/env bash
+# ============================================================================
+# script-name.sh - Brief description (Japanese or English)
+#
+# Detailed description (multiple lines allowed)
+# - Purpose of the script
+# - Main functionality
+# - Special notes
+#
+# Usage: ./scripts/script-name.sh [options]
+#        ./scripts/script-name.sh <required-arg> [optional-arg]
+#
+# Arguments:
+#   required-arg    Description of required argument
+#   optional-arg    Description of optional argument
+#
+# Options:
+#   -h, --help      Show help message
+#   -v, --verbose   Enable verbose output
+#
+# Exit codes:
+#   0 - Success
+#   1 - General error
+#   2 - Invalid arguments
+#   3 - Dependency error
+#
+# Examples:
+#   ./scripts/script-name.sh 42
+#   ./scripts/script-name.sh 42 --verbose
+# ============================================================================
+```
+
+### Header Components
+
+#### 1. Shebang
+```bash
+#!/usr/bin/env bash
+```
+- Always use `#!/usr/bin/env bash` for portability
+
+#### 2. Script Name and Brief Description
+```bash
+# script-name.sh - Brief description
+```
+- Keep it concise (one line)
+- Can be in Japanese or English
+
+#### 3. Detailed Description
+```bash
+#
+# Detailed description (multiple lines allowed)
+# - Purpose of the script
+# - Main functionality
+# - Special notes
+#
+```
+- Explain what the script does
+- List main features
+- Include any important notes
+
+#### 4. Usage
+```bash
+# Usage: ./scripts/script-name.sh [options]
+#        ./scripts/script-name.sh <required-arg> [optional-arg]
+#
+```
+- Show command syntax
+- Use `<arg>` for required arguments
+- Use `[arg]` for optional arguments
+
+#### 5. Arguments
+```bash
+# Arguments:
+#   required-arg    Description of required argument
+#   optional-arg    Description of optional argument
+#
+```
+- List all arguments with descriptions
+- Include type/format information if relevant
+
+#### 6. Options
+```bash
+# Options:
+#   -h, --help      Show help message
+#   -v, --verbose   Enable verbose output
+#
+```
+- List all command-line options
+- Show both short and long forms if available
+
+#### 7. Exit Codes
+```bash
+# Exit codes:
+#   0 - Success
+#   1 - General error
+#   2 - Invalid arguments
+#   3 - Dependency error
+#
+```
+- Document all non-zero exit codes
+- Explain what each code means
+
+#### 8. Examples
+```bash
+# Examples:
+#   ./scripts/script-name.sh 42
+#   ./scripts/script-name.sh 42 --verbose
+# ============================================================================
+```
+- Provide practical usage examples
+- Show common use cases
+
+### Style Guidelines
+
+1. **Line Width**: Keep comments within 80 characters when possible
+2. **Language**: Japanese or English (consistent within a file)
+3. **Indentation**: Use 2 spaces for alignment within comments
+4. **Separators**: Use `# ===...` for the top and bottom borders
+
+### Example: Simple Script
+
+```bash
+#!/usr/bin/env bash
+# ============================================================================
+# attach.sh - Attach to a tmux session
+#
+# Connects to an existing pi-issue-runner tmux session by session name
+# or issue number.
+#
+# Usage: ./scripts/attach.sh <session-name|issue-number>
+#
+# Arguments:
+#   session-name    tmux session name (e.g., pi-issue-42)
+#   issue-number    GitHub Issue number (e.g., 42)
+#
+# Options:
+#   -h, --help      Show help message
+#
+# Exit codes:
+#   0 - Successfully attached to session
+#   1 - Session not found or error occurred
+#
+# Examples:
+#   ./scripts/attach.sh pi-issue-42
+#   ./scripts/attach.sh 42
+# ============================================================================
+```
+
+### Example: Complex Script
+
+```bash
+#!/usr/bin/env bash
+# ============================================================================
+# run.sh - Execute GitHub Issue in isolated worktree
+#
+# Creates a Git worktree from a GitHub Issue and launches a coding agent
+# in a tmux session. Supports multiple agent types including pi,
+# Claude Code, OpenCode, and custom agents.
+#
+# Usage: ./scripts/run.sh <issue-number> [options]
+#
+# Arguments:
+#   issue-number    GitHub Issue number to process
+#
+# Options:
+#   -b, --branch NAME   Custom branch name (default: issue-<num>-<title>)
+#   --base BRANCH       Base branch (default: HEAD)
+#   -w, --workflow NAME Workflow name (default: default)
+#   --no-attach         Don't attach to session after creation
+#   --no-cleanup        Disable auto-cleanup after agent exits
+#   --reattach          Attach to existing session if available
+#   --force             Remove and recreate existing session/worktree
+#   --agent-args ARGS   Additional arguments for the agent
+#   --list-workflows    List available workflows
+#   --ignore-blockers   Skip dependency check and force execution
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - Success or attached to existing session
+#   1 - General error or invalid arguments
+#   2 - Issue blocked by dependencies
+#
+# Examples:
+#   ./scripts/run.sh 42
+#   ./scripts/run.sh 42 -w simple
+#   ./scripts/run.sh 42 --no-attach
+#   ./scripts/run.sh 42 --force
+# ============================================================================
+```
+
+## Additional Coding Standards
+
+### Strict Mode
+Always include at the beginning of the script (after the header):
+```bash
+set -euo pipefail
+```
+
+### Script Directory
+Define script directory for sourcing libraries:
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+```
+
+### Function Definitions
+- Use lowercase with underscores: `my_function_name`
+- Add brief comments for complex functions
+- Use `local` for local variables
+
+### Error Handling
+- Use `log_error` function from `lib/log.sh`
+- Always provide meaningful error messages
+- Exit with appropriate exit codes

--- a/scripts/attach.sh
+++ b/scripts/attach.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
-# attach.sh - セッションアタッチ
+# ============================================================================
+# attach.sh - Attach to a tmux session
+#
+# Connects to an existing pi-issue-runner tmux session by session name
+# or issue number.
+#
+# Usage: ./scripts/attach.sh <session-name|issue-number>
+#
+# Arguments:
+#   session-name    tmux session name (e.g., pi-issue-42)
+#   issue-number    GitHub Issue number (e.g., 42)
+#
+# Options:
+#   -h, --help      Show help message
+#
+# Exit codes:
+#   0 - Successfully attached to session
+#   1 - Session not found or error occurred
+#
+# Examples:
+#   ./scripts/attach.sh pi-issue-42
+#   ./scripts/attach.sh 42
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,5 +1,43 @@
 #!/usr/bin/env bash
-# cleanup.sh - worktree + セッション削除
+# ============================================================================
+# cleanup.sh - Cleanup worktree and session
+#
+# Removes worktrees and stops tmux sessions created by pi-issue-runner.
+# Supports various cleanup modes including orphan cleanup and batch operations.
+#
+# Usage: ./scripts/cleanup.sh <session-name|issue-number> [options]
+#        ./scripts/cleanup.sh --orphans [--dry-run]
+#        ./scripts/cleanup.sh --all [--dry-run]
+#
+# Arguments:
+#   session-name    tmux session name (e.g., pi-issue-42)
+#   issue-number    GitHub Issue number (e.g., 42)
+#
+# Options:
+#   --force, -f         Force removal (even with uncommitted changes)
+#   --delete-branch     Also delete the corresponding Git branch
+#   --keep-session      Keep the session (remove worktree only)
+#   --keep-worktree     Keep the worktree (stop session only)
+#   --orphans           Clean up orphaned status files
+#   --orphan-worktrees  Clean up worktrees with 'complete' status
+#   --delete-plans      Delete plans for closed issues
+#   --rotate-plans      Rotate old plans (keep recent N)
+#   --improve-logs      Clean up .improve-logs directory
+#   --all               Run all cleanup operations
+#   --age <days>        Delete status files older than N days
+#   --dry-run           Show what would be deleted without deleting
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#
+# Examples:
+#   ./scripts/cleanup.sh pi-issue-42
+#   ./scripts/cleanup.sh 42
+#   ./scripts/cleanup.sh --orphans
+#   ./scripts/cleanup.sh --all --dry-run
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/context.sh
+++ b/scripts/context.sh
@@ -1,5 +1,39 @@
 #!/usr/bin/env bash
-# context.sh - コンテキスト管理CLI
+# ============================================================================
+# context.sh - Context management CLI
+#
+# Manages context persistence for GitHub Issues. Allows storing and
+# retrieving issue-specific and project-wide context information.
+#
+# Usage: ./scripts/context.sh <subcommand> [options]
+#
+# Subcommands:
+#   show <issue>          Show issue-specific context
+#   show-project          Show project-wide context
+#   add <issue> <text>    Add text to issue context
+#   add-project <text>    Add text to project context
+#   edit <issue>          Edit issue context in editor
+#   edit-project          Edit project context in editor
+#   list                  List issues with context
+#   clean [--days N]      Remove old contexts (default: 30 days)
+#   export <issue>        Export context as Markdown
+#   remove <issue>        Remove issue context
+#   remove-project        Remove project context
+#   init <issue> [title]  Initialize issue context
+#   init-project          Initialize project context
+#
+# Options:
+#   -h, --help            Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#
+# Examples:
+#   ./scripts/context.sh show 42
+#   ./scripts/context.sh add 42 "Important note about implementation"
+#   ./scripts/context.sh list
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -1,5 +1,32 @@
 #!/usr/bin/env bash
-# dashboard.sh - プロジェクトダッシュボード
+# ============================================================================
+# dashboard.sh - Project dashboard
+#
+# Displays a comprehensive overview of the project status, including
+# running sessions, blocked issues, and ready-to-work issues.
+#
+# Usage: ./scripts/dashboard.sh [options]
+#
+# Options:
+#   --json              Output in JSON format
+#   --no-color          Disable colored output (for CI environments)
+#   --compact           Compact view (summary only)
+#   --section <name>    Show only specific section
+#                       (summary|progress|blocked|ready)
+#   -w, --watch         Auto-refresh mode (every 5 seconds)
+#   -v, --verbose       Show detailed information
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#
+# Examples:
+#   ./scripts/dashboard.sh
+#   ./scripts/dashboard.sh --compact
+#   ./scripts/dashboard.sh --json
+#   ./scripts/dashboard.sh --watch
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/force-complete.sh
+++ b/scripts/force-complete.sh
@@ -1,5 +1,32 @@
 #!/usr/bin/env bash
-# force-complete.sh - セッションを強制的に完了させる
+# ============================================================================
+# force-complete.sh - Forcefully complete a session
+#
+# Sends a completion or error marker to a tmux session to trigger
+# watch-session.sh cleanup. Useful when the AI forgets to output the
+# completion marker or when manually determining task completion.
+#
+# Usage: ./scripts/force-complete.sh <session-name|issue-number> [options]
+#
+# Arguments:
+#   session-name    tmux session name (e.g., pi-issue-42)
+#   issue-number    GitHub Issue number (e.g., 42)
+#
+# Options:
+#   --error             Send error marker instead of completion marker
+#   --message <msg>     Add custom message
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - Marker sent successfully
+#   1 - Session not found or error occurred
+#
+# Examples:
+#   ./scripts/force-complete.sh 42
+#   ./scripts/force-complete.sh pi-issue-42
+#   ./scripts/force-complete.sh 42 --error
+#   ./scripts/force-complete.sh 42 --message "Manual completion"
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/improve.sh
+++ b/scripts/improve.sh
@@ -1,6 +1,35 @@
 #!/usr/bin/env bash
-# improve.sh - Continuous improvement (2-phase approach)
-# Uses pi --print for review, GitHub API for issue retrieval
+# ============================================================================
+# improve.sh - Continuous improvement script
+#
+# Performs continuous improvement using a 2-phase approach:
+# 1. Review phase: Uses pi --print for code review
+# 2. Execution phase: Uses GitHub API for issue retrieval and execution
+#
+# Usage: ./scripts/improve.sh [options]
+#
+# Options:
+#   --max-iterations N   Max iteration count (default: 3)
+#   --max-issues N       Max issues per iteration (default: 5)
+#   --timeout N          Session completion timeout in seconds (default: 3600)
+#   --iteration N        Current iteration number (internal use)
+#   --log-dir DIR        Log directory (default: .improve-logs)
+#   --label LABEL        Session label for Issue filtering
+#   --dry-run            Review only, do not create Issues
+#   --review-only        Show problems only (no Issue creation or execution)
+#   --auto-continue      Auto-continue without approval
+#   -v, --verbose        Show verbose logs
+#   -h, --help           Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#
+# Examples:
+#   ./scripts/improve.sh
+#   ./scripts/improve.sh --max-iterations 1
+#   ./scripts/improve.sh --dry-run
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
-# init.sh - プロジェクト初期化
+# ============================================================================
+# init.sh - Project initialization
+#
+# Initializes a project for use with pi-issue-runner by creating
+# configuration files, directories, and optional templates.
+#
+# Usage: ./scripts/init.sh [options]
+#
+# Options:
+#   --full          Full setup (creates agents/ and workflows/ directories)
+#   --minimal       Minimal setup (.pi-runner.yaml only)
+#   --force         Overwrite existing files
+#   -h, --help      Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#
+# Examples:
+#   ./scripts/init.sh              # Standard setup
+#   ./scripts/init.sh --full       # Full setup
+#   ./scripts/init.sh --minimal    # Minimal setup
+#   ./scripts/init.sh --force      # Force overwrite
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
-# list.sh - 実行中セッション一覧
+# ============================================================================
+# list.sh - List active pi-issue-runner sessions
+#
+# Displays a list of all active tmux sessions created by pi-issue-runner,
+# including issue numbers, statuses, and error messages.
+#
+# Usage: ./scripts/list.sh [options]
+#
+# Options:
+#   -v, --verbose   Show detailed information
+#   -h, --help      Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Invalid option
+#
+# Examples:
+#   ./scripts/list.sh
+#   ./scripts/list.sh -v
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/next.sh
+++ b/scripts/next.sh
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
-# next.sh - インテリジェントな次タスク提案
+# ============================================================================
+# next.sh - Intelligent next task recommendation
+#
+# Intelligently recommends the next GitHub Issue to work on based on
+# dependencies, priority, and blocker status. Considers dependency depth,
+# priority labels, and blocking issues.
+#
+# Usage: ./scripts/next.sh [options]
+#
+# Options:
+#   -n, --count <N>     Number of issues to recommend (default: 1)
+#   -l, --label <name>  Filter by specific label
+#   --json              Output in JSON format
+#   --dry-run           Show only recommendations (don't show run command)
+#   -v, --verbose       Show detailed reasoning
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - No candidates found
+#   2 - GitHub API error
+#   3 - Invalid arguments
+#
+# Examples:
+#   ./scripts/next.sh
+#   ./scripts/next.sh -n 3
+#   ./scripts/next.sh -l feature
+#   ./scripts/next.sh --json
+#   ./scripts/next.sh -v
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/nudge.sh
+++ b/scripts/nudge.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
-# nudge.sh - tmuxセッションに続行を促すメッセージを送信
+# ============================================================================
+# nudge.sh - Send a continuation message to a tmux session
+#
+# Sends a message to an existing pi-issue-runner tmux session to prompt
+# the agent to continue working on the task.
+#
+# Usage: ./scripts/nudge.sh <session-name|issue-number> [options]
+#
+# Arguments:
+#   session-name    tmux session name (e.g., pi-issue-42)
+#   issue-number    GitHub Issue number (e.g., 42)
+#
+# Options:
+#   -m, --message TEXT  Custom message to send (default: "続けてください")
+#   -s, --session NAME  Explicitly specify session name
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - Message sent successfully
+#   1 - Session not found or error occurred
+#
+# Examples:
+#   ./scripts/nudge.sh 42
+#   ./scripts/nudge.sh pi-issue-42
+#   ./scripts/nudge.sh 42 --message "Please continue"
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/run-batch.sh
+++ b/scripts/run-batch.sh
@@ -1,11 +1,42 @@
 #!/usr/bin/env bash
-# run-batch.sh - 複数Issueを依存関係順に自動実行
+# ============================================================================
+# run-batch.sh - Execute multiple issues in dependency order
 #
-# このスクリプトはバッチ処理のオーケストレーションを行い、
-# コア機能は lib/batch.sh に委譲しています。
+# Orchestrates batch processing of multiple GitHub Issues, respecting
+# dependency relationships. Delegates core functionality to lib/batch.sh.
 #
+# Usage: ./scripts/run-batch.sh <issue-number>... [options]
+#
+# Arguments:
+#   issue-number...   Issue numbers to execute (multiple allowed)
+#
+# Options:
+#   --dry-run           Show execution plan only (don't execute)
+#   --sequential        Execute sequentially without parallelization
+#   --continue-on-error Continue to next layer even if errors occur
+#   --timeout <sec>     Completion wait timeout (default: 3600)
+#   --interval <sec>    Check interval in seconds (default: 5)
+#   --workflow <name>   Workflow name to use (default: default)
+#   --base <branch>     Base branch (default: HEAD)
+#   -q, --quiet         Suppress progress display
+#   -v, --verbose       Enable verbose logging
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - All issues succeeded
+#   1 - Some issues failed
+#   2 - Circular dependency detected
+#   3 - Argument error
+#
+# Examples:
+#   ./scripts/run-batch.sh 482 483 484 485 486
+#   ./scripts/run-batch.sh 482 483 --dry-run
+#   ./scripts/run-batch.sh 482 483 --sequential
+#   ./scripts/run-batch.sh 482 483 --continue-on-error
+# ============================================================================
+
 # shellcheck disable=SC2034
-# 上記: グローバル変数は lib/batch.sh で使用される
+# Global variables are used in lib/batch.sh
 
 set -euo pipefail
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,42 @@
 #!/usr/bin/env bash
-# run.sh - GitHub Issueからworktreeを作成してコーディングエージェントを起動
-# 対応エージェント: pi, Claude Code, OpenCode, カスタム
+# ============================================================================
+# run.sh - Execute GitHub Issue in isolated worktree
+#
+# Creates a Git worktree from a GitHub Issue and launches a coding agent
+# in a tmux session. Supports multiple agent types including pi,
+# Claude Code, OpenCode, and custom agents.
+#
+# Usage: ./scripts/run.sh <issue-number> [options]
+#
+# Arguments:
+#   issue-number    GitHub Issue number to process
+#
+# Options:
+#   -b, --branch NAME   Custom branch name (default: issue-<num>-<title>)
+#   --base BRANCH       Base branch (default: HEAD)
+#   -w, --workflow NAME Workflow name (default: default)
+#   --no-attach         Don't attach to session after creation
+#   --no-cleanup        Disable auto-cleanup after agent exits
+#   --reattach          Attach to existing session if available
+#   --force             Remove and recreate existing session/worktree
+#   --agent-args ARGS   Additional arguments for the agent
+#   --pi-args ARGS      Alias for --agent-args (backward compatibility)
+#   --list-workflows    List available workflows
+#   --ignore-blockers   Skip dependency check and force execution
+#   -h, --help          Show help message
+#
+# Exit codes:
+#   0 - Success or attached to existing session
+#   1 - General error or invalid arguments
+#   2 - Issue blocked by dependencies
+#
+# Examples:
+#   ./scripts/run.sh 42
+#   ./scripts/run.sh 42 -w simple
+#   ./scripts/run.sh 42 --no-attach
+#   ./scripts/run.sh 42 --force
+#   ./scripts/run.sh 42 -b custom-feature
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,5 +1,29 @@
 #!/usr/bin/env bash
-# status.sh - タスク状態確認
+# ============================================================================
+# status.sh - Check task status
+#
+# Displays detailed status information for a pi-issue-runner session,
+# including issue details, session state, worktree path, and recent output.
+#
+# Usage: ./scripts/status.sh <session-name|issue-number> [options]
+#
+# Arguments:
+#   session-name    tmux session name (e.g., pi-issue-42)
+#   issue-number    GitHub Issue number (e.g., 42)
+#
+# Options:
+#   --output N      Show last N lines of session output (default: 20)
+#   -h, --help      Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Invalid arguments or options
+#
+# Examples:
+#   ./scripts/status.sh pi-issue-42
+#   ./scripts/status.sh 42
+#   ./scripts/status.sh 42 --output 50
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
-# stop.sh - セッション停止
+# ============================================================================
+# stop.sh - Stop a running tmux session
+#
+# Terminates a pi-issue-runner tmux session by session name or issue number.
+#
+# Usage: ./scripts/stop.sh <session-name|issue-number>
+#
+# Arguments:
+#   session-name    tmux session name (e.g., pi-issue-42)
+#   issue-number    GitHub Issue number (e.g., 42)
+#
+# Options:
+#   -h, --help      Show help message
+#
+# Exit codes:
+#   0 - Session stopped successfully
+#   1 - Session not found or error occurred
+#
+# Examples:
+#   ./scripts/stop.sh pi-issue-42
+#   ./scripts/stop.sh 42
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,38 @@
 #!/usr/bin/env bash
-# test.sh - テスト一括実行スクリプト
+# ============================================================================
+# test.sh - Test runner script
+#
+# Runs all tests including Bats tests and ShellCheck static analysis.
+# Supports parallel execution, verbose output, and fail-fast mode.
+#
+# Usage: ./scripts/test.sh [options] [target]
+#
+# Options:
+#   -v, --verbose     Show verbose logs
+#   -f, --fail-fast   Stop on first failure
+#   -s, --shellcheck  Run ShellCheck only
+#   -a, --all         Run all checks (bats + shellcheck)
+#   -j, --jobs N      Number of parallel jobs (default: 16)
+#   --fast            Fast mode (skip heavy tests)
+#   -h, --help        Show help message
+#
+# Target:
+#   lib               Run test/lib/*.bats only
+#   scripts           Run test/scripts/*.bats only
+#   (default)         Run all Bats tests
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - Some tests failed
+#
+# Examples:
+#   ./scripts/test.sh
+#   ./scripts/test.sh lib
+#   ./scripts/test.sh -v
+#   ./scripts/test.sh -f
+#   ./scripts/test.sh -s
+#   ./scripts/test.sh -a
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/wait-for-sessions.sh
+++ b/scripts/wait-for-sessions.sh
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
-# wait-for-sessions.sh - 複数セッションの完了を待機
+# ============================================================================
+# wait-for-sessions.sh - Wait for multiple sessions to complete
+#
+# Waits for all specified issue sessions to complete by monitoring
+# status files (.worktrees/.status/<issue>.json).
+#
+# Usage: ./scripts/wait-for-sessions.sh <issue-number>... [options]
+#
+# Arguments:
+#   issue-number...   Issue numbers to wait for (multiple allowed)
+#
+# Options:
+#   --timeout <sec>   Timeout in seconds (default: 3600 = 1 hour)
+#   --interval <sec>  Check interval in seconds (default: 5)
+#   --fail-fast       Exit immediately if any session errors
+#   --cleanup         Auto-cleanup worktrees after completion
+#   --quiet           Suppress progress display
+#   -h, --help        Show help message
+#
+# Exit codes:
+#   0 - All sessions completed successfully
+#   1 - One or more sessions failed
+#   2 - Timeout
+#   3 - Argument error
+#
+# Examples:
+#   ./scripts/wait-for-sessions.sh 140 141 144
+#   ./scripts/wait-for-sessions.sh 140 141 --timeout 1800
+#   ./scripts/wait-for-sessions.sh 140 141 --fail-fast
+# ============================================================================
 
 set -euo pipefail
 

--- a/scripts/watch-session.sh
+++ b/scripts/watch-session.sh
@@ -1,5 +1,31 @@
 #!/usr/bin/env bash
-# watch-session.sh - セッション出力を監視し、完了/エラーマーカーでアクションを実行
+# ============================================================================
+# watch-session.sh - Monitor session output and execute actions on markers
+#
+# Monitors tmux session output and automatically runs cleanup.sh when
+# a completion marker is detected. Shows notifications and opens Terminal.app
+# when an error marker is detected.
+#
+# Usage: ./scripts/watch-session.sh <session-name> [options]
+#
+# Arguments:
+#   session-name    tmux session name to watch
+#
+# Options:
+#   --marker <text>       Custom completion marker (default: ###TASK_COMPLETE_<issue>###)
+#   --interval <sec>      Check interval in seconds (default: 2)
+#   --cleanup-args        Additional arguments to pass to cleanup.sh
+#   --no-auto-attach      Don't auto-open Terminal on error detection
+#   -h, --help            Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#
+# Examples:
+#   ./scripts/watch-session.sh pi-issue-42
+#   ./scripts/watch-session.sh pi-issue-42 --interval 5
+# ============================================================================
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
Closes #685

## Changes
- Standardized header comment format for all 17 scripts in scripts/ directory
- Headers now include: description, usage, arguments, options, exit codes, examples
- Created docs/coding-standards.md with header format guidelines
- All scripts follow the same format for better maintainability

## Testing
- All 1136 Bats tests pass
- ShellCheck passes with no warnings
- Syntax validation passes for all modified scripts

## Standardized Header Format
```bash
#!/usr/bin/env bash
# ============================================================================
# script-name.sh - Brief description
#
# Detailed description
#
# Usage: ./scripts/script-name.sh [options]
#
# Arguments:
#   arg1    Description
#
# Options:
#   -h, --help    Show help
#
# Exit codes:
#   0 - Success
#   1 - Error
#
# Examples:
#   ./scripts/script-name.sh 42
# ============================================================================
```