### PR TITLE
fix: mux_kill_session の max_wait パラメータが実際の待機秒数と不一致

### DIFF
--- a/lib/multiplexer-tmux.sh
+++ b/lib/multiplexer-tmux.sh
@@ -134,7 +134,7 @@ mux_kill_session() {
     # 終了を待機
     local waited=0
     while mux_session_exists "$session_name" && [[ "$waited" -lt "$max_wait" ]]; do
-        sleep 0.5
+        sleep 1
         waited=$((waited + 1))
     done
     
@@ -155,7 +155,7 @@ mux_kill_session() {
             done <<< "$pane_pids"
             
             if [[ "$any_running" == "true" ]]; then
-                sleep 0.5
+                sleep 1
                 pid_waited=$((pid_waited + 1))
             fi
         done


### PR DESCRIPTION
## Summary
Closes #995

## Changes
- `mux_kill_session` の `sleep 0.5` を `sleep 1` に変更（2箇所）
- セッション終了待機ループとPID終了待機ループの両方を修正
- これにより `max_wait=30` が実際に30秒待機するようになる（以前は15秒）

## Details
問題:
- `max_wait` パラメータは「秒数」を意味するように見えるが、実装では `sleep 0.5` でループし `waited` を1ずつインクリメントしていた
- そのため `max_wait=30` の場合、実際の最大待機時間は15秒（30 × 0.5秒）で、期待される30秒の半分だった

修正内容:
- セッション終了待機: `sleep 0.5` → `sleep 1`
- PID終了待機: `sleep 0.5` → `sleep 1`

## Testing
- ShellCheck: ✅ パス（警告なし）
- 既存のロジックは維持（変更は sleep 時間のみ）