### PR TITLE
refactor: scripts/ の引数解析・セッション名解決パターンの共通化

### DIFF
--- a/lib/session-resolver.sh
+++ b/lib/session-resolver.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# ============================================================================
+# session-resolver.sh - Session name resolution utilities
+#
+# Provides common helper functions for resolving issue numbers and session
+# names from user input. This centralizes the argument parsing pattern used
+# across multiple scripts.
+#
+# Functions:
+#   resolve_session_target - Resolves issue number and session name from input
+#
+# Dependencies:
+#   - lib/tmux.sh (generate_session_name, extract_issue_number)
+# ============================================================================
+
+set -euo pipefail
+
+# Source dependencies
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tmux.sh"
+
+# ============================================================================
+# resolve_session_target - Resolve issue number and session name from input
+#
+# Takes either an issue number or session name and returns both values.
+# This function encapsulates the common pattern of accepting flexible input
+# and resolving it to the canonical issue number and session name pair.
+#
+# Arguments:
+#   $1 - target: Issue number (digits only) or session name
+#
+# Output:
+#   Writes to stdout: "issue_number<TAB>session_name"
+#
+# Exit codes:
+#   0 - Success
+#   1 - Invalid input or resolution failed
+#
+# Examples:
+#   # From issue number
+#   IFS=$'\t' read -r issue_number session_name < <(resolve_session_target "42")
+#   # issue_number="42", session_name="pi-issue-42"
+#
+#   # From session name
+#   IFS=$'\t' read -r issue_number session_name < <(resolve_session_target "pi-issue-42")
+#   # issue_number="42", session_name="pi-issue-42"
+# ============================================================================
+resolve_session_target() {
+    local target="$1"
+    
+    if [[ -z "$target" ]]; then
+        echo "Error: target is required" >&2
+        return 1
+    fi
+    
+    local issue_number
+    local session_name
+    
+    if [[ "$target" =~ ^[0-9]+$ ]]; then
+        # Input is an issue number
+        issue_number="$target"
+        session_name="$(generate_session_name "$issue_number")"
+    else
+        # Input is a session name
+        session_name="$target"
+        issue_number="$(extract_issue_number "$session_name")"
+    fi
+    
+    # Output as tab-separated values
+    printf "%s\t%s\n" "$issue_number" "$session_name"
+    return 0
+}

