### PR TITLE
docs: AGENTS.mdのディレクトリ構造から重複エントリを削除

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,8 @@ pi-issue-runner/
 │   ├── improve.sh     # 継続的改善スクリプト
 │   ├── next.sh        # 次のタスク取得
 │   ├── nudge.sh       # セッションへメッセージ送信
-│   ├── restart-watcher.sh  # ウォッチャー再起動
 │   ├── wait-for-sessions.sh  # 複数セッション完了待機
 │   ├── watch-session.sh  # セッション監視
-│   ├── restart-watcher.sh  # ウォッチャー再起動
 │   └── test.sh        # テスト一括実行
 ├── lib/               # 共通ライブラリ
 │   ├── agent.sh       # マルチエージェント対応
@@ -129,13 +127,11 @@ pi-issue-runner/
 │   │   ├── restart-watcher.bats
 │   │   ├── run.bats
 │   │   ├── run-batch.bats        # run-batch.sh のテスト
-│   │   ├── restart-watcher.bats  # restart-watcher.sh のテスト
 │   │   ├── status.bats
 │   │   ├── stop.bats
 │   │   ├── test.bats
 │   │   ├── wait-for-sessions.bats
-│   │   ├── watch-session.bats
-│   │   └── restart-watcher.bats
+│   │   └── watch-session.bats
 │   ├── regression/    # 回帰テスト
 │   │   └── critical-fixes.bats
 │   ├── fixtures/      # テスト用フィクスチャ


### PR DESCRIPTION
## Summary
Closes #722

## Changes
- AGENTS.mdのディレクトリ構造から重複エントリを削除
- `restart-watcher.sh` が3回記載されていた → 1回に修正（26行目を保持）
- `restart-watcher.bats` が3回記載されていた → 1回に修正（127行目を保持）

## Details
### scripts/ セクション
- ❌ 削除: 40行目の `restart-watcher.sh`
- ❌ 削除: 43行目の `restart-watcher.sh`
- ✅ 保持: 26行目の `restart-watcher.sh`

### test/scripts/ セクション
- ❌ 削除: 132行目の `restart-watcher.bats`
- ❌ 削除: 138行目の `restart-watcher.bats`
- ✅ 保持: 127行目の `restart-watcher.bats`

## Verification
```bash
# 重複がないことを確認
$ grep -n "restart-watcher" AGENTS.md
26:│   ├── restart-watcher.sh  # Watcher再起動
127:│   │   ├── restart-watcher.bats

# ディレクトリ構造が実際のファイルと一致
$ ls scripts/*.sh | wc -l
19
$ ls test/scripts/*.bats | wc -l
19
```

## Impact
- ✅ ドキュメントのみの変更
- ✅ 機能への影響なし
- ✅ テスト不要