### PR TITLE
refactor: next.sh parse_next_arguments の変数出力ブロックが6回重複

### DIFF
--- a/scripts/next.sh
+++ b/scripts/next.sh
@@ -123,6 +123,23 @@ EOF
 # Note: Does not handle --help/-h (handled in main before calling this)
 # ============================================================================
 parse_next_arguments() {
+    # Helper function to output variables (reduces code duplication)
+    _output_next_variables() {
+        local count="$1"
+        local label_filter="$2"
+        local json_output="$3"
+        local dry_run="$4"
+        local verbose="$5"
+        local exit_code="${6:-0}"
+
+        echo "local count=$count"
+        echo "local label_filter='${label_filter//\x27/\x27\\\x27\x27}'"
+        echo "local json_output=$json_output"
+        echo "local dry_run=$dry_run"
+        echo "local verbose=$verbose"
+        echo "local __PARSE_EXIT_CODE=$exit_code"
+    }
+    
     local count=1
     local label_filter=""
     local json_output=false
@@ -135,23 +152,13 @@ parse_next_arguments() {
                 if [[ -z "${2:-}" ]]; then
                     log_error "Option $1 requires an argument" >&2
                     usage >&2
-                    echo "local count=$count"
-                    echo "local label_filter='$label_filter'"
-                    echo "local json_output=$json_output"
-                    echo "local dry_run=$dry_run"
-                    echo "local verbose=$verbose"
-                    echo "local __PARSE_EXIT_CODE=3"
+                    _output_next_variables "$count" "$label_filter" "$json_output" "$dry_run" "$verbose" 3
                     return 0
                 fi
                 count="$2"
                 if ! [[ "$count" =~ ^[0-9]+$ ]] || [[ "$count" -lt 1 ]]; then
                     log_error "Count must be a positive integer" >&2
-                    echo "local count=$count"
-                    echo "local label_filter='$label_filter'"
-                    echo "local json_output=$json_output"
-                    echo "local dry_run=$dry_run"
-                    echo "local verbose=$verbose"
-                    echo "local __PARSE_EXIT_CODE=3"
+                    _output_next_variables "$count" "$label_filter" "$json_output" "$dry_run" "$verbose" 3
                     return 0
                 fi
                 shift 2
@@ -160,12 +167,7 @@ parse_next_arguments() {
                 if [[ -z "${2:-}" ]]; then
                     log_error "Option $1 requires an argument" >&2
                     usage >&2
-                    echo "local count=$count"
-                    echo "local label_filter='$label_filter'"
-                    echo "local json_output=$json_output"
-                    echo "local dry_run=$dry_run"
-                    echo "local verbose=$verbose"
-                    echo "local __PARSE_EXIT_CODE=3"
+                    _output_next_variables "$count" "$label_filter" "$json_output" "$dry_run" "$verbose" 3
                     return 0
                 fi
                 label_filter="$2"
@@ -187,34 +189,19 @@ parse_next_arguments() {
             -h|--help)
                 # Should not reach here (handled before main)
                 usage >&2
-                echo "local count=$count"
-                echo "local label_filter='$label_filter'"
-                echo "local json_output=$json_output"
-                echo "local dry_run=$dry_run"
-                echo "local verbose=$verbose"
-                echo "local __PARSE_EXIT_CODE=0"
+                _output_next_variables "$count" "$label_filter" "$json_output" "$dry_run" "$verbose" 0
                 return 0
                 ;;
             *)
                 log_error "Unknown option: $1" >&2
                 usage >&2
-                echo "local count=$count"
-                echo "local label_filter='$label_filter'"
-                echo "local json_output=$json_output"
-                echo "local dry_run=$dry_run"
-                echo "local verbose=$verbose"
-                echo "local __PARSE_EXIT_CODE=3"
+                _output_next_variables "$count" "$label_filter" "$json_output" "$dry_run" "$verbose" 3
                 return 0
                 ;;
         esac
     done
     
-    echo "local count=$count"
-    echo "local label_filter='$label_filter'"
-    echo "local json_output=$json_output"
-    echo "local dry_run=$dry_run"
-    echo "local verbose=$verbose"
-    echo "local __PARSE_EXIT_CODE=0"
+    _output_next_variables "$count" "$label_filter" "$json_output" "$dry_run" "$verbose" 0
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Closes #862

## Changes
- Created `_output_next_variables` helper function to eliminate code duplication
- Replaced 6 duplicate 5-line variable output blocks with single function call
- Reduced code duplication by approximately 30 lines
- Added proper single-quote escaping in `label_filter` variable

## Technical Details
- Helper function handles all 5 variables (count, label_filter, json_output, dry_run, verbose)
- Exit code is passed as optional 6th parameter (defaults to 0)
- Maintains backward compatibility with eval-based variable assignment pattern

## Testing
- ✅ All 7 tests in `test/scripts/next.bats` pass
- ✅ ShellCheck reports 0 warnings
- ✅ Manual testing of error cases and normal flow confirmed
- ✅ Function line count reduced from ~110 to 81 lines