### PR TITLE
refactor: batch.sh のグローバル変数依存を解消し、関数引数ベースに変更する

### DIFF
--- a/scripts/run-batch.sh
+++ b/scripts/run-batch.sh
@@ -237,6 +237,18 @@ main() {
 
     ALL_ISSUES=("${PARSE_ISSUES[@]}")
 
+    # バッチ処理用の設定構造体を作成
+    declare -A batch_config=(
+        [quiet]="${QUIET}"
+        [sequential]="${SEQUENTIAL}"
+        [continue_on_error]="${CONTINUE_ON_ERROR}"
+        [timeout]="${TIMEOUT}"
+        [interval]="${INTERVAL}"
+        [workflow_name]="${WORKFLOW_NAME}"
+        [base_branch]="${BASE_BRANCH}"
+        [script_dir]="${SCRIPT_DIR}"
+    )
+
     if [[ "$QUIET" != "true" ]]; then
         log_info "Analyzing dependencies for ${#PARSE_ISSUES[@]} issues..."
     fi
@@ -261,7 +273,7 @@ main() {
         exit 0
     fi
 
-    # 実行計画を表示（lib/batch.sh の関数を使用）
+    # 実行計画を表示（dependency.sh の関数を使用）
     show_execution_plan "${PARSE_ISSUES[@]}"
 
     # 最大レイヤー番号を取得
@@ -273,7 +285,7 @@ main() {
 
     while [[ $current_layer -le $max_layer ]]; do
         local result
-        process_layer "$current_layer" "$layers_output"
+        process_layer FAILED_ISSUES COMPLETED_ISSUES batch_config "$current_layer" "$layers_output"
         result=$?
 
         if [[ $result -eq 1 ]]; then
@@ -288,7 +300,7 @@ main() {
     done
 
     # 結果サマリー（lib/batch.sh の関数を使用）
-    show_summary_and_exit
+    show_summary_and_exit ALL_ISSUES FAILED_ISSUES
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
Closes #892

## Changes
- **lib/batch.sh**: 全関数を関数引数ベースに変更
  - グローバル変数 (QUIET, SEQUENTIAL, etc.) を連想配列 config として渡す
  - 可変配列 (FAILED_ISSUES, COMPLETED_ISSUES) を nameref で明示的に渡す
  - 関数シグネチャから依存関係が明確になった
- **scripts/run-batch.sh**: batch_config 構造体を作成し関数呼び出しを更新
- **test/lib/batch.bats**: 新しい関数シグネチャに合わせてテストを更新

## Benefits
- テスタビリティの向上（グローバル状態の初期化が不要）
- モジュール性の向上（関数シグネチャから依存関係が明確）
- 再利用性の向上（他のスクリプトから呼び出しやすい）
- 副作用の明示化（配列の変更が nameref 経由で分かる）

## Testing
- ✅ All 1324 tests pass
- ✅ ShellCheck passes with no warnings
- ✅ run-batch.sh 統合テスト成功

## Breaking Changes
なし（内部 API のリファクタリングのため、外部インターフェースは変更なし）