### PR TITLE
test: Fix test state pollution in config.sh

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CONFIG_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CONFIG_SH_SOURCED="true"
+
 # 共通YAMLパーサーを読み込み
 _CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_CONFIG_LIB_DIR/yaml.sh"

--- a/test/lib/multiplexer.bats
+++ b/test/lib/multiplexer.bats
@@ -10,10 +10,8 @@ setup() {
         export _CLEANUP_TMPDIR=1
     fi
     
-    # 設定をリセット
-    export _CONFIG_LOADED=""
-    unset _MUX_TYPE
-    export CONFIG_MULTIPLEXER_TYPE="tmux"
+    # 設定をリセット（test_helperの関数を使用）
+    reset_config_state
     
     # テスト用の空の設定ファイルパスを作成
     export TEST_CONFIG_FILE="${BATS_TEST_TMPDIR}/empty-config.yaml"
@@ -68,7 +66,8 @@ EOF
 @test "get_multiplexer_type respects config value" {
     # 設定ファイルでzellij指定
     cat > "$TEST_CONFIG_FILE" << EOF
-multiplexer_type: zellij
+multiplexer:
+  type: zellij
 EOF
     
     # モックzellijを作成

--- a/test/scripts/verify-config-docs.bats
+++ b/test/scripts/verify-config-docs.bats
@@ -6,6 +6,11 @@ load '../test_helper'
 # 検証スクリプトのパス
 VERIFY_SCRIPT="$PROJECT_ROOT/scripts/verify-config-docs.sh"
 
+setup() {
+    # 設定状態をリセット（テスト間の汚染防止）
+    reset_config_state
+}
+
 @test "verify-config-docs.sh exists and is executable" {
     [ -f "$VERIFY_SCRIPT" ]
     [ -x "$VERIFY_SCRIPT" ]

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -37,6 +37,21 @@ teardown() {
     fi
 }
 
+# 設定状態をリセット（テスト間の汚染防止）
+reset_config_state() {
+    # Unset config loading flags
+    unset _CONFIG_LOADED
+    unset _CONFIG_FILE_FOUND
+    unset _CONFIG_SH_SOURCED
+    unset _MUX_TYPE
+    
+    # Unset all CONFIG_* variables
+    local var
+    for var in $(compgen -v | grep "^CONFIG_"); do
+        unset "$var"
+    done
+}
+
 # モックをPATHに追加
 enable_mocks() {
     export PATH="$MOCK_DIR:$PATH"


### PR DESCRIPTION
## Summary
Closes #848

Fixes test state pollution that caused `multiplexer.bats` and `verify-config-docs.bats` tests to fail when running the full test suite.

## Root Cause
The issue was caused by `lib/config.sh` being sourced multiple times without a guard:
1. Test sources `config.sh` and calls `load_config()` → sets `_CONFIG_LOADED="true"`
2. Test sources `multiplexer.sh` → which sources `config.sh` again
3. Re-sourcing `config.sh` resets `_CONFIG_LOADED=""` (empty string)
4. Subsequent `load_config()` calls fail to reload because the variable exists but is empty

## Changes
1. **lib/config.sh**: Added source guard (`_CONFIG_SH_SOURCED`) to prevent multi-sourcing
2. **test/test_helper.bash**: Added `reset_config_state()` helper function
3. **test/lib/multiplexer.bats**: Updated setup() to use reset helper, fixed YAML format
4. **test/scripts/verify-config-docs.bats**: Added setup() with state reset

## Testing
- ✅ All 1297 tests pass
- ✅ Previously failing tests now pass:
  - `test/lib/multiplexer.bats` test #2
  - `test/scripts/verify-config-docs.bats` tests #1247-1250, #1253-1255
- ✅ No new test failures introduced
- ✅ Individual test file runs still work correctly

## Impact
- **Low risk**: Changes are isolated to test infrastructure
- **No breaking changes**: Production code unchanged (only added a guard)
- **Better test isolation**: Prevents future state pollution issues