### PR TITLE
docs: README.md のドキュメントセクションに coding-standards.md への参照を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ gh auth login
 - [状態管理](docs/state-management.md) - ステータスファイル管理
 - [設定リファレンス](docs/configuration.md) - 設定オプション
 - [セキュリティ](docs/security.md) - 入力サニタイズとセキュリティ対策
+- [コーディング規約](docs/coding-standards.md) - 開発ガイドライン
 - [変更履歴](docs/CHANGELOG.md) - バージョン履歴
 
 ## 開発


### PR DESCRIPTION
## Summary
Closes #771

## Changes
- README.md の「ドキュメント」セクションに `docs/coding-standards.md` への参照を追加
- 追加位置: セキュリティの後、変更履歴の前
- 説明: "開発ガイドライン"

## Testing
- ファイル `docs/coding-standards.md` の存在を確認済み
- 相対パス `docs/coding-standards.md` が正確であることを確認
- ドキュメントリストのフォーマットが既存のエントリと一致していることを確認

## Impact
- ドキュメントの追加のみ、コードへの影響なし
- 開発者がコーディング規約を見つけやすくなる