### PR TITLE
fix: run.sh の単一引用符エスケープを修正

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -228,14 +228,14 @@ parse_run_arguments() {
 
     # Output variable assignments
     echo "local issue_number='$issue_number'"
-    echo "local custom_branch='${custom_branch//\x27/\x27\\\\\x27\x27}'"
-    echo "local base_branch='${base_branch//\x27/\x27\\\\\x27\x27}'"
-    echo "local workflow_name='${workflow_name//\x27/\x27\\\\\x27\x27}'"
+    echo "local custom_branch='${custom_branch//\'/\'\\\'\'}'"
+    echo "local base_branch='${base_branch//\'/\'\\\'\'}'"
+    echo "local workflow_name='${workflow_name//\'/\'\\\'\'}'"
     echo "local no_attach=$no_attach"
     echo "local reattach=$reattach"
     echo "local force=$force"
-    echo "local extra_agent_args='${extra_agent_args//\x27/\x27\\\\\x27\x27}'"
-    echo "local cleanup_mode='${cleanup_mode//\x27/\x27\\\\\x27\x27}'"
+    echo "local extra_agent_args='${extra_agent_args//\'/\'\\\'\'}'"
+    echo "local cleanup_mode='${cleanup_mode//\'/\'\\\'\'}'"
     echo "local list_workflows=$list_workflows"
     echo "local ignore_blockers=$ignore_blockers"
 }
@@ -310,7 +310,7 @@ handle_existing_session() {
         fi
     fi
 
-    echo "local session_name='${session_name//\x27/\x27\\\\\x27\x27}'"
+    echo "local session_name='${session_name//\'/\'\\\'\'}'"
 }
 
 # ============================================================================
@@ -409,9 +409,9 @@ setup_worktree() {
     # エラー時クリーンアップ用にworktreeを登録
     register_worktree_for_cleanup "$full_worktree_path"
 
-    echo "local branch_name='${branch_name//\x27/\x27\\\\\x27\x27}'"
-    echo "local worktree_path='${worktree_path//\x27/\x27\\\\\x27\x27}'"
-    echo "local full_worktree_path='${full_worktree_path//\x27/\x27\\\\\x27\x27}'"
+    echo "local branch_name='${branch_name//\'/\'\\\'\'}'"
+    echo "local worktree_path='${worktree_path//\'/\'\\\'\'}'"
+    echo "local full_worktree_path='${full_worktree_path//\'/\'\\\'\'}'"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Closes #891

## Changes
- `scripts/run.sh` の9箇所で、誤った単一引用符エスケープパターン `\x27` を正しいパターン `'\'\\'\'` に修正
- `parse_run_arguments`: 5箇所（custom_branch, base_branch, workflow_name, extra_agent_args, cleanup_mode）
- `handle_existing_session`: 1箇所（session_name）
- `setup_worktree`: 3箇所（branch_name, worktree_path, full_worktree_path）

## Technical Details
bashのパラメータ展開では `\x27` は16進数エスケープシーケンスとして解釈されず、リテラル文字列 `\x27` にマッチしようとするため、実際の単一引用符のエスケープが機能していませんでした。

修正により、同一ファイル内の `fetch_issue_data` 関数で既に使用されている正しいパターンに統一し、Issueタイトルやブランチ名に単一引用符が含まれる場合でもevalが正しく動作するようになります。

## Testing
- ✅ ShellCheck: 警告なし
- ✅ run.bats: 20テストが成功
- ✅ 手動テスト: 単一引用符を含む値で正しくエスケープされることを確認

## Security Impact
この修正により、単一引用符が適切にエスケープされるため、悪意あるIssueタイトルによる任意コード実行のリスクが軽減されます。