--- a/scripts/attach.sh
+++ b/scripts/attach.sh
@@ -29,6 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/config.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
+source "$SCRIPT_DIR/../lib/session-resolver.sh"
 
 usage() {
     cat << EOF
@@ -76,15 +77,9 @@ main() {
 
     load_config
 
-    # Issue番号かセッション名か判定
+    # Issue番号またはセッション名から両方を解決
     local session_name
-
-    if [[ "$target" =~ ^[0-9]+$ ]]; then
-        # Issue番号からセッション名を生成
-        session_name="$(generate_session_name "$target")"
-    else
-        session_name="$target"
-    fi
+    IFS=$'\t' read -r _ session_name < <(resolve_session_target "$target")
 
     log_info "Attaching to session: $session_name"
     attach_session "$session_name"

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -51,6 +51,7 @@ source "$SCRIPT_DIR/../lib/hooks.sh"
 source "$SCRIPT_DIR/../lib/cleanup-plans.sh"
 source "$SCRIPT_DIR/../lib/cleanup-orphans.sh"
 source "$SCRIPT_DIR/../lib/cleanup-improve-logs.sh"
+source "$SCRIPT_DIR/../lib/session-resolver.sh"
 
 usage() {
     cat << EOF
@@ -217,17 +218,9 @@ execute_single_cleanup() {
     local keep_session="$4"
     local keep_worktree="$5"
     
-    # Issue番号かセッション名か判定
-    local session_name
-    local issue_number
-
-    if [[ "$target" =~ ^[0-9]+$ ]]; then
-        issue_number="$target"
-        session_name="$(generate_session_name "$issue_number")"
-    else
-        session_name="$target"
-        issue_number="$(extract_issue_number "$session_name")"
-    fi
+    # Issue番号またはセッション名から両方を解決
+    local issue_number session_name
+    IFS=$'\t' read -r issue_number session_name < <(resolve_session_target "$target")
 
     log_info "=== Cleanup ==="
     log_info "Target: $session_name (Issue #$issue_number)"

--- a/scripts/nudge.sh
+++ b/scripts/nudge.sh
@@ -32,6 +32,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/config.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
+source "$SCRIPT_DIR/../lib/session-resolver.sh"
 
 # デフォルトメッセージ
 DEFAULT_MESSAGE="続けてください"
@@ -141,14 +142,9 @@ main() {
             exit 1
         fi
         
-        # Issue番号かセッション名か判定
-        if [[ "$target" =~ ^[0-9]+$ ]]; then
-            # Issue番号からセッション名を生成
-            load_config
-            session_name="$(generate_session_name "$target")"
-        else
-            session_name="$target"
-        fi
+        # Issue番号またはセッション名から両方を解決
+        load_config
+        IFS=$'\t' read -r _ session_name < <(resolve_session_target "$target")
     fi
 
     send_nudge "$session_name" "$message"

--- a/scripts/restart-watcher.sh
+++ b/scripts/restart-watcher.sh
@@ -31,6 +31,7 @@ source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
 source "$SCRIPT_DIR/../lib/daemon.sh"
 source "$SCRIPT_DIR/../lib/status.sh"
+source "$SCRIPT_DIR/../lib/session-resolver.sh"
 
 usage() {
     cat << EOF
@@ -70,19 +71,9 @@ main() {
 
     load_config
 
-    # Issue番号かセッション名か判定
-    local session_name
-    local issue_number
-
-    if [[ "$target" =~ ^[0-9]+$ ]]; then
-        # Issue番号
-        issue_number="$target"
-        session_name="$(generate_session_name "$issue_number")"
-    else
-        # セッション名
-        session_name="$target"
-        issue_number="$(extract_issue_number "$session_name")"
-    fi
+    # Issue番号またはセッション名から両方を解決
+    local issue_number session_name
+    IFS=$'\t' read -r issue_number session_name < <(resolve_session_target "$target")
 
     # セッション存在確認
     if ! session_exists "$session_name"; then

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -33,6 +33,7 @@ source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/github.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
 source "$SCRIPT_DIR/../lib/worktree.sh"
+source "$SCRIPT_DIR/../lib/session-resolver.sh"
 
 usage() {
     cat << EOF
@@ -82,19 +83,9 @@ main() {
 
     load_config
 
-    # Issue番号かセッション名か判定
-    local session_name
-    local issue_number
-
-    if [[ "$target" =~ ^[0-9]+$ ]]; then
-        # Issue番号
-        issue_number="$target"
-        session_name="$(generate_session_name "$issue_number")"
-    else
-        # セッション名
-        session_name="$target"
-        issue_number="$(extract_issue_number "$session_name")"
-    fi
+    # Issue番号またはセッション名から両方を解決
+    local issue_number session_name
+    IFS=$'\t' read -r issue_number session_name < <(resolve_session_target "$target")
 
     echo "=== Task Status ==="
     echo ""

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -28,6 +28,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/config.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
+source "$SCRIPT_DIR/../lib/session-resolver.sh"
 
 usage() {
     cat << EOF
@@ -75,14 +76,9 @@ main() {
 
     load_config
 
-    # Issue番号かセッション名か判定
+    # Issue番号またはセッション名から両方を解決
     local session_name
-
-    if [[ "$target" =~ ^[0-9]+$ ]]; then
-        session_name="$(generate_session_name "$target")"
-    else
-        session_name="$target"
-    fi
+    IFS=$'\t' read -r _ session_name < <(resolve_session_target "$target")
 
     kill_session "$session_name"
     log_info "Session stopped: $session_name"

--- a/test/lib/session-resolver.bats
+++ b/test/lib/session-resolver.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+# ============================================================================
+# test/lib/session-resolver.bats - Tests for session-resolver.sh
+# ============================================================================
+
+load '../test_helper'
+
+setup() {
+    # TMPDIRセットアップ
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    
+    # テスト用の空の設定ファイルパスを作成
+    export TEST_CONFIG_FILE="${BATS_TEST_TMPDIR}/empty-config.yaml"
+    touch "$TEST_CONFIG_FILE"
+    
+    # 設定をリセット
+    unset _CONFIG_LOADED
+    unset _MUX_TYPE
+    unset PI_RUNNER_MULTIPLEXER_SESSION_PREFIX
+    unset PI_RUNNER_SESSION_PREFIX
+    
+    # テストでは tmux を使用
+    export PI_RUNNER_MULTIPLEXER_TYPE="tmux"
+}
+
+teardown() {
+    unset PI_RUNNER_MULTIPLEXER_SESSION_PREFIX
+    unset PI_RUNNER_SESSION_PREFIX
+    
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ============================================================================
+# resolve_session_target tests
+# ============================================================================
+
+@test "resolve_session_target: resolves issue number to session name" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local result
+    result=$(resolve_session_target "42")
+    
+    # Should output: "42<TAB>pi-issue-42"
+    [[ "$result" == "42"$'\t'"pi-issue-42" ]]
+}
+
+@test "resolve_session_target: resolves session name to issue number" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local result
+    result=$(resolve_session_target "pi-issue-42")
+    
+    # Should output: "42<TAB>pi-issue-42"
+    [[ "$result" == "42"$'\t'"pi-issue-42" ]]
+}
+
+@test "resolve_session_target: handles multi-digit issue numbers" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local result
+    result=$(resolve_session_target "1234")
+    
+    [[ "$result" == "1234"$'\t'"pi-issue-1234" ]]
+}
+
+@test "resolve_session_target: handles custom session prefix" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    # Override session prefix
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="custom"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local result
+    result=$(resolve_session_target "99")
+    
+    [[ "$result" == "99"$'\t'"custom-issue-99" ]]
+}
+
+@test "resolve_session_target: can be parsed with IFS read" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local issue_number session_name
+    IFS=$'\t' read -r issue_number session_name < <(resolve_session_target "42")
+    
+    [[ "$issue_number" == "42" ]]
+    [[ "$session_name" == "pi-issue-42" ]]
+}
+
+@test "resolve_session_target: returns error for empty input" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    run resolve_session_target ""
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"target is required"* ]]
+}
+
+@test "resolve_session_target: handles session name with hyphens" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local result
+    result=$(resolve_session_target "pi-issue-42-test")
+    
+    # Should extract "42" from the session name
+    [[ "$result" == "42"$'\t'"pi-issue-42-test" ]]
+}
+
+@test "resolve_session_target: integration with real scripts workflow" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    # Test both input types
+    local issue_number1 session_name1
+    IFS=$'\t' read -r issue_number1 session_name1 < <(resolve_session_target "42")
+    
+    local issue_number2 session_name2
+    IFS=$'\t' read -r issue_number2 session_name2 < <(resolve_session_target "$session_name1")
+    
+    # Both should resolve to the same values
+    [[ "$issue_number1" == "$issue_number2" ]]
+    [[ "$session_name1" == "$session_name2" ]]
+}
+
+# ============================================================================
+# Edge cases
+# ============================================================================
+
+@test "resolve_session_target: handles single digit issue number" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local result
+    result=$(resolve_session_target "1")
+    
+    [[ "$result" == "1"$'\t'"pi-issue-1" ]]
+}
+
+@test "resolve_session_target: handles very large issue numbers" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    local result
+    result=$(resolve_session_target "999999")
+    
+    [[ "$result" == "999999"$'\t'"pi-issue-999999" ]]
+}
+
+@test "resolve_session_target: distinguishes numbers from session names" {
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/session-resolver.sh"
+    
+    _CONFIG_LOADED=""
+    CONFIG_MULTIPLEXER_SESSION_PREFIX="pi"
+    load_config "$TEST_CONFIG_FILE"
+    
+    # Pure number -> treat as issue number
+    local result1
+    result1=$(resolve_session_target "123")
+    [[ "$result1" == "123"$'\t'"pi-issue-123" ]]
+    
+    # Session name containing numbers -> treat as session name
+    local result2
+    result2=$(resolve_session_target "pi-issue-123")
+    [[ "$result2" == "123"$'\t'"pi-issue-123" ]]
+}

