### PR TITLE
docs: テンプレート変数リファレンスに {{plans_dir}} と {{pr_number}} を追加

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -515,6 +515,8 @@ agent:
 | `{{worktree_path}}` | worktreeのパス | `.worktrees/issue-411` |
 | `{{step_name}}` | 現在のステップ名 | `plan`, `implement` |
 | `{{workflow_name}}` | ワークフロー名 | `default`, `simple` |
+| `{{plans_dir}}` | 計画書ディレクトリパス | `docs/plans` |
+| `{{pr_number}}` | PR番号 | `123` |
 
 **使用例**:
 ```markdown


### PR DESCRIPTION
## Summary
Closes #801

## Changes
- `docs/configuration.md` のテンプレート変数リファレンステーブルに `{{plans_dir}}` と `{{pr_number}}` を追加
- これらの変数は `lib/template.sh` で既に実装されており、エージェントテンプレート（`agents/ci-fix.md`, `agents/merge.md`, `agents/plan.md`）で使用されています

## Testing
- ✅ 変数の整合性を確認（lib/template.sh ↔ docs/configuration.md）
- ✅ 全8個のテンプレート変数がドキュメントに記載されていることを確認
- ✅ テーブルのフォーマットが正しいことを確認

## Variables Added
| 変数 | 説明 | 例 |
|------|------|-----|
| `{{plans_dir}}` | 計画書ディレクトリパス | `docs/plans` |
| `{{pr_number}}` | PR番号 | `123` |