### PR TITLE
docs: add eval-injection.bats to AGENTS.md directory structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,8 @@ pi-issue-runner/
 │   │   ├── wait-for-sessions.bats
 │   │   └── watch-session.bats
 │   ├── regression/    # 回帰テスト
-│   │   └── critical-fixes.bats
+│   │   ├── critical-fixes.bats
+│   │   └── eval-injection.bats
 │   ├── fixtures/      # テスト用フィクスチャ
 │   │   └── sample-config.yaml
 │   └── test_helper.bash  # Bats共通ヘルパー


### PR DESCRIPTION
## Summary
Closes #886

## Changes
- Added `test/regression/eval-injection.bats` to the directory structure section in AGENTS.md
- Updated the tree structure to show both regression test files:
  - `critical-fixes.bats`
  - `eval-injection.bats`

## Testing
- Verified all regression test files are documented using the validation command:
  ```bash
  for f in test/regression/*.bats; do
      b=$(basename "$f")
      grep -q "$b" AGENTS.md || echo "MISSING: $b"
  done
  ```
- Result: No output (all files are documented)

## Impact
- Documentation only change
- No code modifications
- Improves consistency between documentation and actual project structure