### PR TITLE
docs: update references from lib/tmux.sh to lib/multiplexer.sh

### DIFF
--- a/docs/parallel-execution.md
+++ b/docs/parallel-execution.md
@@ -144,7 +144,7 @@ parallel:
   max_concurrent: 5  # 最大同時実行数（0 = 無制限）
 ```
 
-**実装** (`lib/tmux.sh`):
+**実装** (`lib/multiplexer.sh` / `lib/tmux.sh`):
 
 ```bash
 # 並列実行数の制限をチェック

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -22,13 +22,13 @@
 
 ### count_active_sessions
 
-**定義場所**: `lib/tmux.sh`
+**定義場所**: `lib/tmux.sh`（後方互換ラッパー、実装: `lib/multiplexer.sh`）
 
 **説明**: アクティブなセッション数をカウントします。これは `mux_count_active_sessions()` の後方互換性ラッパーです。
 
 **使用例**:
 ```bash
-source lib/tmux.sh
+source lib/multiplexer.sh  # または lib/tmux.sh（後方互換）
 
 count=$(count_active_sessions)
 echo "Active sessions: $count"
@@ -45,7 +45,7 @@ echo "Active sessions: $count"
 
 **関連関数**:
 - `mux_count_active_sessions` (lib/multiplexer-tmux.sh, lib/multiplexer-zellij.sh)
-- `check_concurrent_limit` (lib/tmux.sh)
+- `check_concurrent_limit` (lib/multiplexer.sh / lib/tmux.sh)
 
 ---
 


### PR DESCRIPTION
## Summary
Closes #873

## Changes
- Updated `docs/public-api.md` to clarify that `lib/tmux.sh` is a backward compatibility wrapper
- Added references to `lib/multiplexer.sh` as the actual implementation
- Updated usage examples to recommend `lib/multiplexer.sh` for new code
- Updated `docs/parallel-execution.md` implementation reference
- Maintained backward compatibility by mentioning both files

## Details
This PR addresses documentation inconsistency where `lib/tmux.sh` was referenced as the implementation location, when it is actually a backward compatibility wrapper. The actual implementation is in:
- `lib/multiplexer.sh` (abstraction layer)
- `lib/multiplexer-tmux.sh` / `lib/multiplexer-zellij.sh` (implementations)

## Files Changed
- `docs/public-api.md` (3 references updated)
- `docs/parallel-execution.md` (1 reference updated)

## Testing
- Documentation-only changes
- No code modifications
- Existing functionality unaffected