### PR TITLE
fix: make run_local_validation() multi-project compatible

### DIFF
--- a/test/lib/ci-fix.bats
+++ b/test/lib/ci-fix.bats
@@ -289,3 +289,105 @@ teardown() {
     run try_fix_lint "$BATS_TEST_TMPDIR/bash-lint-test"
     [ "$status" -eq 2 ]
 }
+
+# ===================
+# run_local_validation マルチプロジェクト対応テスト
+# ===================
+
+@test "run_local_validation detects rust project and validates with cargo" {
+    mkdir -p "$BATS_TEST_TMPDIR/rust-validation"
+    touch "$BATS_TEST_TMPDIR/rust-validation/Cargo.toml"
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/rust-validation"
+    # cargoがない場合は0（スキップ）、ある場合は0か1（検証結果による）
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+    # ログにRustプロジェクトが検出されたことを確認
+    [[ "$output" == *"rust"* ]]
+}
+
+@test "run_local_validation detects node project and validates with npm" {
+    mkdir -p "$BATS_TEST_TMPDIR/node-validation"
+    cat > "$BATS_TEST_TMPDIR/node-validation/package.json" << 'EOF'
+{
+  "name": "test",
+  "scripts": {
+    "lint": "echo 'lint ok'",
+    "test": "echo 'test ok'"
+  }
+}
+EOF
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/node-validation"
+    # npmがある場合は検証を実行、ない場合は0（スキップ）
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"node"* ]]
+}
+
+@test "run_local_validation detects python project and validates with flake8/pytest" {
+    mkdir -p "$BATS_TEST_TMPDIR/python-validation"
+    touch "$BATS_TEST_TMPDIR/python-validation/pyproject.toml"
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/python-validation"
+    # flake8/pytestがない場合は0（スキップ）、ある場合は検証結果による
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+    [[ "$output" == *"python"* ]]
+}
+
+@test "run_local_validation detects go project and validates with go vet/test" {
+    mkdir -p "$BATS_TEST_TMPDIR/go-validation"
+    touch "$BATS_TEST_TMPDIR/go-validation/go.mod"
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/go-validation"
+    # goがない場合は0（スキップ）、ある場合は検証結果による
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+    [[ "$output" == *"go"* ]]
+}
+
+@test "run_local_validation detects bash project and validates with shellcheck/bats" {
+    mkdir -p "$BATS_TEST_TMPDIR/bash-validation"
+    touch "$BATS_TEST_TMPDIR/bash-validation/test.bats"
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/bash-validation"
+    # shellcheck/batsがない場合は0（スキップ）、ある場合は検証結果による
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+    [[ "$output" == *"bash"* ]]
+}
+
+@test "run_local_validation skips validation for unknown project type" {
+    mkdir -p "$BATS_TEST_TMPDIR/unknown-validation"
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/unknown-validation"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unknown"* ]]
+    [[ "$output" == *"Skipping validation"* ]]
+}
+
+@test "run_local_validation skips npm lint if not configured in package.json" {
+    mkdir -p "$BATS_TEST_TMPDIR/node-no-lint"
+    cat > "$BATS_TEST_TMPDIR/node-no-lint/package.json" << 'EOF'
+{
+  "name": "test",
+  "scripts": {}
+}
+EOF
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/node-no-lint"
+    [ "$status" -eq 0 ]
+    # lintスクリプトがないのでスキップされる
+    [[ "$output" != *"Running npm run lint"* ]]
+}
+
+@test "run_local_validation skips npm test if not configured in package.json" {
+    mkdir -p "$BATS_TEST_TMPDIR/node-no-test"
+    cat > "$BATS_TEST_TMPDIR/node-no-test/package.json" << 'EOF'
+{
+  "name": "test",
+  "scripts": {}
+}
+EOF
+    
+    run run_local_validation "$BATS_TEST_TMPDIR/node-no-test"
+    [ "$status" -eq 0 ]
+    # testスクリプトがないのでスキップされる
+    [[ "$output" != *"Running npm test"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #852

## Changes
- Updated `run_local_validation()` to use `detect_project_type()` for multi-project support
- Added validation logic for rust, node, python, go, and bash projects
- Improved script detection in package.json using jq with grep fallback
- Added 8 comprehensive tests covering all project types and edge cases

## Testing
- ✅ All 1294 tests pass (including 8 new tests)
- ✅ ShellCheck passes with no warnings
- ✅ Tested with multiple project types (rust, node, python, go, bash)
- ✅ Edge cases tested: missing tools, missing scripts in package.json

## Implementation Details
### Before
`run_local_validation()` was hardcoded for Rust projects only:
- Only ran `cargo clippy` and `cargo test`
- Returned success (0) when cargo was not found
- Non-Rust projects had no validation

### After
`run_local_validation()` now supports all project types:
- **Rust**: `cargo clippy` + `cargo test --lib`
- **Node**: `npm run lint` (if configured) + `npm test` (if configured)
- **Python**: `flake8` (if available) + `pytest` (if available)
- **Go**: `go vet ./...` + `go test ./...`
- **Bash**: `shellcheck -x scripts/*.sh lib/*.sh` + `bats test/` (if available)
- **Unknown**: Skips validation with warning

### Smart Script Detection
For Node projects, the function checks if lint/test scripts exist in package.json:
- Uses `jq` if available for JSON parsing
- Falls back to grep pattern matching
- Only runs scripts that are actually defined