### PR TITLE
fix: release-workflowテストのMOCK_DIR未設定を修正

### DIFF
--- a/test/skills/release-workflow/release.bats
+++ b/test/skills/release-workflow/release.bats
@@ -10,6 +10,9 @@ setup() {
         export _CLEANUP_TMPDIR=1
     fi
     
+    # モックディレクトリをセットアップ
+    export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
+    mkdir -p "$MOCK_DIR"
     export ORIGINAL_PATH="$PATH"
     
     # Gitリポジトリをセットアップ


### PR DESCRIPTION
## Summary
Closes #697

## Problem
`test/skills/release-workflow/release.bats` のテストで `mock_gh_release()` 関数が「Read-only file system」エラーを起こしていました。

## Root Cause
`release.bats` の `setup()` 関数で `MOCK_DIR` が設定されていなかったため、モック関数が `/gh` に書き込もうとしていました。

## Changes
- `test/skills/release-workflow/release.bats` の `setup()` 関数に `MOCK_DIR` の設定を追加
- 他のテストファイル（`cleanup.bats`, `dashboard.bats` など）と同じパターンを使用

## Testing
- `bats test/skills/release-workflow/release.bats` が全てパス
- 「Read-only file system」エラーが発生しないことを確認

## Implementation Details
追加した3行:
```bash
# モックディレクトリをセットアップ
export MOCK_DIR="${BATS_TEST_TMPDIR}/mocks"
mkdir -p "$MOCK_DIR"
```

これにより、モック関数が `$BATS_TEST_TMPDIR/mocks/gh` に正しく書き込めるようになります。