### PR TITLE
fix: daemon.sh の find_daemon_pid テスト失敗

### DIFF
--- a/test/lib/daemon.bats
+++ b/test/lib/daemon.bats
@@ -228,11 +228,10 @@ EOF
     
     # テスト用の一意なパターンを持つプロセスを起動
     local unique_pattern
-    unique_pattern="test_daemon_$$_$(date +%s)_unique"
-    local test_script="$BATS_TEST_TMPDIR/test_find.sh"
-    cat > "$test_script" << EOF
+    unique_pattern="test_daemon_$$_$(date +%s)"
+    local test_script="$BATS_TEST_TMPDIR/${unique_pattern}_script.sh"
+    cat > "$test_script" << 'EOF'
 #!/usr/bin/env bash
-# $unique_pattern
 sleep 5
 EOF
     chmod +x "$test_script"


### PR DESCRIPTION
## Summary
Closes #699

## Changes
- テストスクリプトのファイル名にユニークパターンを含めるように修正
- スクリプト内のコメントにパターンを記述する方式を廃止

## Root Cause
`find_daemon_pid` のテストが失敗していた原因は、ユニークなパターンがスクリプトファイルのコメント内に記述されていたため。`pgrep -f` はプロセスのコマンドライン全体を検索するため、ファイルの内容（コメント）は検索対象外となり、プロセスを検出できなかった。

## Solution
スクリプトファイル名自体にユニークなパターンを含めることで、コマンドライン（例: `bash /tmp/test_daemon_12345_1234567890_script.sh`）にパターンが表示されるようになり、`pgrep -f` が正しく検索できるようになった。

## Testing
```bash
# 特定のテストのみ実行
bats test/lib/daemon.bats --filter "find_daemon_pid finds running"
# Result: ok 1 find_daemon_pid finds running process by pattern

# 全テスト実行
bats test/lib/daemon.bats
# Result: All 14 tests passed
```

## Impact
- テストの信頼性向上
- `lib/daemon.sh` の実装には変更なし
- 他のテストケースに影響なし