### PR TITLE
docs: docs/workflows.md にビルトインワークフロー（thorough, ci-fix）の説明を追加

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -44,6 +44,54 @@ steps:
   - merge     # PRの作成とマージ
 ```
 
+### thorough - 徹底ワークフロー
+
+大規模な変更や重要な機能向けに、計画・実装・テスト・レビュー・マージの5ステップを実行します。
+
+| ステップ | 説明 |
+|----------|------|
+| `plan` | Issue分析と実装計画の作成 |
+| `implement` | コード実装 |
+| `test` | テスト実行とカバレッジ確認 |
+| `review` | セルフレビューと品質確認 |
+| `merge` | PR作成とマージ |
+
+```yaml
+# workflows/thorough.yaml
+name: thorough
+description: 徹底ワークフロー（計画・実装・テスト・レビュー・マージ）
+steps:
+  - plan
+  - implement
+  - test
+  - review
+  - merge
+```
+
+### ci-fix - CI修正ワークフロー
+
+CI失敗を検出し、自動修正を試行します。マージエージェントから自動的に呼び出されることもあります。
+
+| ステップ | 説明 |
+|----------|------|
+| `ci-fix` | CI失敗を検出し自動修正を試行 |
+
+```yaml
+# workflows/ci-fix.yaml
+name: ci-fix
+description: CI失敗を検出し自動修正を試行
+steps:
+  - ci-fix
+```
+
+**使用例**:
+```bash
+# 手動でCI修正を実行
+./scripts/run.sh 42 --workflow ci-fix
+```
+
+> **注意**: このワークフローは通常、マージエージェントによって自動的に呼び出されます。手動実行は主にテストやデバッグ目的で使用します。
+
 ## 使用方法
 
 ### ワークフローの指定
@@ -66,13 +114,13 @@ steps:
 `workflows/` ディレクトリにYAMLファイルを作成します：
 
 ```yaml
-# workflows/thorough.yaml
-name: thorough
-description: 徹底ワークフロー（計画・実装・テスト・レビュー・マージ）
+# workflows/custom-example.yaml
+name: custom-example
+description: カスタムワークフロー例（計画・実装・検証・レビュー・マージ）
 steps:
   - plan
   - implement
-  - test
+  - validate  # カスタムステップ
   - review
   - merge
 ```
@@ -91,21 +139,21 @@ steps:
 `agents/` ディレクトリにMarkdownファイルを作成します：
 
 ```markdown
-# agents/test.md（カスタムステップの例）
-# Test Agent
+# agents/validate.md（カスタムステップの例）
+# Validate Agent
 
-GitHub Issue #{{issue_number}} のテストを実行します。
+GitHub Issue #{{issue_number}} の実装を検証します。
 
 ## タスク
-1. 単体テストを実行
-2. 結合テストを実行
-3. カバレッジレポートを確認
+1. コードスタイルをチェック
+2. セキュリティスキャンを実行
+3. パフォーマンステストを実行
 ```
 
 ### 3. カスタムワークフローの使用
 
 ```bash
-./scripts/run.sh 42 --workflow thorough
+./scripts/run.sh 42 --workflow custom-example
 ```
 
 > **注意**: カスタムワークフローで定義したステップに対応するエージェントテンプレートが存在しない場合、ビルトインのフォールバックプロンプトが使用されます。最適な結果を得るには、各ステップ用のテンプレートを作成してください。


### PR DESCRIPTION
## Summary
Closes #810

## Changes
- **thorough ワークフローの説明を追加**: 5ステップ（plan, implement, test, review, merge）の徹底ワークフローをビルトインワークフローセクションに追加
- **ci-fix ワークフローの説明を追加**: CI失敗を自動修正するワークフローをビルトインワークフローセクションに追加
- **カスタムワークフロー作成例を修正**: `thorough` から `custom-example` に変更し、カスタムステップ `validate` を使用した例に更新

## Impact
これにより、`--list-workflows` で表示される全てのビルトインワークフロー（default, simple, thorough, ci-fix）が docs/workflows.md に記載されます。

## Testing
- ✅ All 4 workflows from `--list-workflows` are documented
- ✅ ShellCheck passes (52 files checked)
- ✅ Custom workflow example no longer conflicts with built-in `thorough` workflow
- ✅ Documentation style is consistent across all workflow sections

## Documentation Structure
```
ビルトインワークフロー
├── default   (既存)
├── simple    (既存)
├── thorough  (新規追加)
└── ci-fix    (新規追加)
```