### PR TITLE
docs: fix github.sh description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ pi-issue-runner/
 │   ├── config.sh           # 設定読み込み
 │   ├── daemon.sh           # プロセスデーモン化
 │   ├── dependency.sh       # 依存関係解析・レイヤー計算
-│   ├── github.sh           # GitHub API操作
+│   ├── github.sh           # GitHub CLI操作
 │   ├── hooks.sh            # イベントhook機能
 │   ├── log.sh              # ログ出力
 │   ├── notify.sh           # 通知機能


### PR DESCRIPTION
## Summary
Closes #707

## Changes
- Fixed inconsistent documentation for `lib/github.sh`
- Changed description in README.md from "GitHub API操作" to "GitHub CLI操作"
- Now matches the actual source code comment and AGENTS.md description

## Testing
- Verified consistency across all documentation files:
  - `lib/github.sh` (source code comment)
  - `AGENTS.md`
  - `README.md`
- All three now consistently describe it as "GitHub CLI操作"

## Impact
- Documentation only change
- No code or functionality changes