### PR TITLE
docs: restart-watcher.sh をドキュメントのディレクトリ構造に追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ pi-issue-runner/
 ├── scripts/           # 実行スクリプト
 │   ├── run.sh         # メインエントリーポイント
 │   ├── run-batch.sh   # 複数Issueを依存関係順にバッチ実行
+│   ├── restart-watcher.sh  # Watcher再起動
 │   ├── init.sh        # プロジェクト初期化
 │   ├── list.sh        # セッション一覧
 │   ├── status.sh      # 状態確認
@@ -125,6 +126,7 @@ pi-issue-runner/
 │   │   ├── nudge.bats
 │   │   ├── run.bats
 │   │   ├── run-batch.bats        # run-batch.sh のテスト
+│   │   ├── restart-watcher.bats  # restart-watcher.sh のテスト
 │   │   ├── status.bats
 │   │   ├── stop.bats
 │   │   ├── test.bats

--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ pi-issue-runner/
 ├── scripts/
 │   ├── run.sh              # Issue実行
 │   ├── run-batch.sh        # 複数Issueを依存関係順にバッチ実行
+│   ├── restart-watcher.sh  # Watcher再起動
 │   ├── list.sh             # セッション一覧
 │   ├── status.sh           # 状態確認
 │   ├── attach.sh           # セッションアタッチ
@@ -685,6 +686,7 @@ test/
 │   ├── nudge.bats               # nudge.sh のテスト
 │   ├── run.bats                 # run.sh のテスト
 │   ├── run-batch.bats           # run-batch.sh のテスト
+│   ├── restart-watcher.bats     # restart-watcher.sh のテスト
 │   ├── status.bats              # status.sh のテスト
 │   ├── stop.bats                # stop.sh のテスト
 │   ├── test.bats                # test.sh のテスト


### PR DESCRIPTION
## Summary
Closes #708

## Changes
AGENTS.mdとREADME.mdのディレクトリ構造セクションにrestart-watcher.shとそのテストファイルを追加しました。

### 追加箇所
- AGENTS.md scripts/セクションに `restart-watcher.sh` を追加
- AGENTS.md test/scripts/セクションに `restart-watcher.bats` を追加
- README.md scripts/セクションに `restart-watcher.sh` を追加
- README.md test/scripts/セクションに `restart-watcher.bats` を追加

## Testing
```bash
# ドキュメントへの追加確認
grep "restart-watcher" AGENTS.md README.md
# 期待: 4行が検出される（各ファイルに2箇所ずつ）
```

## Impact
- ドキュメント変更のみ
- コードへの影響なし
- 既存のテストへの影響なし