### PR TITLE
docs: AGENTS.mdにtest/scripts/mux-all.batsの記載を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ pi-issue-runner/
 │   │   ├── improve.bats
 │   │   ├── init.bats
 │   │   ├── list.bats
+│   │   ├── mux-all.bats         # mux-all.sh のテスト
 │   │   ├── next.bats
 │   │   ├── nudge.bats
 │   │   ├── run.bats


### PR DESCRIPTION
## Summary
Closes #804

## Changes
- AGENTS.mdの`test/scripts/`セクションに`mux-all.bats`のエントリを追加
- アルファベット順に正しく配置（`list.bats`と`next.bats`の間）
- コメント形式を他のエントリと統一: `# mux-all.sh のテスト`

## Testing
- ファイルの存在確認: `test/scripts/mux-all.bats`が実際に存在することを確認済み
- フォーマット確認: 既存のエントリと同じ形式で記載
- 配置確認: アルファベット順に正しく配置されていることを確認済み

## Documentation
このPRはドキュメント更新のみで、コード変更は含まれません。