### PR TITLE
feat: Add generic formatter/linter detection for CI fixes

### DIFF
--- a/agents/ci-fix.md
+++ b/agents/ci-fix.md
@@ -108,11 +108,22 @@ Refs #{{issue_number}}"
 ```bash
 cd "{{worktree_path}}"
 
-# フォーマット修正
-cargo fmt --all 2>&1 && echo "Format fixed" || true
+# ヘルパースクリプトのパス
+HELPER_SCRIPT="${HELPER_SCRIPT:-./scripts/ci-fix-helper.sh}"
 
-# Clippy修正
-cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features 2>&1 && echo "Lint fixed" || true
+# プロジェクトタイプに応じたフォーマット修正
+if "$HELPER_SCRIPT" fix format "{{worktree_path}}" 2>&1; then
+    echo "Format fixed"
+else
+    echo "Format fix failed or not available"
+fi
+
+# プロジェクトタイプに応じたLint修正
+if "$HELPER_SCRIPT" fix lint "{{worktree_path}}" 2>&1; then
+    echo "Lint fixed"
+else
+    echo "Lint fix failed or not available"
+fi
 
 # 変更を確認
 if git diff --quiet && git diff --cached --quiet; then

--- a/test/lib/ci-fix.bats
+++ b/test/lib/ci-fix.bats
@@ -120,3 +120,172 @@ teardown() {
     [[ -n "$MAX_RETRY_COUNT" ]]
     [[ -n "$FAILURE_TYPE_FORMAT" ]]
 }
+
+# ===================
+# detect_project_type テスト
+# ===================
+
+@test "detect_project_type function exists" {
+    declare -f detect_project_type
+}
+
+@test "detect_project_type returns rust for Cargo.toml" {
+    mkdir -p "$BATS_TEST_TMPDIR/rust-project"
+    touch "$BATS_TEST_TMPDIR/rust-project/Cargo.toml"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/rust-project"
+    [ "$status" -eq 0 ]
+    [ "$output" = "rust" ]
+}
+
+@test "detect_project_type returns node for package.json" {
+    mkdir -p "$BATS_TEST_TMPDIR/node-project"
+    touch "$BATS_TEST_TMPDIR/node-project/package.json"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/node-project"
+    [ "$status" -eq 0 ]
+    [ "$output" = "node" ]
+}
+
+@test "detect_project_type returns python for pyproject.toml" {
+    mkdir -p "$BATS_TEST_TMPDIR/python-project"
+    touch "$BATS_TEST_TMPDIR/python-project/pyproject.toml"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/python-project"
+    [ "$status" -eq 0 ]
+    [ "$output" = "python" ]
+}
+
+@test "detect_project_type returns python for setup.py" {
+    mkdir -p "$BATS_TEST_TMPDIR/python-project-setup"
+    touch "$BATS_TEST_TMPDIR/python-project-setup/setup.py"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/python-project-setup"
+    [ "$status" -eq 0 ]
+    [ "$output" = "python" ]
+}
+
+@test "detect_project_type returns go for go.mod" {
+    mkdir -p "$BATS_TEST_TMPDIR/go-project"
+    touch "$BATS_TEST_TMPDIR/go-project/go.mod"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/go-project"
+    [ "$status" -eq 0 ]
+    [ "$output" = "go" ]
+}
+
+@test "detect_project_type returns bash for .bats files" {
+    mkdir -p "$BATS_TEST_TMPDIR/bash-project"
+    touch "$BATS_TEST_TMPDIR/bash-project/test.bats"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/bash-project"
+    [ "$status" -eq 0 ]
+    [ "$output" = "bash" ]
+}
+
+@test "detect_project_type returns bash for test/test_helper.bash" {
+    mkdir -p "$BATS_TEST_TMPDIR/bash-project-helper/test"
+    touch "$BATS_TEST_TMPDIR/bash-project-helper/test/test_helper.bash"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/bash-project-helper"
+    [ "$status" -eq 0 ]
+    [ "$output" = "bash" ]
+}
+
+@test "detect_project_type returns unknown for unrecognized project" {
+    mkdir -p "$BATS_TEST_TMPDIR/unknown-project"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/unknown-project"
+    [ "$status" -eq 1 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "detect_project_type prioritizes rust over node" {
+    mkdir -p "$BATS_TEST_TMPDIR/mixed-project"
+    touch "$BATS_TEST_TMPDIR/mixed-project/Cargo.toml"
+    touch "$BATS_TEST_TMPDIR/mixed-project/package.json"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/mixed-project"
+    [ "$status" -eq 0 ]
+    [ "$output" = "rust" ]
+}
+
+@test "detect_project_type prioritizes node over python" {
+    mkdir -p "$BATS_TEST_TMPDIR/mixed-node-python"
+    touch "$BATS_TEST_TMPDIR/mixed-node-python/package.json"
+    touch "$BATS_TEST_TMPDIR/mixed-node-python/pyproject.toml"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/mixed-node-python"
+    [ "$status" -eq 0 ]
+    [ "$output" = "node" ]
+}
+
+@test "detect_project_type prioritizes python over go" {
+    mkdir -p "$BATS_TEST_TMPDIR/mixed-python-go"
+    touch "$BATS_TEST_TMPDIR/mixed-python-go/pyproject.toml"
+    touch "$BATS_TEST_TMPDIR/mixed-python-go/go.mod"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/mixed-python-go"
+    [ "$status" -eq 0 ]
+    [ "$output" = "python" ]
+}
+
+@test "detect_project_type prioritizes go over bash" {
+    mkdir -p "$BATS_TEST_TMPDIR/mixed-go-bash"
+    touch "$BATS_TEST_TMPDIR/mixed-go-bash/go.mod"
+    touch "$BATS_TEST_TMPDIR/mixed-go-bash/test.bats"
+    
+    run detect_project_type "$BATS_TEST_TMPDIR/mixed-go-bash"
+    [ "$status" -eq 0 ]
+    [ "$output" = "go" ]
+}
+
+# ===================
+# try_fix_format 汎用化テスト
+# ===================
+
+@test "try_fix_format detects project type and returns appropriate status" {
+    # Rustプロジェクトの場合（cargoがない環境では失敗する）
+    mkdir -p "$BATS_TEST_TMPDIR/rust-format-test"
+    touch "$BATS_TEST_TMPDIR/rust-format-test/Cargo.toml"
+    
+    run try_fix_format "$BATS_TEST_TMPDIR/rust-format-test"
+    # cargoがない場合は1、ある場合は0か1（フォーマット結果による）
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+@test "try_fix_format returns 2 for unknown project type" {
+    mkdir -p "$BATS_TEST_TMPDIR/unknown-format-test"
+    
+    run try_fix_format "$BATS_TEST_TMPDIR/unknown-format-test"
+    [ "$status" -eq 2 ]
+}
+
+# ===================
+# try_fix_lint 汎用化テスト
+# ===================
+
+@test "try_fix_lint detects project type and returns appropriate status" {
+    # Rustプロジェクトの場合（cargoがない環境では失敗する）
+    mkdir -p "$BATS_TEST_TMPDIR/rust-lint-test"
+    touch "$BATS_TEST_TMPDIR/rust-lint-test/Cargo.toml"
+    
+    run try_fix_lint "$BATS_TEST_TMPDIR/rust-lint-test"
+    # cargoがない場合は1、ある場合は0か1（lint結果による）
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+@test "try_fix_lint returns 2 for unknown project type" {
+    mkdir -p "$BATS_TEST_TMPDIR/unknown-lint-test"
+    
+    run try_fix_lint "$BATS_TEST_TMPDIR/unknown-lint-test"
+    [ "$status" -eq 2 ]
+}
+
+@test "try_fix_lint returns 2 for bash projects (shellcheck does not support auto-fix)" {
+    mkdir -p "$BATS_TEST_TMPDIR/bash-lint-test"
+    touch "$BATS_TEST_TMPDIR/bash-lint-test/test.bats"
+    
+    run try_fix_lint "$BATS_TEST_TMPDIR/bash-lint-test"
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary
Closes #733

## Changes
- Added `detect_project_type()` function to detect project type (Rust, Node, Python, Go, Bash)
- Refactored `try_fix_format()` to support multiple languages:
  - Rust: cargo fmt
  - Node: npm run format || npx prettier
  - Python: black || autopep8
  - Go: gofmt
  - Bash: shfmt
- Refactored `try_fix_lint()` to support multiple languages:
  - Rust: cargo clippy
  - Node: npm run lint:fix || npx eslint
  - Python: autopep8
  - Go: golangci-lint
  - Bash: N/A (shellcheck doesn't support auto-fix)
- Updated `agents/ci-fix.md` to use helper script instead of hardcoded cargo commands
- Added 24 comprehensive tests for new functionality
- Maintained backward compatibility with existing Rust projects

## Testing
- ✅ All 1172 tests pass
- ✅ ShellCheck: No warnings
- ✅ Project type detection tested for all supported languages
- ✅ Format/lint fix functions tested for each project type
- ✅ Priority order tested for mixed-language projects
- ✅ Unknown project type handling tested

## Documentation
- ✅ Implementation plan created (docs/plans/issue-733-plan.md)
- ✅ Code comments added for all new functions
- ✅ Function documentation includes usage and return values