### PR TITLE
refactor: use jq for JSON parsing in status.sh

### DIFF
--- a/lib/status.sh
+++ b/lib/status.sh
@@ -224,8 +224,13 @@ get_status_value() {
     json="$(load_status "$issue_number")"
     
     if [[ -n "$json" ]]; then
-        # "status": "value" からvalueを抽出
-        echo "$json" | grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || echo "unknown"
+        # jqを使用してstatusフィールドを抽出（null時は"unknown"を返す）
+        if command -v jq &>/dev/null; then
+            echo "$json" | jq -r '.status // "unknown"'
+        else
+            # jqがない場合はフォールバック（grep/sed）
+            echo "$json" | grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || echo "unknown"
+        fi
     else
         echo "unknown"
     fi
@@ -250,8 +255,13 @@ get_error_message() {
     json="$(load_status "$issue_number")"
     
     if [[ -n "$json" ]]; then
-        # "error_message": "value" からvalueを抽出
-        echo "$json" | grep -o '"error_message"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || true
+        # jqを使用してerror_messageフィールドを抽出（null時は空文字列を返す）
+        if command -v jq &>/dev/null; then
+            echo "$json" | jq -r '.error_message // ""'
+        else
+            # jqがない場合はフォールバック（grep/sed）
+            echo "$json" | grep -o '"error_message"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/' || true
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
Closes #895

## Changes
- Refactored `get_status_value` to use `jq -r '.status // "unknown"'` instead of grep/sed
- Refactored `get_error_message` to use `jq -r '.error_message // ""'` instead of grep/sed
- Both functions maintain backward compatibility with fallback to grep/sed when jq is unavailable
- Properly handles escaped characters (quotes, newlines, tabs) in error messages

## Benefits
- Robust JSON parsing that handles edge cases correctly
- Consistent parsing method with `build_json_with_jq` function
- Better handling of complex error messages with special characters

## Testing
- All existing tests in `test/lib/status.bats` pass
- Verified edge cases with escaped quotes and newlines
- No ShellCheck warnings