### PR TITLE
docs: improve_logs設定オプションをREADMEに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ github:
   include_comments: true  # Issueコメントを含める（デフォルト: true）
   max_comments: 10        # 最大コメント数（0 = 無制限）
 
+# improve-logs クリーンアップ設定
+improve_logs:
+  keep_recent: 10    # 直近N件のログを保持（0=全て保持）
+  keep_days: 7       # N日以内のログを保持（0=日数制限なし）
+  dir: .improve-logs # ログディレクトリ
+
 # エージェント設定（複数エージェント対応）
 agent:
   type: pi  # pi, claude, opencode, custom


### PR DESCRIPTION
## Summary
Closes #731

## Changes
- README.mdの設定セクションに `improve_logs` クリーンアップ設定を追加
- デフォルト値は `lib/config.sh` と一致
- `docs/configuration.md` との整合性を確保

## Testing
- `grep -A 5 'improve_logs' README.md` でYAMLフォーマットを確認
- `lib/config.sh` のデフォルト値と照合
- `docs/configuration.md` の記載内容と照合