### PR TITLE
fix(agents/merge.md): BASH_SOURCE がMarkdownテンプレート内で機能しない

### DIFF
--- a/agents/merge.md
+++ b/agents/merge.md
@@ -124,9 +124,8 @@ $FAILED_LOGS
     
     echo "🛠️ Attempting auto-fix for failure type: $FAILURE_TYPE"
     
-    # ci-fix-helper.sh のパスを解決
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-    CI_FIX_HELPER="$SCRIPT_DIR/scripts/ci-fix-helper.sh"
+    # ci-fix-helper.sh のパスを解決（worktree内の相対パス）
+    CI_FIX_HELPER="./scripts/ci-fix-helper.sh"
     
     if [[ -f "$CI_FIX_HELPER" ]]; then
       # ci-fix-helper.sh を使用（プロジェクトタイプを自動検出）


### PR DESCRIPTION
## Summary
Closes #815

## Changes
- `agents/merge.md` 内の `BASH_SOURCE[0]` を使用したパス解決を、worktree内の相対パス（`./scripts/ci-fix-helper.sh`）に変更
- Markdownテンプレートから実行されるコードでは `BASH_SOURCE` が正しく機能しないため、よりシンプルで確実な相対パスを使用
- `agents/ci-fix.md` と同じアプローチで一貫性を保持

## Technical Details
### Before
```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
CI_FIX_HELPER="$SCRIPT_DIR/scripts/ci-fix-helper.sh"
```

### After
```bash
CI_FIX_HELPER="./scripts/ci-fix-helper.sh"
```

## Testing
- ✅ Verified no more `BASH_SOURCE` usage in `agents/` directory
- ✅ Path resolution is simpler and more reliable
- ✅ Consistent with existing patterns in `agents/ci-fix.md`
- ✅ Worktree always contains complete project structure

## Benefits
- **Simpler**: Removes complex path resolution logic
- **Reliable**: Works correctly in Markdown template context
- **Consistent**: Matches pattern used in other agent templates
- **Maintainable**: Easier to understand and modify