### PR TITLE
fix: replace undefined send_notification with log_warn in watch-session.sh

### DIFF
--- a/scripts/watch-session.sh
+++ b/scripts/watch-session.sh
@@ -166,7 +166,7 @@ check_pr_merge_status() {
             log_warn "PR #$pr_number exists but is not merged yet"
             log_warn "Completion marker detected but PR is still open - waiting for merge..."
             log_warn "This may indicate the AI output the marker too early"
-            send_notification "Warning" "PR #$pr_number is not merged yet for Issue #$issue_number"
+            log_warn "PR #$pr_number is not merged yet for Issue #$issue_number"
             return 1
         else
             log_info "PR #$pr_number state: $pr_state"
@@ -176,7 +176,7 @@ check_pr_merge_status() {
         log_warn "No PR found for Issue #$issue_number"
         log_warn "Completion marker detected but no PR was created - workflow may not have completed correctly"
         log_warn "Skipping cleanup. Please check the session manually."
-        send_notification "Warning" "No PR created for Issue #$issue_number - check session"
+        log_warn "No PR created for Issue #$issue_number - check session"
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
Closes #901

## Problem
`scripts/watch-session.sh` was calling an undefined function `send_notification` on lines 169 and 179, causing the script to fail with "command not found" error when PR merge status checks detected issues.

## Changes
- **Line 169**: Replaced `send_notification "Warning" "PR #$pr_number is not merged yet for Issue #$issue_number"` with `log_warn "PR #$pr_number is not merged yet for Issue #$issue_number"`
- **Line 179**: Replaced `send_notification "Warning" "No PR created for Issue #$issue_number - check session"` with `log_warn "No PR created for Issue #$issue_number - check session"`

## Rationale
- `send_notification` function does not exist in any sourced library
- `log_warn` is already used extensively in the same function for similar warning messages
- Consistent with existing logging patterns in the codebase

## Testing
✅ ShellCheck validation: No warnings
✅ Bats tests: 27/27 passed
✅ Manual verification: No remaining `send_notification` calls found

## Impact
- Fixes critical bug that caused script termination during PR status checks
- No breaking changes
- Maintains same warning functionality through logging