### PR TITLE
docs: AGENTS.md のディレクトリ構造に verify-config-docs 関連ファイルを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,10 @@ pi-issue-runner/
 │   ├── improve.sh     # 継続的改善スクリプト
 │   ├── next.sh        # 次のタスク取得
 │   ├── nudge.sh       # セッションへメッセージ送信
+│   ├── test.sh        # テスト一括実行
+│   ├── verify-config-docs.sh  # 設定ドキュメントの整合性検証
 │   ├── wait-for-sessions.sh  # 複数セッション完了待機
-│   ├── watch-session.sh  # セッション監視
-│   └── test.sh        # テスト一括実行
+│   └── watch-session.sh  # セッション監視
 ├── lib/               # 共通ライブラリ
 │   ├── agent.sh       # マルチエージェント対応
 │   ├── batch.sh       # バッチ処理コア機能
@@ -134,6 +135,7 @@ pi-issue-runner/
 │   │   ├── status.bats
 │   │   ├── stop.bats
 │   │   ├── test.bats
+│   │   ├── verify-config-docs.bats
 │   │   ├── wait-for-sessions.bats
 │   │   └── watch-session.bats
 │   ├── regression/    # 回帰テスト


### PR DESCRIPTION
## Summary
Closes #770

## Changes
- `scripts/verify-config-docs.sh` を AGENTS.md の scripts/ セクションに追加
- `test/scripts/verify-config-docs.bats` を AGENTS.md の test/scripts/ セクションに追加
- ディレクトリ構造をアルファベット順で整列

## Testing
- [x] `grep "verify-config-docs" AGENTS.md` で2行が検出されることを確認
- [x] ファイルが実際に存在することを確認
- [x] アルファベット順が正しいことを確認
- [x] ツリー構造の記号（├── と └──）が正しいことを確認

## Impact
ドキュメントのみの変更。コードへの影響なし。