--- a/test/scripts/attach.bats
+++ b/test/scripts/attach.bats
@@ -102,16 +102,16 @@ teardown() {
     grep -q "usage()" "$PROJECT_ROOT/scripts/attach.sh"
 }
 
-@test "attach.sh calls generate_session_name" {
-    grep -q "generate_session_name" "$PROJECT_ROOT/scripts/attach.sh"
+@test "attach.sh sources session-resolver.sh" {
+    grep -q "session-resolver.sh" "$PROJECT_ROOT/scripts/attach.sh"
+}
+
+@test "attach.sh uses resolve_session_target" {
+    grep -q "resolve_session_target" "$PROJECT_ROOT/scripts/attach.sh"
 }
 
 @test "attach.sh calls attach_session" {
     grep -q "attach_session" "$PROJECT_ROOT/scripts/attach.sh"
-}
-
-@test "attach.sh handles numeric issue number" {
-    grep -q '\[0-9\]' "$PROJECT_ROOT/scripts/attach.sh"
 }
 
 # ====================

--- a/test/scripts/force-complete.bats
+++ b/test/scripts/force-complete.bats
@@ -127,20 +127,16 @@ teardown() {
     grep -q "usage()" "$PROJECT_ROOT/scripts/force-complete.sh"
 }
 
-@test "force-complete.sh calls generate_session_name" {
-    grep -q "generate_session_name" "$PROJECT_ROOT/scripts/force-complete.sh"
+@test "force-complete.sh sources session-resolver.sh" {
+    grep -q "session-resolver.sh" "$PROJECT_ROOT/scripts/force-complete.sh"
 }
 
-@test "force-complete.sh calls extract_issue_number" {
-    grep -q "extract_issue_number" "$PROJECT_ROOT/scripts/force-complete.sh"
+@test "force-complete.sh uses resolve_session_target" {
+    grep -q "resolve_session_target" "$PROJECT_ROOT/scripts/force-complete.sh"
 }
 
 @test "force-complete.sh calls session_exists" {
     grep -q "session_exists" "$PROJECT_ROOT/scripts/force-complete.sh"
-}
-
-@test "force-complete.sh handles numeric issue number" {
-    grep -q '\[0-9\]' "$PROJECT_ROOT/scripts/force-complete.sh"
 }
 
 @test "force-complete.sh sends completion marker" {

--- a/test/scripts/nudge.bats
+++ b/test/scripts/nudge.bats
@@ -131,12 +131,12 @@ teardown() {
     grep -q "send_nudge()" "$PROJECT_ROOT/scripts/nudge.sh"
 }
 
-@test "nudge.sh uses generate_session_name" {
-    grep -q "generate_session_name" "$PROJECT_ROOT/scripts/nudge.sh"
+@test "nudge.sh sources session-resolver.sh" {
+    grep -q "session-resolver.sh" "$PROJECT_ROOT/scripts/nudge.sh"
 }
 
-@test "nudge.sh handles numeric issue number" {
-    grep -q '\[0-9\]' "$PROJECT_ROOT/scripts/nudge.sh"
+@test "nudge.sh uses resolve_session_target" {
+    grep -q "resolve_session_target" "$PROJECT_ROOT/scripts/nudge.sh"
 }
 
 @test "nudge.sh has default message" {

--- a/test/scripts/stop.bats
+++ b/test/scripts/stop.bats
@@ -107,16 +107,16 @@ teardown() {
     grep -q "usage()" "$PROJECT_ROOT/scripts/stop.sh"
 }
 
-@test "stop.sh calls generate_session_name" {
-    grep -q "generate_session_name" "$PROJECT_ROOT/scripts/stop.sh"
+@test "stop.sh sources session-resolver.sh" {
+    grep -q "session-resolver.sh" "$PROJECT_ROOT/scripts/stop.sh"
+}
+
+@test "stop.sh uses resolve_session_target" {
+    grep -q "resolve_session_target" "$PROJECT_ROOT/scripts/stop.sh"
 }
 
 @test "stop.sh calls kill_session" {
     grep -q "kill_session" "$PROJECT_ROOT/scripts/stop.sh"
-}
-
-@test "stop.sh handles numeric issue number" {
-    grep -q '\[0-9\]' "$PROJECT_ROOT/scripts/stop.sh"
 }
 
 # ====================


### PR DESCRIPTION
## Summary
Closes #945

## Changes
- Created `lib/session-resolver.sh` with `resolve_session_target()` function to consolidate the common pattern of resolving issue numbers and session names
- Refactored 7 scripts to use the common helper:
  - `scripts/attach.sh`
  - `scripts/cleanup.sh`
  - `scripts/force-complete.sh`
  - `scripts/nudge.sh`
  - `scripts/restart-watcher.sh`
  - `scripts/status.sh`
  - `scripts/stop.sh`
- Added comprehensive unit tests in `test/lib/session-resolver.bats` (11 tests)
- Updated existing script tests to verify the new refactored pattern

## Benefits
- **DRY principle**: Eliminates code duplication across 7 scripts
- **Maintainability**: Single source of truth for session resolution logic
- **Consistency**: All scripts now use the same resolution mechanism
- **Testability**: Centralized logic is easier to test and verify

## Testing
- ✅ New unit tests for `session-resolver.sh` (11 tests, all passing)
- ✅ Updated existing tests for affected scripts
- ✅ ShellCheck passes with no warnings
- ✅ Manual testing of session resolution with both issue numbers and session names

## Breaking Changes
None - this is a pure refactoring with no functional changes