### PR TITLE
fix(agents/merge.md): add feature/ prefix to git push command

### DIFF
--- a/agents/merge.md
+++ b/agents/merge.md
@@ -26,7 +26,7 @@ GitHub Issue #{{issue_number}} のPRを作成し、マージします。
 
 ### 1. プッシュ
 ```bash
-git push -u origin {{branch_name}}
+git push -u origin feature/{{branch_name}}
 ```
 
 ### 2. PR作成


### PR DESCRIPTION
## Summary
Closes #814

## Changes
- Modified `agents/merge.md` line 29: `git push -u origin {{branch_name}}` → `git push -u origin feature/{{branch_name}}`
- This aligns with the branch creation in `lib/worktree.sh` which uses `feature/${branch_name}` prefix

## Testing
- Verified that `lib/worktree.sh` creates branches with `feature/` prefix (lines 32, 34, 36, 39)
- Confirmed no other agent templates have similar issues
- All git push commands in other files use correct syntax (no arguments or correct branch reference)

## Impact
- This is a documentation fix only (agent template)
- No code logic changes
- Ensures first push after worktree creation will succeed