### PR TITLE
docs: README.mdとSKILL.mdにrun.shのデバッグオプションを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ scripts/run.sh 42 --force
 scripts/run.sh 42 --agent-args "--verbose"
 # または従来のオプション（後方互換性）
 scripts/run.sh 42 --pi-args "--verbose"
+
+# デバッグオプション
+scripts/run.sh --show-config           # 現在の設定を表示
+scripts/run.sh --list-agents           # 利用可能なエージェント一覧
+scripts/run.sh 42 --show-agent-config  # エージェント設定を表示
 ```
 
 ### コンテキスト永続化

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,6 +26,9 @@ Options:
   --agent-args <args>    エージェントに渡す追加の引数
   --pi-args <args>       --agent-args のエイリアス（後方互換性）
   --ignore-blockers      依存関係チェックをスキップして強制実行
+  --show-config          現在の設定を表示（デバッグ用）
+  --list-agents          利用可能なエージェントプリセット一覧を表示
+  --show-agent-config    エージェント設定を表示（デバッグ用）
 
 # バッチ実行（依存関係順）
 scripts/run-batch.sh <issue>... [options]


### PR DESCRIPTION
## Summary
Closes #805

## Changes
- README.mdに3つのデバッグオプションを追記（--show-config, --list-agents, --show-agent-config）
- SKILL.mdのOptionsセクションに同じ3つのデバッグオプションを追記
- run.sh --helpの出力とドキュメントの整合性を確保

## Testing
- 各デバッグオプションが正しく動作することを確認
- ドキュメントの記載がrun.sh --helpの出力と一致することを確認

## Screenshots
```bash
$ ./scripts/run.sh --help | grep -E 'show-config|list-agents|show-agent-config'
    --show-config       現在の設定を表示（デバッグ用）
    --list-agents       利用可能なエージェントプリセット一覧を表示
    --show-agent-config エージェント設定を表示（デバッグ用）
```