### PR TITLE
fix: list_available_workflows()がビルトインのthoroughとci-fixワークフローを正しく表示しない

### DIFF
--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -124,8 +124,11 @@ get_workflow_steps_array() {
 list_available_workflows() {
     local project_root="${1:-.}"
     
-    echo "default: 完全ワークフロー（計画・実装・レビュー・マージ）"
+    # ビルトインワークフローを明示的に表示
+    echo "default: 完全なワークフロー（計画・実装・レビュー・マージ）"
     echo "simple: 簡易ワークフロー（実装・マージのみ）"
+    echo "thorough: 徹底ワークフロー（計画・実装・テスト・レビュー・マージ）"
+    echo "ci-fix: CI失敗を検出し自動修正を試行"
     
     # プロジェクト固有のワークフロー
     if [[ -d "$project_root/workflows" ]]; then
@@ -133,7 +136,8 @@ list_available_workflows() {
             if [[ -f "$f" ]]; then
                 local name
                 name="$(basename "$f" .yaml)"
-                if [[ "$name" != "default" && "$name" != "simple" ]]; then
+                # ビルトインワークフローを除外
+                if [[ "$name" != "default" && "$name" != "simple" && "$name" != "thorough" && "$name" != "ci-fix" ]]; then
                     echo "$name: (custom workflow)"
                 fi
             fi


### PR DESCRIPTION
## Summary
Closes #752

## Changes
- `lib/workflow.sh`の`list_available_workflows()`関数に `thorough` と `ci-fix` を追加
- カスタムワークフロー判定の条件も更新して、これらを除外するように修正
- YAMLファイルのdescriptionフィールドと完全に一致

## Testing
- 全テストがパス (1175 tests)
- `./scripts/run.sh --list-workflows` で動作確認済み

### 期待される出力
```
default: 完全なワークフロー（計画・実装・レビュー・マージ）
simple: 簡易ワークフロー（実装・マージのみ）
thorough: 徹底ワークフロー（計画・実装・テスト・レビュー・マージ）
ci-fix: CI失敗を検出し自動修正を試行
```