### PR TITLE
docs: README.mdの重複エントリを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,9 +540,8 @@ pi-issue-runner/
 │   ├── ci-fix.sh           # CI失敗検出・自動修正（ci-fix-helper.sh経由で使用）
 │   ├── ci-monitor.sh       # CI状態監視
 │   ├── ci-retry.sh         # CI自動修正リトライ管理
-│   ├── cleanup-improve-logs.sh  # improve-logsクリーンアップ
-│   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-improve-logs.sh  # improve-logsのクリーンアップ
+│   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh           # 設定読み込み
 │   ├── daemon.sh           # プロセスデーモン化
@@ -583,7 +582,6 @@ pi-issue-runner/
 │   │   ├── ci-retry.bats        # ci-retry.sh のテスト
 │   │   ├── cleanup-improve-logs.bats  # cleanup-improve-logs.sh のテスト
 │   │   ├── cleanup-orphans.bats  # cleanup-orphans.sh のテスト
-│   │   ├── cleanup-improve-logs.bats  # cleanup-improve-logs.sh のテスト
 │   │   ├── cleanup-plans.bats    # cleanup-plans.sh のテスト
 │   │   ├── config.bats      # config.sh のテスト
 │   │   ├── daemon.bats      # daemon.sh のテスト


### PR DESCRIPTION
## Summary
Closes #705

## Changes
- lib/セクションの `cleanup-improve-logs.sh` 重複を削除
- test/lib/セクションの `cleanup-improve-logs.bats` 重複を削除

## Details
調査の結果、`cleanup-improve-logs.sh` の重複だけでなく、test/lib/セクションにも `cleanup-improve-logs.bats` の重複が発見されたため、両方を修正しました。

## Verification
```bash
grep -c "cleanup-improve-logs.sh" README.md   # 結果: 2 (lib/とtest/lib/コメント内)
grep -c "cleanup-improve-logs.bats" README.md # 結果: 1
```

## Testing
- ✅ 重複エントリの削除を確認
- ✅ ファイルの順序が正しく保持されていることを確認
- ✅ マークダウン構文エラーなし