### PR TITLE
chore: register pi-verify-config-docs command in install/uninstall scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ pi-restart-watcher:scripts/restart-watcher.sh
 pi-mux-all:scripts/mux-all.sh
 pi-generate-config:scripts/generate-config.sh
 pi-test:scripts/test.sh
-pi-verify-config:scripts/verify-config-docs.sh
+pi-verify-config-docs:scripts/verify-config-docs.sh
 "
 
 echo "Installing pi-issue-runner to $INSTALL_DIR..."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -28,6 +28,7 @@ pi-init
 pi-nudge
 pi-context
 pi-generate-config
+pi-verify-config-docs
 "
 
 echo "Uninstalling pi-issue-runner from $INSTALL_DIR..."


### PR DESCRIPTION
## Summary
Closes #998

## Changes
- Renamed `pi-verify-config` to `pi-verify-config-docs` in `install.sh` for better clarity
- Added `pi-verify-config-docs` to `uninstall.sh` COMMANDS list
- Ensures the command is properly registered and can be cleanly uninstalled

## Testing
- ✅ Verified `./install.sh` creates `pi-verify-config-docs` command
- ✅ Verified `pi-verify-config-docs --help` works correctly
- ✅ ShellCheck validation passed for both scripts