### PR TITLE
perf: lib/ ファイルにソースガード（多重読み込み防止）を追加

### DIFF
--- a/lib/agent.sh
+++ b/lib/agent.sh
@@ -4,6 +4,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_AGENT_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_AGENT_SH_SOURCED="true"
+
 _AGENT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_AGENT_LIB_DIR/config.sh"
 source "$_AGENT_LIB_DIR/log.sh"

--- a/lib/batch.sh
+++ b/lib/batch.sh
@@ -27,6 +27,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_BATCH_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_BATCH_SH_SOURCED="true"
+
 _BATCH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_BATCH_LIB_DIR/log.sh"
 source "$_BATCH_LIB_DIR/status.sh"

--- a/lib/ci-classifier.sh
+++ b/lib/ci-classifier.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CI_CLASSIFIER_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CI_CLASSIFIER_SH_SOURCED="true"
+
 _CI_CLASSIFIER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_CI_CLASSIFIER_LIB_DIR/log.sh"
 

--- a/lib/ci-fix.sh
+++ b/lib/ci-fix.sh
@@ -36,6 +36,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CI_FIX_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CI_FIX_SH_SOURCED="true"
+
 __CI_FIX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$__CI_FIX_LIB_DIR/log.sh"
 source "$__CI_FIX_LIB_DIR/github.sh"

--- a/lib/ci-monitor.sh
+++ b/lib/ci-monitor.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CI_MONITOR_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CI_MONITOR_SH_SOURCED="true"
+
 _CI_MONITOR_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_CI_MONITOR_LIB_DIR/log.sh"
 source "$_CI_MONITOR_LIB_DIR/github.sh"

--- a/lib/ci-retry.sh
+++ b/lib/ci-retry.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CI_RETRY_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CI_RETRY_SH_SOURCED="true"
+
 _CI_RETRY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_CI_RETRY_LIB_DIR/log.sh"
 source "$_CI_RETRY_LIB_DIR/status.sh"

--- a/lib/cleanup-improve-logs.sh
+++ b/lib/cleanup-improve-logs.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CLEANUP_IMPROVE_LOGS_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CLEANUP_IMPROVE_LOGS_SH_SOURCED="true"
+
 # 自身のディレクトリを取得
 _CLEANUP_IMPROVE_LOGS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/lib/cleanup-orphans.sh
+++ b/lib/cleanup-orphans.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CLEANUP_ORPHANS_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CLEANUP_ORPHANS_SH_SOURCED="true"
+
 # 自身のディレクトリを取得
 _CLEANUP_ORPHANS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/lib/cleanup-plans.sh
+++ b/lib/cleanup-plans.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CLEANUP_PLANS_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CLEANUP_PLANS_SH_SOURCED="true"
+
 # 自身のディレクトリを取得
 _CLEANUP_PLANS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/lib/context.sh
+++ b/lib/context.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_CONTEXT_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_CONTEXT_SH_SOURCED="true"
+
 # 自身のディレクトリを取得
 _CONTEXT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -6,6 +6,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_DAEMON_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_DAEMON_SH_SOURCED="true"
+
 # コマンドをデーモン化して実行
 # Usage: daemonize <log_file> <command> [args...]
 # Returns: デーモンプロセスのPID（setsid使用時）、または子シェルのPID（互換モード時）

--- a/lib/dashboard.sh
+++ b/lib/dashboard.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_DASHBOARD_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_DASHBOARD_SH_SOURCED="true"
+
 _DASHBOARD_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Bash 4.0以上を要求（連想配列のサポート）

--- a/lib/dependency.sh
+++ b/lib/dependency.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_DEPENDENCY_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_DEPENDENCY_SH_SOURCED="true"
+
 _DEPENDENCY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_DEPENDENCY_LIB_DIR/log.sh"
 source "$_DEPENDENCY_LIB_DIR/github.sh"

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_GITHUB_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_GITHUB_SH_SOURCED="true"
+
 _GITHUB_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_GITHUB_LIB_DIR/log.sh"
 

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -6,6 +6,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_HOOKS_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_HOOKS_SH_SOURCED="true"
+
 _HOOKS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 依存ライブラリの読み込み（未読み込みの場合のみ）

