### PR TITLE
docs: clarify CONFIG_FILE handling in workflow-loader.sh

### DIFF
--- a/lib/workflow-loader.sh
+++ b/lib/workflow-loader.sh
@@ -45,6 +45,10 @@ get_workflow_steps() {
     # config-workflow:NAME 形式の処理（.pi-runner.yaml の workflows.{NAME}.steps）
     if [[ "$workflow_file" == config-workflow:* ]]; then
         local workflow_name="${workflow_file#config-workflow:}"
+        # 設定ファイルのパスを決定
+        # - CONFIG_FILE 環境変数が設定されている場合はそれを使用（テスト用）
+        # - 未設定の場合は config_file_found() で自動検索
+        # NOTE: このパターンは #954 で追加され、#942 の重複issue でも同様の問題が報告された
         local config_file
         if [[ -n "${CONFIG_FILE:-}" ]]; then
             # CONFIG_FILE 環境変数が設定されている場合（テスト用）
@@ -137,6 +141,7 @@ get_workflow_context() {
     # config-workflow:NAME 形式の処理（.pi-runner.yaml の workflows.{NAME}.context）
     if [[ "$workflow_file" == config-workflow:* ]]; then
         local workflow_name="${workflow_file#config-workflow:}"
+        # 設定ファイルのパスを決定（同上）
         local config_file
         if [[ -n "${CONFIG_FILE:-}" ]]; then
             # CONFIG_FILE 環境変数が設定されている場合（テスト用）
@@ -189,7 +194,7 @@ get_all_workflows_info() {
     # shellcheck disable=SC2034  # project_root reserved for future use
     local project_root="${1:-.}"
     
-    # 設定ファイルのパスを決定
+    # 設定ファイルのパスを決定（同上）
     local config_file
     if [[ -n "${CONFIG_FILE:-}" ]]; then
         # CONFIG_FILE 環境変数が設定されている場合（テスト用）


### PR DESCRIPTION
## Summary
Closes #942

This issue is a duplicate of #954, which was already fixed in PR #961.

## Background

Issue #942 was automatically generated by a code review tool and identified that `lib/workflow-loader.sh` references `CONFIG_FILE`, which is not exported by `config.sh`. However, this was already addressed in issue #954 with the following commits:

- 0136979: Replace undefined CONFIG_FILE with config_file_found() API
- 3d74fe6: Support CONFIG_FILE env var for backward compatibility
- PR #961: Merged the fix into main

## Changes

This PR adds documentation comments to clarify the `CONFIG_FILE` handling pattern in 3 locations within `lib/workflow-loader.sh`:

1. `get_workflow_steps()` - config-workflow:NAME handling
2. `get_workflow_context()` - config-workflow:NAME context handling  
3. `get_all_workflows_info()` - config file resolution

The pattern properly handles:
- **Test environment**: Uses `CONFIG_FILE` environment variable when set
- **Production**: Uses `config_file_found()` API to search for config files

## Testing

- ✅ All workflow-loader tests pass (66/66)
- ✅ All workflow-prompt tests pass
- ✅ All workflow-selector tests pass
- ✅ ShellCheck validation passes with no warnings

## Related Issues

- Closes #942
- Related to #954 (original fix)