### PR TITLE
docs: README.mdのlib/セクションにdashboard.shとpriority.shを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,11 +547,13 @@ pi-issue-runner/
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh           # 設定読み込み
 │   ├── daemon.sh           # プロセスデーモン化
+│   ├── dashboard.sh        # ダッシュボード機能
 │   ├── dependency.sh       # 依存関係解析・レイヤー計算
 │   ├── github.sh           # GitHub CLI操作
 │   ├── hooks.sh            # イベントhook機能
 │   ├── log.sh              # ログ出力
 │   ├── notify.sh           # 通知機能
+│   ├── priority.sh         # 優先度計算
 │   ├── status.sh           # ステータスファイル管理
 │   ├── template.sh         # テンプレート処理
 │   ├── tmux.sh             # tmux操作


### PR DESCRIPTION
## Summary
Closes #709

## Changes
- lib/dashboard.sh（ダッシュボード機能）をdaemon.shの後に追加
- lib/priority.sh（優先度計算）をnotify.shの後に追加
- AGENTS.mdとの整合性を確保
- アルファベット順を維持

## Testing
- dashboard.shとpriority.shがREADME.mdのlib/セクションに記載されていることを確認
- AGENTS.mdと同じ説明文を使用していることを確認
- アルファベット順が正しいことを確認（daemon→dashboard→dependency, notify→priority→status）

## Review Checklist
- [x] 既存のフォーマットに従っている
- [x] AGENTS.mdと整合性がある
- [x] アルファベット順が正しい
- [x] コミットメッセージが適切