### PR TITLE
docs: add public-api.md to AGENTS.md directory structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ pi-issue-runner/
 │   ├── hooks.md           # Hook機能
 │   ├── overview.md        # 概要
 │   ├── parallel-execution.md # 並列実行
+│   ├── public-api.md        # 公開APIリファレンス
 │   ├── security.md        # セキュリティ
 │   ├── state-management.md # 状態管理
 │   ├── multiplexer-integration.md # マルチプレクサ統合（tmux/Zellij）


### PR DESCRIPTION
## Summary
Closes #864

## Changes
- Added `docs/public-api.md` entry to `AGENTS.md` directory structure
- Maintains alphabetical order (between `parallel-execution.md` and `security.md`)
- Uses consistent formatting with other entries

## Background
The file `docs/public-api.md` exists and is referenced in `docs/README.md` (line 47), but was missing from the directory structure tree in `AGENTS.md`.

## Testing
- Verified file exists in `docs/` directory
- Confirmed format matches existing entries
- Checked alphabetical ordering

## Impact
- Documentation only
- No functional changes
- Improves consistency between actual file structure and documentation