--- a/lib/improve.sh
+++ b/lib/improve.sh
@@ -12,6 +12,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_IMPROVE_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_IMPROVE_SH_SOURCED="true"
+
 _IMPROVE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source required dependencies

--- a/lib/improve/args.sh
+++ b/lib/improve/args.sh
@@ -7,6 +7,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_ARGS_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_ARGS_SH_SOURCED="true"
+
 # Constants
 readonly _IMPROVE_DEFAULT_MAX_ITERATIONS=3
 readonly _IMPROVE_DEFAULT_MAX_ISSUES=5

--- a/lib/improve/deps.sh
+++ b/lib/improve/deps.sh
@@ -10,6 +10,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_DEPS_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_DEPS_SH_SOURCED="true"
+
 # ============================================================================
 # Check dependencies for improve workflow
 # Returns: 0 if all dependencies are met, 1 otherwise

--- a/lib/improve/env.sh
+++ b/lib/improve/env.sh
@@ -7,6 +7,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_ENV_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_ENV_SH_SOURCED="true"
+
 # ============================================================================
 # Validate iteration number against maximum
 # Arguments: $1=current iteration, $2=max iterations

--- a/lib/improve/execution.sh
+++ b/lib/improve/execution.sh
@@ -12,6 +12,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_EXECUTION_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_EXECUTION_SH_SOURCED="true"
+
 # Global: Track active sessions for cleanup on exit
 declare -a ACTIVE_ISSUE_NUMBERS=()
 

--- a/lib/improve/review.sh
+++ b/lib/improve/review.sh
@@ -7,6 +7,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_REVIEW_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_REVIEW_SH_SOURCED="true"
+
 # ============================================================================
 # Execute project review using pi --print
 # Arguments: $1=max_issues, $2=session_label, $3=log_file, $4=dry_run,

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_LOG_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_LOG_SH_SOURCED="true"
+
 # ログレベル: DEBUG < INFO < WARN < ERROR < QUIET
 LOG_LEVEL="${LOG_LEVEL:-INFO}"
 

