### PR TITLE
fix: prefix unused variables with underscore in workflow-selector.sh

### DIFF
--- a/lib/workflow-selector.sh
+++ b/lib/workflow-selector.sh
@@ -90,7 +90,7 @@ _select_workflow_by_ai() {
 
     # ワークフロー名と説明の一覧テキスト
     local workflows_text=""
-    while IFS=$'\t' read -r name description steps context; do
+    while IFS=$'\t' read -r name description _steps _context; do
         if [[ -n "$name" ]]; then
             workflows_text+="- ${name}: ${description}"$'\n'
         fi


### PR DESCRIPTION
## Summary
Closes #946

## Changes
- Changed `steps context` to `_steps _context` on line 93 of `lib/workflow-selector.sh`
- Silences ShellCheck SC2034 warning by indicating variables are intentionally unused

## Testing
- ✅ All 20 unit tests pass (`bats test/lib/workflow-selector.bats`)
- ✅ ShellCheck passes on all 54 files
- ✅ No regressions introduced