### PR TITLE
docs: README.md の Hook 設定例を環境変数に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,13 +631,27 @@ steps:
 # .pi-runner.yaml
 hooks:
   on_start: ./hooks/on-start.sh
-  on_success: terminal-notifier -title "完了" -message "Issue #{{issue_number}} が完了しました"
+  on_success: terminal-notifier -title "完了" -message "Issue #$PI_ISSUE_NUMBER が完了しました"
   on_error: |
     curl -X POST -H 'Content-Type: application/json' \
-      -d '{"text": "Issue #{{issue_number}} でエラー"}' \
+      -d '{"text": "Issue #$PI_ISSUE_NUMBER でエラー"}' \
       $SLACK_WEBHOOK_URL
   on_cleanup: echo "クリーンアップ完了" >> ~/.pi-runner/activity.log
 ```
+
+### 利用可能な環境変数
+
+hookスクリプトには以下の環境変数が渡されます：
+
+| 環境変数 | 説明 |
+|----------|------|
+| `PI_ISSUE_NUMBER` | Issue番号 |
+| `PI_ISSUE_TITLE` | Issueタイトル |
+| `PI_SESSION_NAME` | セッション名 |
+| `PI_BRANCH_NAME` | ブランチ名 |
+| `PI_WORKTREE_PATH` | worktreeパス |
+| `PI_ERROR_MESSAGE` | エラーメッセージ（on_errorのみ） |
+| `PI_EXIT_CODE` | 終了コード |
 
 ### ⚠️ セキュリティ注意
 


### PR DESCRIPTION
## Summary
Closes #996

## Changes
- テンプレート変数 `{{issue_number}}` を環境変数 `$PI_ISSUE_NUMBER` に変更（L634, L637）
- Hook セクションに「利用可能な環境変数」テーブルを追加
- docs/hooks.md との整合性を確保

## Testing
- ShellCheck: ✅ 全56ファイルパス
- verify-config-docs.sh: ✅ ドキュメント整合性確認

## Details
README.md の Hook 設定例で使われていたテンプレート変数 `{{issue_number}}` は、実際には `lib/hooks.sh` で展開されず、リテラル文字列として出力されていました。

この問題を修正するため、環境変数 `$PI_ISSUE_NUMBER` を使用するように変更し、利用可能な環境変数の一覧表も追加しました。これにより、ユーザーが README の例をコピペした際に期待通りに動作するようになります。