### PR TITLE
docs: ドキュメント参照の不整合を修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ pi-issue-runner/
 │   │   ├── nudge.bats
 │   │   ├── run.bats
 │   │   ├── run-batch.bats        # run-batch.sh のテスト
+│   │   ├── restart-watcher.bats  # restart-watcher.sh のテスト
 │   │   ├── status.bats
 │   │   ├── stop.bats
 │   │   ├── test.bats

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ GitHub Issueを入力として、独立したworktree環境でpiインスタン�
 - [ディレクトリ構造](./SPECIFICATION.md#ディレクトリ構造)
 - [API設計](./architecture.md#2-library-layer-lib)
 - [エラーハンドリング](./architecture.md#エラーハンドリング)
+- [コーディング規約](./coding-standards.md)
 
 ### 運用者向け
 


### PR DESCRIPTION
## Summary
Closes #748

## Changes
- `docs/README.md` に `coding-standards.md` への参照を追加（開発者向けセクション）
- `AGENTS.md` に `restart-watcher.bats` を追加（test/scripts/ セクション）

## Details

### 1. coding-standards.md への参照追加
- **場所**: `docs/README.md` の「開発者向け」セクション
- **理由**: コーディング規約ドキュメントの発見性を向上
- **内容**: シェルスクリプトのヘッダーフォーマット、スタイルガイドライン、命名規則

### 2. restart-watcher.bats の記載追加
- **場所**: `AGENTS.md` の `test/scripts/` セクション
- **理由**: 実際のファイル構造とドキュメントの一致
- **配置**: アルファベット順（run-batch.bats と status.bats の間）

## Testing
- ✅ `coding-standards.md` への参照が `docs/README.md` に追加されていることを確認
- ✅ `restart-watcher.bats` が `AGENTS.md` に記載されていることを確認
- ✅ 全ての .bats ファイルが `AGENTS.md` に記載されていることを確認
- ✅ Markdown フォーマットの整合性を確認

## Type
- [x] Documentation
- [ ] Feature
- [ ] Bug Fix
- [ ] Refactoring

## Priority
P3 (Low) - ドキュメントの品質改善