### PR TITLE
docs: 設定ドキュメントの tmux から multiplexer への命名統一

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,8 +36,6 @@ worktree:
     - config/secrets.yml     # 例: Railsプロジェクトの場合
 
 # =====================================
-# tmux設定
-# =====================================
 # マルチプレクサ設定
 # =====================================
 multiplexer:
@@ -684,7 +682,7 @@ worktree:
     - ".env.local"
     - ".envrc"
 
-tmux:
+multiplexer:
   start_in_session: true
 
 pi:
@@ -704,7 +702,7 @@ worktree:
   copy_files:
     - ".env.production"
 
-tmux:
+multiplexer:
   start_in_session: false  # 非対話モード
 
 parallel:


### PR DESCRIPTION
## Summary
Closes #818

## Changes
- ✅ 重複していた古い「tmux設定」セクションヘッダーを削除（3行）
- ✅ 開発環境の設定例を `tmux:` から `multiplexer:` に変更
- ✅ 本番環境の設定例を `tmux:` から `multiplexer:` に変更
- ✅ lib/config.sh の実装（`CONFIG_MULTIPLEXER_*`）と命名が統一された

## Testing
- ✅ `./scripts/verify-config-docs.sh` - PASSED
- ✅ `grep -n "^tmux:" docs/configuration.md` - No matches (全て修正済み)
- ✅ `grep -n "^multiplexer:" docs/configuration.md` - 4箇所検出（正常）

## Verification
```bash
# tmux: セクションが残っていないことを確認
grep -n "^tmux:" docs/configuration.md
# → 出力なし ✅

# multiplexer: セクションが正しく存在
grep -n "^multiplexer:" docs/configuration.md
# → 41:multiplexer:
# → 194:multiplexer:
# → 685:multiplexer:
# → 705:multiplexer:
```