### PR TITLE
docs: README.mdのtest/lib/セクションで重複していたcleanup-improve-logs.batsを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,6 @@ pi-issue-runner/
 │   │   ├── ci-retry.bats        # ci-retry.sh のテスト
 │   │   ├── cleanup-improve-logs.bats  # cleanup-improve-logs.sh のテスト
 │   │   ├── cleanup-orphans.bats  # cleanup-orphans.sh のテスト
-│   │   ├── cleanup-improve-logs.bats  # cleanup-improve-logs.sh のテスト
 │   │   ├── cleanup-plans.bats    # cleanup-plans.sh のテスト
 │   │   ├── config.bats      # config.sh のテスト
 │   │   ├── daemon.bats      # daemon.sh のテスト


### PR DESCRIPTION
## Summary
Closes #706

## Changes
- README.mdのtest/lib/セクションから重複していた`cleanup-improve-logs.bats`のエントリを削除しました
- 584行目と586行目に記載されていた重複を解消し、1つのエントリに統一しました

## Verification
```bash
# 重複が解消されたことを確認
grep -c "cleanup-improve-logs.bats" README.md
# 結果: 1（修正前は2）
```

## Testing
- ドキュメント修正のみのため、コードやテストの変更なし
- README.mdの該当セクションを目視確認し、重複が解消されていることを確認しました