### PR TITLE
chore: 計画書テンプレートにplans_dirテンプレート変数を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,7 @@ GitHub Issue #{{issue_number}} のテストを実行します。
 | `{{issue_title}}` | Issueタイトル | ✅ |
 | `{{branch_name}}` | ブランチ名 | ✅ |
 | `{{worktree_path}}` | worktreeのパス | ✅ |
+| `{{plans_dir}}` | 計画書ディレクトリパス | ✅ |
 | `{{step_name}}` | 現在のステップ名 | *カスタム用 |
 | `{{workflow_name}}` | ワークフロー名 | *カスタム用 |
 

--- a/agents/merge.md
+++ b/agents/merge.md
@@ -199,7 +199,7 @@ fi
 
 > **Note**: 以下のクリーンアップは `watch-session.sh` により自動的に行われます：
 > - Worktree の削除
-> - 計画書（`docs/plans/issue-{{issue_number}}-plan.md`）の削除
+> - 計画書（`{{plans_dir}}/issue-{{issue_number}}-plan.md`）の削除
 > 
 > 手動でクリーンアップが必要な場合は `scripts/cleanup.sh` を使用してください。
 

--- a/agents/plan.md
+++ b/agents/plan.md
@@ -36,7 +36,7 @@ GitHub Issue #{{issue_number}} の実装計画を作成します。
 5. **リスクと対策**: 潜在的な問題とその対処法
 
 ### 3. 出力
-ディレクトリがない場合は作成してから、計画書を `docs/plans/issue-{{issue_number}}-plan.md` に保存してください。
+ディレクトリがない場合は作成してから、計画書を `{{plans_dir}}/issue-{{issue_number}}-plan.md` に保存してください。
 
 ## 完了条件
 

--- a/lib/template.sh
+++ b/lib/template.sh
@@ -29,6 +29,7 @@ Push changes and create a pull request.'
 #   {{step_name}} - 現在のステップ名
 #   {{workflow_name}} - ワークフロー名
 #   {{pr_number}} - PR番号
+#   {{plans_dir}} - 計画書ディレクトリパス
 render_template() {
     local template="$1"
     local issue_number="${2:-}"
@@ -38,6 +39,7 @@ render_template() {
     local workflow_name="${6:-default}"
     local issue_title="${7:-}"
     local pr_number="${8:-}"
+    local plans_dir="${9:-docs/plans}"
     
     local result="$template"
     
@@ -49,6 +51,7 @@ render_template() {
     result="${result//\{\{step_name\}\}/$step_name}"
     result="${result//\{\{workflow_name\}\}/$workflow_name}"
     result="${result//\{\{pr_number\}\}/$pr_number}"
+    result="${result//\{\{plans_dir\}\}/$plans_dir}"
     
     echo "$result"
 }

--- a/lib/workflow-loader.sh
+++ b/lib/workflow-loader.sh
@@ -7,6 +7,7 @@ _WORKFLOW_LOADER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_WORKFLOW_LOADER_LIB_DIR/yaml.sh"
 source "$_WORKFLOW_LOADER_LIB_DIR/log.sh"
 source "$_WORKFLOW_LOADER_LIB_DIR/template.sh"
+source "$_WORKFLOW_LOADER_LIB_DIR/config.sh"
 
 # ビルトインワークフロー定義
 # workflows/ ディレクトリが存在しない場合に使用
@@ -114,6 +115,11 @@ get_agent_prompt() {
         prompt=$(cat "$agent_file")
     fi
     
+    # 設定から plans_dir を取得
+    load_config
+    local plans_dir
+    plans_dir=$(get_config plans_dir)
+    
     # テンプレート変数展開
-    render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "default" "$issue_title" "$pr_number"
+    render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "default" "$issue_title" "$pr_number" "$plans_dir"
 }

--- a/test/lib/template.bats
+++ b/test/lib/template.bats
@@ -135,3 +135,21 @@ teardown() {
     result="$(render_template "$template" "99" "fix/bug" "/tmp/wt" "implement" "default" "Fix Bug" "555")"
     [ "$result" = "Issue #99: Fix Bug on fix/bug at /tmp/wt, step implement of default, PR #555" ]
 }
+
+@test "render_template renders plans_dir with default value" {
+    template="Plan path: {{plans_dir}}/issue-{{issue_number}}-plan.md"
+    result="$(render_template "$template" "42")"
+    [ "$result" = "Plan path: docs/plans/issue-42-plan.md" ]
+}
+
+@test "render_template renders plans_dir with custom value" {
+    template="Plan path: {{plans_dir}}/issue-{{issue_number}}-plan.md"
+    result="$(render_template "$template" "42" "" "" "" "" "" "" "custom/plans")"
+    [ "$result" = "Plan path: custom/plans/issue-42-plan.md" ]
+}
+
+@test "render_template renders all variables including plans_dir" {
+    template="Issue #{{issue_number}}: {{issue_title}} on {{branch_name}} at {{worktree_path}}, step {{step_name}} of {{workflow_name}}, PR #{{pr_number}}, plans at {{plans_dir}}"
+    result="$(render_template "$template" "99" "fix/bug" "/tmp/wt" "implement" "default" "Fix Bug" "555" "my/plans")"
+    [ "$result" = "Issue #99: Fix Bug on fix/bug at /tmp/wt, step implement of default, PR #555, plans at my/plans" ]
+}


### PR DESCRIPTION
## Summary
Closes #734

## Changes
- **lib/template.sh**: `{{plans_dir}}` テンプレート変数を追加
- **lib/workflow-loader.sh**: config.shから `plans_dir` を取得してテンプレートに渡す
- **agents/plan.md**: ハードコードされたパス (`docs/plans/`) を `{{plans_dir}}` に変更
- **agents/merge.md**: ハードコードされたパス (`docs/plans/`) を `{{plans_dir}}` に変更
- **AGENTS.md**: テンプレート変数表に `{{plans_dir}}` を追加
- **test/lib/template.bats**: `plans_dir` のテストケースを追加

## Benefits
- `.pi-runner.yaml` の `plans.dir` 設定がエージェントテンプレートに正しく反映される
- 計画書の保存先をプロジェクトごとにカスタマイズ可能
- 後方互換性を維持（デフォルト値: `docs/plans`）

## Testing
- ✅ 全テスト（1157件）がパス
- ✅ ShellCheck警告なし
- ✅ デフォルト値とカスタム値の両方をテストカバー