### PR TITLE
docs: configuration.mdにhooks設定セクションを追加

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -450,6 +450,30 @@ github:
   max_comments: 10        # 最新10件のコメントのみ
 ```
 
+### hooks
+
+| キー | 型 | デフォルト | 説明 |
+|------|------|-----------|------|
+| `on_start` | string | (なし) | セッション開始時に実行するコマンドまたはスクリプト |
+| `on_success` | string | (なし) | タスク正常完了時に実行するコマンドまたはスクリプト |
+| `on_error` | string | (なし) | エラー検出時に実行するコマンドまたはスクリプト |
+| `on_cleanup` | string | (なし) | クリーンアップ完了後に実行するコマンドまたはスクリプト |
+
+#### 使用例
+
+```yaml
+hooks:
+  on_start: ./hooks/on-start.sh
+  on_success: terminal-notifier -title "完了" -message "Issue #{{issue_number}} が完了しました"
+  on_error: |
+    curl -X POST -H 'Content-Type: application/json' \
+      -d '{"text": "Issue #{{issue_number}} でエラー"}' \
+      $SLACK_WEBHOOK_URL
+  on_cleanup: echo "クリーンアップ完了" >> ~/.pi-runner/activity.log
+```
+
+詳細は [hooks.md](./hooks.md) を参照してください。
+
 ### agents
 
 | キー | 型 | デフォルト | 説明 |


### PR DESCRIPTION
## Summary
Closes #836

## Changes
- `docs/configuration.md`の`github`セクションと`agents`セクションの間に`hooks`セクションを追加
- hooks設定項目のテーブルを追加（`on_start`, `on_success`, `on_error`, `on_cleanup`）
- 使用例のYAML設定を追加（スクリプトファイル指定、インラインコマンド、Slack通知の例）
- `docs/hooks.md`への参照リンクを追加

## Details

### 追加された設定項目

| Hook | 説明 |
|------|------|
| `on_start` | セッション開始時に実行するコマンドまたはスクリプト |
| `on_success` | タスク正常完了時に実行するコマンドまたはスクリプト |
| `on_error` | エラー検出時に実行するコマンドまたはスクリプト |
| `on_cleanup` | クリーンアップ完了後に実行するコマンドまたはスクリプト |

### 修正内容

これにより、設定リファレンスを参照するユーザーがhooks機能を見落とすことがなくなり、ドキュメントの一貫性が向上します。

- 既存のセクション（`worktree`, `multiplexer`等）と同じ形式でテーブルを記述
- 実用的な使用例を追加（macOS通知、Slack通知、ログ記録）
- 詳細情報への導線として`docs/hooks.md`へのリンクを配置

## Testing
- ✅ `./scripts/verify-config-docs.sh` - 設定ドキュメントの整合性検証がパス
- ✅ 基本的なスモークテスト（run.sh, list.sh, status.sh等）がパス
- ✅ YAML構文の妥当性を検証
- ✅ 既存のドキュメント構造との整合性を確認

## Impact
- ドキュメントのみの変更のため、既存機能への影響はありません
- ユーザーは設定リファレンスからhooks機能を発見しやすくなります