### PR TITLE
docs: update hooks configuration to use environment variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -464,26 +464,30 @@ github:
 ```yaml
 hooks:
   on_start: ./scripts/notify-start.sh
-  on_success: echo "Task completed for Issue #{{issue_number}}"
+  on_success: echo "Task completed for Issue #$PI_ISSUE_NUMBER"
   on_error: |
     curl -X POST https://example.com/webhook \
-      -d '{"issue": {{issue_number}}, "error": "{{error_message}}"}'
+      -H 'Content-Type: application/json' \
+      -d "{\"issue\": \"$PI_ISSUE_NUMBER\", \"error\": \"$PI_ERROR_MESSAGE\"}"
   on_cleanup: ./scripts/cleanup-resources.sh
 ```
 
-#### テンプレート変数
+#### 環境変数
 
-hooks設定では以下のテンプレート変数が使用できます：
+hookスクリプトには以下の環境変数が渡されます：
 
-- `{{issue_number}}` - Issue番号
-- `{{issue_title}}` - Issueタイトル
-- `{{session_name}}` - セッション名
-- `{{branch_name}}` - ブランチ名
-- `{{worktree_path}}` - worktreeのパス
-- `{{error_message}}` - エラーメッセージ（on_errorのみ）
-- `{{exit_code}}` - 終了コード（on_errorのみ）
+| 環境変数 | 説明 | 利用可能イベント |
+|----------|------|-----------------|
+| `PI_ISSUE_NUMBER` | Issue番号 | 全て |
+| `PI_ISSUE_TITLE` | Issueタイトル | 全て |
+| `PI_SESSION_NAME` | セッション名 | 全て |
+| `PI_BRANCH_NAME` | ブランチ名 | 全て |
+| `PI_WORKTREE_PATH` | worktreeパス | 全て |
+| `PI_ERROR_MESSAGE` | エラーメッセージ | on_error |
+| `PI_EXIT_CODE` | 終了コード | 全て |
 
-詳細は [Hook機能ドキュメント](./hooks.md) を参照してください。
+> **⚠️ 非推奨**: テンプレート変数（`{{issue_number}}`等）はセキュリティ上の理由により非推奨です。
+> 環境変数を使用してください。詳細は [Hook機能ドキュメント](./hooks.md#マイグレーションガイド) を参照してください。
 
 ### agents
 


### PR DESCRIPTION
## Summary
Closes #903

## Problem
`docs/configuration.md` の hooks セクションで非推奨のテンプレート変数（`{{issue_number}}`等）を現行仕様として記載していた。

実際には `lib/hooks.sh` でテンプレート変数の展開は既に無効化されており、環境変数（`$PI_ISSUE_NUMBER`等）を使用する方式に移行している。

## Changes
- **使用例の更新**: テンプレート変数から環境変数への変更
  - `{{issue_number}}` → `$PI_ISSUE_NUMBER`
  - `{{error_message}}` → `$PI_ERROR_MESSAGE`
- **セクション名の変更**: 「テンプレート変数」→「環境変数」
- **表形式での記載**: 利用可能イベントの明示
- **非推奨警告の追加**: セキュリティ上の理由を明記
- **マイグレーションガイドへのリンク**: `docs/hooks.md#マイグレーションガイド`

## Testing
- ✅ `./scripts/verify-config-docs.sh` 成功
- ✅ 環境変数名が `docs/hooks.md` と一致
- ✅ Markdown構文が正しい
- ✅ リンクが機能する

## Documentation
- Updated: `docs/configuration.md` (hooks セクション)
- Aligned with: `docs/hooks.md`