### PR TITLE
docs: fix outdated tmux.* references in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -778,7 +778,7 @@ workflow:
 
 以下の設定は `lib/config.sh` で処理されます:
 - `worktree.*` - worktreeのベースディレクトリ、コピーするファイル
-- `tmux.*` - セッション名のプレフィックス、セッション内起動設定
+- `multiplexer.*` - マルチプレクサ設定（セッション名のプレフィックス、セッション内起動設定）
 - `pi.*` - piコマンドのパス、追加引数（後方互換性）
 - `agent.*` - エージェントプリセット、カスタムコマンド、引数、テンプレート
 - `parallel.*` - 並列実行の最大同時実行数
@@ -905,7 +905,7 @@ rm .pi-runner.yaml
 以下の機能は将来のバージョンで実装予定です：
 
 - `--config` オプションによる設定ファイル指定
-- `tmux.log_output`: セッション出力のファイル記録
+- `multiplexer.log_output`: セッション出力のファイル記録
 - `pi.timeout`: タスクのタイムアウト設定
 - `parallel.queue_strategy`: キュー戦略（fifo/priority）
 - `parallel.auto_cleanup`: 完了後の自動クリーンアップ


### PR DESCRIPTION
## Summary
Closes #854

## Changes
- Updated `tmux.*` to `multiplexer.*` in configuration implementation details section (line 781)
- Updated `tmux.log_output` to `multiplexer.log_output` in future extensions section (line 908)

## Context
After the multiplexer integration feature was implemented, configuration keys were migrated from `tmux.*` to `multiplexer.*`. While `lib/config.sh` provides backward compatibility aliases, the official documentation should use the modern key names.

## Testing
- ✅ `./scripts/verify-config-docs.sh` passes
- ✅ No outdated `tmux.*` references remain in documentation
- ✅ Configuration structure verification successful

## Verification
```bash
# Verified no old references remain
grep -n "tmux\.\*\|tmux\.log_output\|tmux\.session_prefix" docs/configuration.md
# Output: (none)

# Verified new references are in place
grep -n "multiplexer\.\*\|multiplexer\.log_output" docs/configuration.md
# 781:- \`multiplexer.*\` - マルチプレクサ設定（...）
# 908:- \`multiplexer.log_output\`: セッション出力のファイル記録
```