### PR TITLE
fix: use generate_session_name() in lib/improve/execution.sh

### DIFF
--- a/lib/improve/execution.sh
+++ b/lib/improve/execution.sh
@@ -116,9 +116,8 @@ _wait_for_available_slot() {
             status="$(get_status_value "$issue_num" 2>/dev/null || echo "")"
             if [[ "$status" == "completed" || "$status" == "failed" || "$status" == "error" || "$status" == "merged" ]]; then
                 # Cleanup the tmux session if it's still lingering
-                local prefix
-                prefix="$(get_config session_prefix)"
-                local session_name="${prefix}-issue-${issue_num}"
+                local session_name
+                session_name="$(generate_session_name "$issue_num")"
                 if mux_session_exists "$session_name" 2>/dev/null; then
                     log_info "Cleaning up completed session: $session_name (status: $status)"
                     "${SCRIPT_DIR}/cleanup.sh" "$session_name" --force 2>/dev/null || true

--- a/test/lib/improve/execution.bats
+++ b/test/lib/improve/execution.bats
@@ -375,6 +375,8 @@ EOF
     run bash -c "
         source '$PROJECT_ROOT/lib/log.sh'
         get_config() { echo '2'; }
+        generate_session_name() { echo \"pi-issue-\$1\"; }
+        mux_session_exists() { return 0; }
         COUNTER_FILE='$counter_file'
         mux_count_active_sessions() {
             local count=\$(cat \"\$COUNTER_FILE\")
@@ -411,6 +413,8 @@ EOF
     run bash -c "
         source '$PROJECT_ROOT/lib/log.sh'
         get_config() { echo '2'; }
+        generate_session_name() { echo \"pi-issue-\$1\"; }
+        mux_session_exists() { return 0; }
         COUNTER_FILE='$counter_file'
         # Simulate: first 2 calls under limit, 3rd at limit, then drops
         mux_count_active_sessions() {


### PR DESCRIPTION
## Summary
Closes #985

## Changes
- Replaced manual session name construction with `generate_session_name()` in `lib/improve/execution.sh`
- Added necessary mocks (`generate_session_name`, `mux_session_exists`) in test files
- Ensures that session name format changes are centrally managed and `session_prefix` config changes are properly reflected

## Testing
- All 42 tests in `test/lib/improve/execution.bats` pass
- ShellCheck validation passed with no warnings
- Manual verification: session names are now generated consistently across the codebase

## Impact
- Fixes DRY violation
- Ensures future session name format changes only need to be updated in one place
- No breaking changes