### PR TITLE
fix: daemon.bats の不安定なテストを修正

### DIFF
--- a/test/lib/daemon.bats
+++ b/test/lib/daemon.bats
@@ -303,7 +303,8 @@ EOF
     TEST_WATCHER_PID="$watcher_pid"
     
     # 親が終了してもwatcherが生きているか確認
-    sleep 0.5
+    # Note: daemon起動オーバーヘッド + ログ書き込み時間を考慮して1.0秒待機
+    sleep 1.0
     run is_daemon_running "$watcher_pid"
     [ "$status" -eq 0 ]
     


### PR DESCRIPTION
## Summary
Closes #828

## Problem
`test/lib/daemon.bats` の「Issue #553: watcher survives batch timeout scenario」テストがタイミングの問題で時々失敗していました（flaky test）。

## Root Cause
- デーモン起動のオーバーヘッド（0.1-0.2秒）
- ログ書き込みまでの時間（0.5秒のsleep後）
- テストの待機時間が0.5秒と不十分

タイムライン:
```
0.0s: daemonize呼び出し
0.1-0.2s: daemon.sh のオーバーヘッド、スクリプト起動
0.2s: "Batch started" 書き込み
0.7s: "Still running" 書き込み（sleep 0.5後）
テストは0.5s待機 → "Still running"がまだ書き込まれていない
```

## Changes
- テストの待機時間を `0.5秒` → `1.0秒` に増加
- デーモン起動のオーバーヘッドとログ書き込み時間を考慮した適切な待機時間に変更
- 理由を説明するコメントを追加

## Testing
- ✅ 対象テストを10回連続実行して全て成功
- ✅ daemon.bats全体（14件）のテストが全て成功
- ✅ 他のテストへの影響なし

## Documentation
- 詳細な分析と解決策を `docs/plans/issue-828-plan.md` に記載