### PR TITLE
docs: 完全な設定例にhooksセクションを追加

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,25 @@ agents:
   merge: agents/merge.md
   test: agents/test.md
   ci-fix: agents/ci-fix.md
+
+# =====================================
+# Hook設定
+# =====================================
+hooks:
+  # セッション開始時
+  # on_start: ./hooks/on-start.sh
+  
+  # タスク正常完了時
+  # on_success: terminal-notifier -title "完了" -message "Issue #{{issue_number}} が完了しました"
+  
+  # エラー検出時
+  # on_error: |
+  #   curl -X POST -H 'Content-Type: application/json' \
+  #     -d '{"text": "Issue #{{issue_number}} でエラー"}' \
+  #     $SLACK_WEBHOOK_URL
+  
+  # クリーンアップ完了後
+  # on_cleanup: echo "クリーンアップ完了" >> ~/.pi-runner/activity.log
 ```
 
 ## 設定項目詳細


### PR DESCRIPTION
## Summary
Closes #837

## Changes
- `docs/configuration.md` の「完全な設定例」セクションに `hooks` 設定を追加
- 4つのhookイベント（on_start, on_success, on_error, on_cleanup）をコメント付きで記載
- 実用的な使用例を含める（通知、Slack連携、ログ記録）
- テンプレート変数の使用例を含める（`{{issue_number}}`）

## Testing
- YAML構文検証: ✅ 成功
- 全hookイベント確認: ✅ 成功
- 設定ドキュメント検証: ✅ 成功

## Impact
- ドキュメントのみの変更
- 機能への影響なし
- 既存の設定ファイルに影響なし