### PR TITLE
docs: README.md と SKILL.md の前提条件セクションの不一致を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,12 @@ GitHub Issueを入力として、Git worktreeを作成し、tmuxセッション�
 
 ## 前提条件
 
-```bash
-# GitHub CLI（認証済み）
-gh auth status
-
-# tmux
-which tmux
-
-# pi
-which pi
-
-# jq (JSON処理)
-which jq
-
-# yq (YAML処理、オプション - なくてもフォールバックで動作)
-which yq  # オプション
-```
+- **Bash 4.0以上** (macOSの場合: `brew install bash`)
+- `gh` (GitHub CLI、認証済み)
+- `tmux`
+- `pi`
+- `jq` (JSON処理)
+- `yq` (オプション - ワークフローのカスタマイズに必要)
 
 ## インストール
 


### PR DESCRIPTION
## Summary
Closes #740

## Changes
- README.mdの前提条件セクションにBash 4.0以上の要件を追加
- yqの説明をSKILL.mdと統一（「ワークフローのカスタマイズに必要」）
- コードブロック形式から箇条書き形式に変更し、SKILL.mdとフォーマットを統一

## Testing
- 全テストがパス（./scripts/test.sh）
- README.mdとSKILL.mdの前提条件セクションが一致することを確認