### PR TITLE
docs: AGENTS.md のディレクトリ構造から重複エントリを削除

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,8 @@ pi-issue-runner/
 │   ├── improve.sh     # 継続的改善スクリプト
 │   ├── next.sh        # 次のタスク取得
 │   ├── nudge.sh       # セッションへメッセージ送信
-│   ├── restart-watcher.sh  # ウォッチャー再起動
 │   ├── wait-for-sessions.sh  # 複数セッション完了待機
 │   ├── watch-session.sh  # セッション監視
-│   ├── restart-watcher.sh  # ウォッチャー再起動
 │   └── test.sh        # テスト一括実行
 ├── lib/               # 共通ライブラリ
 │   ├── agent.sh       # マルチエージェント対応
@@ -126,7 +124,6 @@ pi-issue-runner/
 │   │   ├── list.bats
 │   │   ├── next.bats
 │   │   ├── nudge.bats
-│   │   ├── restart-watcher.bats
 │   │   ├── run.bats
 │   │   ├── run-batch.bats        # run-batch.sh のテスト
 │   │   ├── restart-watcher.bats  # restart-watcher.sh のテスト
@@ -134,8 +131,7 @@ pi-issue-runner/
 │   │   ├── stop.bats
 │   │   ├── test.bats
 │   │   ├── wait-for-sessions.bats
-│   │   ├── watch-session.bats
-│   │   └── restart-watcher.bats
+│   │   └── watch-session.bats
 │   ├── regression/    # 回帰テスト
 │   │   └── critical-fixes.bats
 │   ├── fixtures/      # テスト用フィクスチャ


### PR DESCRIPTION
## Summary
Closes #725

## Changes
- AGENTS.md の scripts/ セクションから restart-watcher.sh の重複2箇所を削除
- AGENTS.md の test/scripts/ セクションから restart-watcher.bats の重複2箇所を削除
- ディレクトリツリー構造を維持（├── と └── の正しい使用）

## Verification
```bash
# 検証結果
grep -c '│.*restart-watcher\.sh' AGENTS.md   # 2 (1つは実ファイル、1つはコメント内参照)
grep -c '│.*restart-watcher\.bats' AGENTS.md # 1
```

## Testing
- ✅ ディレクトリ構造のフォーマットが正しい
- ✅ 重複エントリが削除された
- ✅ 適切なエントリが残っている（コメント付き）