### PR TITLE
fix: remove unused INTERVAL and LINES variables in mux-all.sh

### DIFF
--- a/scripts/mux-all.sh
+++ b/scripts/mux-all.sh
@@ -14,8 +14,6 @@
 #   -a, --all           All *-issue-* sessions (ignore prefix)
 #   -p, --prefix NAME   Specific prefix (e.g., dict)
 #   -w, --watch         Watch mode: xpanes tiled view
-#   -l, --lines NUM     Lines to show in watch mode (default: 100)
-#   -i, --interval SEC  Refresh interval in watch mode (default: 2)
 #   -k, --kill          Kill existing monitor session first
 #   -h, --help          Show help message
 #
@@ -35,8 +33,6 @@ source "$SCRIPT_DIR/../lib/tmux.sh"
 MONITOR_SESSION="pi-monitor"
 KILL_EXISTING=false
 WATCH_MODE=false
-LINES=100
-INTERVAL=2
 ALL_SESSIONS=false
 PREFIX=""
 
@@ -60,8 +56,6 @@ Options:
     -a, --all           全ての *-issue-* セッションを対象
     -p, --prefix NAME   特定のプレフィックスを指定（例: dict）
     -w, --watch         ウォッチモード（xpanesでタイル表示）
-    -l, --lines NUM     表示行数（ウォッチモード用、default: 100）
-    -i, --interval SEC  更新間隔（ウォッチモード用、default: 2）
     -k, --kill          既存のモニターセッションを削除して再作成
     -h, --help          このヘルプを表示
 
@@ -210,14 +204,6 @@ main() {
             -w|--watch)
                 WATCH_MODE=true
                 shift
-                ;;
-            -l|--lines)
-                LINES="$2"
-                shift 2
-                ;;
-            -i|--interval)
-                INTERVAL="$2"
-                shift 2
                 ;;
             -k|--kill)
                 KILL_EXISTING=true


### PR DESCRIPTION
## Summary
Closes #775

## Problem
ShellCheck SC2034 warnings were being triggered by unused variables `$INTERVAL` and `$LINES` in `scripts/mux-all.sh`. These variables were defined and could be set via `--lines` and `--interval` command-line options, but were never actually used in the script.

## Solution
Removed the unused variables and their associated command-line options:
- Removed `LINES=100` and `INTERVAL=2` variable definitions
- Removed `--lines` and `--interval` options from help messages (both English and Japanese)
- Removed option parsing for `-l|--lines` and `-i|--interval`

## Changes
- `scripts/mux-all.sh`: Removed 14 lines total
  - 2 lines: variable definitions
  - 4 lines: help/usage documentation
  - 8 lines: option parsing code

## Testing
- ✅ `shellcheck -x scripts/mux-all.sh` passes with no warnings
- ✅ `./scripts/test.sh --shellcheck` passes (52 files checked)
- ✅ Removed options correctly show "Unknown option" error
- ✅ Help message displays correctly
- ✅ Existing functionality unaffected

## Impact
This is technically a breaking change for users who might have been using `--lines` or `--interval` options, but:
1. These options never actually worked (they were parsed but never used)
2. Users will get clear error messages if they try to use these options
3. No actual functionality is lost

## Verification
```bash
# ShellCheck passes
shellcheck -x scripts/mux-all.sh

# Options correctly rejected
./scripts/mux-all.sh --lines 50    # Shows: Unknown option: --lines
./scripts/mux-all.sh --interval 5  # Shows: Unknown option: --interval
```