### PR TITLE
refactor: 未使用のユーティリティ関数を活用

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -63,6 +63,9 @@ Options:
     --pi-args ARGS      --agent-args のエイリアス（後方互換性）
     --list-workflows    利用可能なワークフロー一覧を表示
     --ignore-blockers   依存関係チェックをスキップして強制実行
+    --show-config       現在の設定を表示（デバッグ用）
+    --list-agents       利用可能なエージェントプリセット一覧を表示
+    --show-agent-config エージェント設定を表示（デバッグ用）
     -h, --help          このヘルプを表示
 
 Examples:
@@ -77,7 +80,7 @@ Examples:
 EOF
 }
 
-# ヘルプと--list-workflowsを先に処理（依存関係チェック前）
+# ヘルプと情報表示オプションを先に処理（依存関係チェック前）
 for arg in "$@"; do
     case "$arg" in
         -h|--help)
@@ -91,6 +94,28 @@ for arg in "$@"; do
             source "$SCRIPT_DIR/../lib/workflow.sh"
             log_info "Available workflows:"
             list_available_workflows
+            exit 0
+            ;;
+        --show-config)
+            source "$SCRIPT_DIR/../lib/config.sh"
+            source "$SCRIPT_DIR/../lib/log.sh"
+            load_config
+            show_config
+            exit 0
+            ;;
+        --list-agents)
+            source "$SCRIPT_DIR/../lib/config.sh"
+            source "$SCRIPT_DIR/../lib/log.sh"
+            source "$SCRIPT_DIR/../lib/agent.sh"
+            list_agent_presets
+            exit 0
+            ;;
+        --show-agent-config)
+            source "$SCRIPT_DIR/../lib/config.sh"
+            source "$SCRIPT_DIR/../lib/log.sh"
+            source "$SCRIPT_DIR/../lib/agent.sh"
+            load_config
+            show_agent_config
             exit 0
             ;;
     esac

--- a/test/scripts/run.bats
+++ b/test/scripts/run.bats
@@ -307,3 +307,46 @@ MOCK_EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"ignore"* ]] || [[ "$output" == *"blockers"* ]] || [[ "$output" == *"skip"* ]]
 }
+
+# ====================
+# デバッグオプションテスト
+# ====================
+
+@test "run.sh --show-config displays configuration" {
+    run "$PROJECT_ROOT/scripts/run.sh" --show-config
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"=== Configuration ==="* ]]
+    [[ "$output" == *"worktree_base_dir:"* ]]
+}
+
+@test "run.sh --list-agents displays agent presets" {
+    run "$PROJECT_ROOT/scripts/run.sh" --list-agents
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Available agent presets:"* ]]
+    [[ "$output" == *"pi"* ]]
+}
+
+@test "run.sh --show-agent-config displays agent configuration" {
+    run "$PROJECT_ROOT/scripts/run.sh" --show-agent-config
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"=== Agent Configuration ==="* ]]
+    [[ "$output" == *"type:"* ]]
+}
+
+@test "run.sh help includes --show-config option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--show-config"* ]]
+}
+
+@test "run.sh help includes --list-agents option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--list-agents"* ]]
+}
+
+@test "run.sh help includes --show-agent-config option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--show-agent-config"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #793

## Changes
- **未使用関数の活用**: `lib/agent.sh` と `lib/config.sh` の未使用関数を活用
- **新しいデバッグオプション**: `scripts/run.sh` に3つのデバッグオプションを追加
  - `--show-config`: 現在の設定を表示
  - `--list-agents`: 利用可能なエージェントプリセット一覧を表示
  - `--show-agent-config`: エージェント設定を表示
- **テスト追加**: 6つの新しいテストケースを追加

## Testing
- ✅ 全1,275テストがパス
- ✅ ShellCheck警告なし
- ✅ 新しいデバッグオプションの動作確認完了

## Files Modified
- `scripts/run.sh`: デバッグオプションの追加
- `test/scripts/run.bats`: テストケースの追加
- `docs/plans/issue-793-plan.md`: 実装計画書

## Examples
```bash
# 現在の設定を表示
./scripts/run.sh --show-config

# エージェントプリセット一覧
./scripts/run.sh --list-agents

# エージェント設定を表示
./scripts/run.sh --show-agent-config
```