### PR TITLE
docs: architecture.md のlib/一覧に不足しているファイルを追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,14 +20,21 @@
 │  │cleanup-improve-logs│ cleanup-orphans.sh │cleanup-plans │ │
 │  │  - improve-logs削除│  - 孤立削除        │ - 計画ローテ │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │    config.sh       │   daemon.sh        │dependency.sh │ │
-│  │  - 設定読込        │  - デーモン化      │  - 依存解析  │ │
+│  │    config.sh       │   context.sh       │  daemon.sh   │ │
+│  │  - 設定読込        │  - コンテキスト    │  - デーモン化│ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │    github.sh       │     hooks.sh       │    log.sh    │ │
-│  │  - GitHub CLI      │  - Hook機能        │  - ログ出力  │ │
+│  │  dashboard.sh      │  dependency.sh     │  github.sh   │ │
+│  │  - ダッシュボード  │  - 依存解析        │  - GitHub CLI│ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
-│  │    notify.sh       │    status.sh       │ template.sh  │ │
-│  │  - 通知機能        │  - 状態管理        │  - テンプレ  │ │
+│  │    hooks.sh        │     log.sh         │multiplexer.sh│ │
+│  │  - Hook機能        │  - ログ出力        │  - マルチプレ│ │
+│  │                    │                    │    クサ抽象化│ │
+│  ├────────────────────┼────────────────────┼──────────────┤ │
+│  │multiplexer-tmux.sh │multiplexer-zellij  │  notify.sh   │ │
+│  │  - tmux実装        │  - Zellij実装      │  - 通知機能  │ │
+│  ├────────────────────┼────────────────────┼──────────────┤ │
+│  │   priority.sh      │    status.sh       │ template.sh  │ │
+│  │  - 優先度計算      │  - 状態管理        │  - テンプレ  │ │
 │  ├────────────────────┼────────────────────┼──────────────┤ │
 │  │    tmux.sh         │   workflow.sh      │workflow-finder│ │
 │  │  - セッション      │  - ワークフロー    │  - WF検索    │ │
@@ -79,12 +86,18 @@ pi-issue-runner/
 │   ├── cleanup-orphans.sh  # 孤立ステータスのクリーンアップ
 │   ├── cleanup-plans.sh    # 計画書のローテーション
 │   ├── config.sh      # 設定管理
+│   ├── context.sh     # コンテキスト管理
 │   ├── daemon.sh      # プロセスデーモン化
+│   ├── dashboard.sh   # ダッシュボード機能
 │   ├── dependency.sh  # 依存関係解析・レイヤー計算
 │   ├── github.sh      # GitHub CLI操作
 │   ├── hooks.sh       # Hook機能
 │   ├── log.sh         # ログ出力
+│   ├── multiplexer.sh      # マルチプレクサ抽象化レイヤー
+│   ├── multiplexer-tmux.sh # tmux実装
+│   ├── multiplexer-zellij.sh # Zellij実装
 │   ├── notify.sh      # 通知機能
+│   ├── priority.sh    # 優先度計算
 │   ├── status.sh      # 状態管理
 │   ├── template.sh    # テンプレート処理
 │   ├── tmux.sh        # tmux操作


### PR DESCRIPTION
## Summary
Closes #826

## Changes
- `docs/architecture.md` のディレクトリ構造セクションに6つの不足ファイルを追加
- システム構成図に対応するエントリを追加
- 全lib/ファイルがアルファベット順で記載されるように整理

### 追加したファイル
1. `lib/context.sh` - コンテキスト管理
2. `lib/dashboard.sh` - ダッシュボード機能
3. `lib/multiplexer.sh` - マルチプレクサ抽象化レイヤー
4. `lib/multiplexer-tmux.sh` - tmux実装
5. `lib/multiplexer-zellij.sh` - Zellij実装
6. `lib/priority.sh` - 優先度計算

## Testing
検証コマンドを実行し、実際のlib/ファイルとドキュメント記載に差分がないことを確認済み:

```bash
diff <( ls lib/*.sh | xargs -I{} basename {} | sort) \
     <( grep -E "│\s+├── .*\.sh|^│\s+└── .*\.sh" docs/architecture.md | \
       grep -v scripts | sed "s/.*├── //" | sed "s/.*└── //" | \
       sed "s/#.*//" | tr -d " " | sort)
# 結果: 差分なし
```