### PR TITLE
fix: template.shのビルトインエージェントプロンプトにtestとci-fixを追加

### DIFF
--- a/lib/template.sh
+++ b/lib/template.sh
@@ -16,6 +16,12 @@ Check code quality, tests, and documentation.'
 _BUILTIN_AGENT_MERGE='Create a PR and merge for issue #{{issue_number}}.
 Push changes and create a pull request.'
 
+_BUILTIN_AGENT_TEST='Test the implementation for issue #{{issue_number}}.
+Run existing tests and verify all tests pass.'
+
+_BUILTIN_AGENT_CI_FIX='Fix CI failures for issue #{{issue_number}}.
+Analyze CI logs, identify the failure, and fix the code.'
+
 # ===================
 # テンプレート処理
 # ===================

--- a/lib/workflow-loader.sh
+++ b/lib/workflow-loader.sh
@@ -101,6 +101,12 @@ get_agent_prompt() {
             merge)
                 prompt="$_BUILTIN_AGENT_MERGE"
                 ;;
+            test)
+                prompt="$_BUILTIN_AGENT_TEST"
+                ;;
+            ci-fix)
+                prompt="$_BUILTIN_AGENT_CI_FIX"
+                ;;
             *)
                 log_warn "Unknown builtin agent: $agent_name, using implement"
                 prompt="$_BUILTIN_AGENT_IMPLEMENT"


### PR DESCRIPTION
## Summary
Closes #753

## Changes
- `lib/template.sh` に `_BUILTIN_AGENT_TEST` 変数を追加
- `lib/template.sh` に `_BUILTIN_AGENT_CI_FIX` 変数を追加  
- `lib/workflow-loader.sh` の `get_agent_prompt()` 関数に `test` ケースを追加
- `lib/workflow-loader.sh` の `get_agent_prompt()` 関数に `ci-fix` ケースを追加

これにより、`agents/test.md` や `agents/ci-fix.md` が削除された場合でも、ビルトインのフォールバックプロンプトが使用されるようになります。

## Testing
- ✅ 全テストがパス（1175 tests）
- ✅ ShellCheck エラーなし
- ✅ ビルトインフォールバックの動作確認済み
- ✅ テンプレート変数展開の動作確認済み

## Files Changed
- `lib/template.sh` (+6 lines)
- `lib/workflow-loader.sh` (+6 lines)

## Related
- Workflows: `workflows/thorough.yaml` (uses `test` step), `workflows/ci-fix.yaml` (uses `ci-fix` step)
- Agent templates: `agents/test.md`, `agents/ci-fix.md`