### PR TITLE
docs: add 4 missing commands to README.md command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-nudge` | セッションにメッセージ送信 |
 | `pi-init` | プロジェクト初期化 |
 | `pi-context` | コンテキスト管理 |
+| `pi-dashboard` | ダッシュボード表示 |
+| `pi-ci-fix` | CI修正ヘルパー |
+| `pi-next` | 次のタスク取得 |
+| `pi-restart-watcher` | Watcher再起動 |
 | `pi-mux-all` | 全セッション表示（タイル表示） |
 | `pi-generate-config` | プロジェクト解析・設定生成 |
 


### PR DESCRIPTION
## Summary
Closes #975

## Changes
Added 4 commands to the README.md command table that were missing but are installed by install.sh:
- `pi-ci-fix`: CI修正ヘルパー
- `pi-dashboard`: ダッシュボード表示
- `pi-next`: 次のタスク取得
- `pi-restart-watcher`: Watcher再起動

## Testing
- Verified that all commands in install.sh are now documented in README.md
- Checked that the table formatting is consistent