### PR TITLE
refactor: deprecate legacy tmux_* config key names in favor of multiplexer_*

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -310,9 +310,11 @@ get_config() {
         worktree_copy_files)
             echo "$CONFIG_WORKTREE_COPY_FILES"
             ;;
+        # @deprecated Use multiplexer_session_prefix instead of tmux_session_prefix
         tmux_session_prefix|multiplexer_session_prefix|session_prefix)
             echo "$CONFIG_MULTIPLEXER_SESSION_PREFIX"
             ;;
+        # @deprecated Use multiplexer_start_in_session instead of tmux_start_in_session
         tmux_start_in_session|multiplexer_start_in_session|start_in_session)
             echo "$CONFIG_MULTIPLEXER_START_IN_SESSION"
             ;;

--- a/scripts/mux-all.sh
+++ b/scripts/mux-all.sh
@@ -93,7 +93,7 @@ list_zellij_sessions() {
     elif [[ -n "$prefix" ]]; then
         echo "$all_sessions" | grep "^${prefix}-issue-" | grep -v "^pi-monitor" || true
     else
-        echo "$all_sessions" | grep "^$(get_config tmux_session_prefix)" | grep -v "^pi-monitor" || true
+        echo "$all_sessions" | grep "^$(get_config multiplexer_session_prefix)" | grep -v "^pi-monitor" || true
     fi
 }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -516,7 +516,7 @@ display_summary_and_attach() {
     # アタッチ
     if [[ "$no_attach" == "false" ]]; then
         local start_in_session
-        start_in_session="$(get_config tmux_start_in_session)"
+        start_in_session="$(get_config multiplexer_start_in_session)"
         if [[ "$start_in_session" == "true" ]]; then
             log_info "Attaching to session..."
             attach_session "$session_name"


### PR DESCRIPTION
## Changes

This PR deprecates legacy `tmux_*` config key names and updates all code to use the new `multiplexer_*` names for better consistency.

### Modified Files
- **lib/config.sh** - Added `@deprecated` comments to legacy `tmux_session_prefix` and `tmux_start_in_session` aliases
- **scripts/run.sh** - Changed `get_config tmux_start_in_session` → `get_config multiplexer_start_in_session`
- **scripts/mux-all.sh** - Changed `get_config tmux_session_prefix` → `get_config multiplexer_session_prefix`

### Testing
- ✅ All existing tests pass (59/59 config tests, 49/49 run+mux-all tests)
- ✅ No ShellCheck warnings
- ✅ Backward compatibility maintained (legacy keys still work via aliases)

### Impact
- Improves code consistency across the codebase
- Makes it clear which key names are current vs deprecated
- Prepares for potential future removal of legacy aliases
- No breaking changes - legacy keys continue to work

Closes #924