### PR TITLE
docs: install.sh が macOS (Homebrew) のみ対応であることを明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ GitHub Issueを入力として、Git worktreeを作成し、ターミナルマ�
 - **簡単なクリーンアップ**: セッションとworktreeを一括削除
 - **自動クリーンアップ**: タスク完了時に `###TASK_COMPLETE_<issue_number>###` マーカーを出力すると、外部プロセスが自動的にworktreeとセッションをクリーンアップします
 
+## 動作環境
+
+- **macOS** (Homebrew)
+- **Linux** (依存パッケージは手動インストールが必要)
+
 ## 前提条件
 
 - **Bash 4.0以上** (macOSの場合: `brew install bash`)
@@ -19,6 +24,9 @@ GitHub Issueを入力として、Git worktreeを作成し、ターミナルマ�
 - `pi`
 - `jq` (JSON処理)
 - `yq` (オプション - YAML解析の精度向上。なくても動作します)
+
+> **Note**: `install.sh --with-deps` は macOS (Homebrew) のみ対応しています。  
+> Linux では依存パッケージ（`gh`, `tmux`, `jq`, `yq`）を手動でインストールしてください。
 
 ## インストール
 

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,10 @@
 #   INSTALL_DIR=/usr/local/bin ./install.sh
 #
 # ラッパースクリプトを INSTALL_DIR に作成します。
+#
+# プラットフォーム:
+#   --with-deps / --deps-only は macOS (Homebrew) のみ対応
+#   Linux の場合は依存パッケージ (gh, tmux, jq, yq) を手動でインストールしてください
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
Closes #967

## Changes
- README.md に「動作環境」セクションを追加
  - macOS (Homebrew) と Linux の違いを明記
  - install.sh --with-deps の制約を Note として追加
- install.sh のヘッダーコメントにプラットフォーム制約を記載
  - macOS (Homebrew) のみ対応であることを明記
  - Linux ユーザー向けに手動インストールの案内を追加

## Testing
- install.sh の構文チェック完了
- 既存のドキュメント構造との整合性確認済み