### PR TITLE
fix: save initial 'running' status in run.sh to avoid race condition

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -130,6 +130,7 @@ source "$SCRIPT_DIR/../lib/workflow.sh"
 source "$SCRIPT_DIR/../lib/hooks.sh"
 source "$SCRIPT_DIR/../lib/agent.sh"
 source "$SCRIPT_DIR/../lib/daemon.sh"
+source "$SCRIPT_DIR/../lib/status.sh"
 
 # 設定ファイルの存在チェック（必須）
 require_config_file "pi-run" || exit 1
@@ -455,6 +456,9 @@ start_agent_session() {
     
     # セッション作成成功 - クリーンアップ対象から除外
     unregister_worktree_for_cleanup
+    
+    # Issue #974: セッション作成直後にステータスを保存（レースコンディション回避）
+    save_status "$issue_number" "running" "$session_name"
     
     # on_start hookを実行
     run_hook "on_start" "$issue_number" "$session_name" "feature/$branch_name" "$full_worktree_path" "" "0" "$issue_title"


### PR DESCRIPTION
## Summary
Closes #974

## Problem
`run.sh` was not saving the session status immediately after creation. The status was only saved by `watch-session.sh` which runs asynchronously as a daemon. This created a race condition where the status appeared as 'unknown' for a few seconds after session creation.

## Solution
- Source `lib/status.sh` in `run.sh`
- Call `save_status()` immediately after `create_session()` succeeds
- This prevents the status appearing as 'unknown' during watcher startup
- Idempotent with `watch-session.sh`'s existing status save

## Changes
- Added `source "$SCRIPT_DIR/../lib/status.sh"` to library imports
- Added `save_status "$issue_number" "running" "$session_name"` after session creation

## Testing
- ShellCheck validation passes
- Core run.sh tests pass
- No breaking changes to existing functionality