--- a/lib/multiplexer-tmux.sh
+++ b/lib/multiplexer-tmux.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_MULTIPLEXER_TMUX_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_MULTIPLEXER_TMUX_SH_SOURCED="true"
+
 # tmuxがインストールされているか確認
 mux_check() {
     if ! command -v tmux &> /dev/null; then

--- a/lib/multiplexer-zellij.sh
+++ b/lib/multiplexer-zellij.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_MULTIPLEXER_ZELLIJ_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_MULTIPLEXER_ZELLIJ_SH_SOURCED="true"
+
 # Zellijがインストールされているか確認
 mux_check() {
     if ! command -v zellij &> /dev/null; then

--- a/lib/multiplexer.sh
+++ b/lib/multiplexer.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_MULTIPLEXER_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_MULTIPLEXER_SH_SOURCED="true"
+
 _MUX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_MUX_LIB_DIR/config.sh"
 source "$_MUX_LIB_DIR/log.sh"

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -12,6 +12,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_NOTIFY_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_NOTIFY_SH_SOURCED="true"
+
 _NOTIFY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_NOTIFY_LIB_DIR/config.sh"
 source "$_NOTIFY_LIB_DIR/log.sh"

--- a/lib/priority.sh
+++ b/lib/priority.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_PRIORITY_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_PRIORITY_SH_SOURCED="true"
+
 _PRIORITY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_PRIORITY_LIB_DIR/log.sh"
 source "$_PRIORITY_LIB_DIR/github.sh"

--- a/lib/session-resolver.sh
+++ b/lib/session-resolver.sh
@@ -15,6 +15,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_SESSION_RESOLVER_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_SESSION_RESOLVER_SH_SOURCED="true"
+
 # Source dependencies
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/tmux.sh"

--- a/lib/status.sh
+++ b/lib/status.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_STATUS_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_STATUS_SH_SOURCED="true"
+
 # 自身のディレクトリを取得（SCRIPT_DIRとは別に保存）
 _STATUS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/lib/template.sh
+++ b/lib/template.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_TEMPLATE_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_TEMPLATE_SH_SOURCED="true"
+
 # ビルトインエージェントプロンプト（最小限）
 _BUILTIN_AGENT_PLAN='Plan the implementation for issue #{{issue_number}}.
 Read the issue description and create an implementation plan.'

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -9,6 +9,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_TMUX_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_TMUX_SH_SOURCED="true"
+
 _TMUX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # multiplexer.sh をロード（これが実際の実装を提供）

--- a/lib/workflow-finder.sh
+++ b/lib/workflow-finder.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_WORKFLOW_FINDER_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_WORKFLOW_FINDER_SH_SOURCED="true"
+
 _WORKFLOW_FINDER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_WORKFLOW_FINDER_LIB_DIR/yaml.sh"
 source "$_WORKFLOW_FINDER_LIB_DIR/config.sh"

--- a/lib/workflow-loader.sh
+++ b/lib/workflow-loader.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_WORKFLOW_LOADER_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_WORKFLOW_LOADER_SH_SOURCED="true"
+
 _WORKFLOW_LOADER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_WORKFLOW_LOADER_LIB_DIR/yaml.sh"
 source "$_WORKFLOW_LOADER_LIB_DIR/log.sh"

--- a/lib/workflow-prompt.sh
+++ b/lib/workflow-prompt.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_WORKFLOW_PROMPT_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_WORKFLOW_PROMPT_SH_SOURCED="true"
+
 _WORKFLOW_PROMPT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_WORKFLOW_PROMPT_LIB_DIR/log.sh"
 

--- a/lib/workflow-selector.sh
+++ b/lib/workflow-selector.sh
@@ -8,6 +8,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_WORKFLOW_SELECTOR_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_WORKFLOW_SELECTOR_SH_SOURCED="true"
+
 _WORKFLOW_SELECTOR_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 依存ライブラリ（workflow.sh 経由で既にロード済みの場合はスキップ）

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -8,6 +8,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_WORKFLOW_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_WORKFLOW_SH_SOURCED="true"
+
 _WORKFLOW_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # モジュール読み込み

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_WORKTREE_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_WORKTREE_SH_SOURCED="true"
+
 # 現在のディレクトリを取得
 _WORKTREE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/lib/yaml.sh
+++ b/lib/yaml.sh
@@ -6,6 +6,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_YAML_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_YAML_SH_SOURCED="true"
+
 # ===================
 # yq チェック
 # ===================


### PR DESCRIPTION
## Summary
Closes #966

## Changes
- 全38ファイル（lib/*.sh, lib/improve/*.sh）にソースガードを追加
- 各ファイル固有のガード変数を使用（_<FILENAME>_SH_SOURCED）
- 多重読み込みによるパフォーマンス低下を防止
- 特に高頻度でsourceされるファイルを最適化:
  - lib/log.sh (43回)
  - lib/tmux.sh (15回)
  - lib/status.sh (12回)
  - lib/github.sh (10回)

## Implementation Details
各ファイルの `set -euo pipefail` の直後に以下のパターンを追加:

```bash
# ソースガード（多重読み込み防止）
if [[ -n "${_<FILENAME>_SH_SOURCED:-}" ]]; then
    return 0
fi
_<FILENAME>_SH_SOURCED="true"
```

## Testing
- ✅ 全ファイルにソースガードが存在することを確認
- ✅ ガード変数が一意であることを確認
- ✅ 多重読み込みが正常に動作することを確認
- ✅ 既存テストがパス (1445/1462 tests passed)
  - 失敗テストは既存の問題（verify-config-docs, improve arguments等）

## Performance Impact
同一プロセス内での複数回パースを防止し、特に以下のシナリオで効果を発揮:
- バッチ実行時の複数Issue処理
- 複雑な依存関係を持つスクリプトの実行
- 長時間稼働するデーモンプロセス