### PR TITLE
feat: ワークフローの context フィールドによるプロンプトへのコンテキスト注入

### DIFF
--- a/lib/workflow-prompt.sh
+++ b/lib/workflow-prompt.sh
@@ -100,6 +100,22 @@ Follow the workflow steps below.
 
 EOF
     
+    # ワークフローコンテキストを取得して注入（存在する場合のみ）
+    local workflow_context
+    workflow_context="$(get_workflow_context "$workflow_file" "$workflow_name" 2>/dev/null || true)"
+    
+    if [[ -n "$workflow_context" ]]; then
+        cat << EOF
+
+### Workflow Context
+
+$workflow_context
+
+---
+
+EOF
+    fi
+    
     # 各ステップのプロンプトを生成
     local step_num=1
     for step in $steps; do


### PR DESCRIPTION
## Summary
Closes #914

## Changes
- `lib/workflow-loader.sh` に `get_workflow_context()` 関数を追加
  - `config-workflow:NAME` 形式および YAML ファイルから `context` フィールドを取得
  - context が未定義の場合は空文字を返す
- `lib/workflow-prompt.sh` の `generate_workflow_prompt()` を変更
  - "Workflow Context" セクションをプロンプトに注入
  - context が空の場合はセクション自体を出力しない
- テストを追加
  - `test/lib/workflow-loader.bats`: `get_workflow_context()` のテスト (9件)
  - `test/lib/workflow-prompt.bats`: コンテキスト注入のテスト (7件)

## Testing
- 全ての新規テストがパス
- 手動テストで context 注入を確認
  - context ありのワークフロー: "Workflow Context" セクションが表示される
  - context なしのワークフロー: セクションが表示されない

## Implementation Details
各ワークフローに `context` フィールドを持たせることで、プロンプト生成時に技術スタック、重視すべき点などのコンテキスト情報を注入できるようになりました。

```yaml
workflows:
  frontend:
    steps:
      - plan
      - implement
    context: |
      ## 技術スタック
      - React / Next.js / TypeScript
      
      ## 重視すべき点
      - レスポンシブデザイン
      - アクセシビリティ
```

生成されるプロンプトには以下のように注入されます：

```markdown
## Workflow: frontend
...

### Workflow Context

## 技術スタック
- React / Next.js / TypeScript

## 重視すべき点
- レスポンシブデザイン
- アクセシビリティ

---

### Step 1: Plan
...
```