### PR TITLE
refactor: use persistent status dir for CI retry state

### DIFF
--- a/lib/ci-retry.sh
+++ b/lib/ci-retry.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 _CI_RETRY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_CI_RETRY_LIB_DIR/log.sh"
+source "$_CI_RETRY_LIB_DIR/status.sh"
 
 # ===================
 # 定数定義
@@ -22,7 +23,13 @@ MAX_RETRY_COUNT=3        # 最大リトライ回数
 # Usage: get_retry_state_file <issue_number>
 get_retry_state_file() {
     local issue_number="$1"
-    local state_dir="${PI_RUNNER_STATE_DIR:-/tmp/pi-runner-state}"
+    local state_dir
+    if [[ -n "${PI_RUNNER_STATE_DIR:-}" ]]; then
+        state_dir="$PI_RUNNER_STATE_DIR"
+    else
+        # status.sh と同じディレクトリに保存
+        state_dir="$(get_status_dir)"
+    fi
     mkdir -p "$state_dir"
     echo "$state_dir/ci-retry-$issue_number"
 }


### PR DESCRIPTION
## Summary

Fixes #935 - リトライ状態が /tmp に保存され再起動で失われる問題を修正

## Changes

- リトライ状態のデフォルト保存先を `/tmp` から `.worktrees/.status/` に変更
- `lib/status.sh` の `get_status_dir()` 関数を利用して一貫性を確保
- `PI_RUNNER_STATE_DIR` 環境変数による上書きは引き続きサポート
- システム再起動時にリトライカウントが失われることを防止

## Testing

- ✅ All existing tests pass (18/18)
- ✅ ShellCheck passes
- ✅ No regressions in related tests

## Related

Closes #935