### PR TITLE
docs: 存在しないスクリプトファイルへの参照を修正

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -827,13 +827,15 @@ github:
 
 ```yaml
 hooks:
-  on_start: ./scripts/notify-start.sh
+  # 例: ./hooks/notify-start.sh (ユーザーが作成)
+  on_start: ./hooks/notify-start.sh
   on_success: echo "Task completed for Issue #$PI_ISSUE_NUMBER"
   on_error: |
     curl -X POST https://example.com/webhook \
       -H 'Content-Type: application/json' \
       -d "{\"issue\": \"$PI_ISSUE_NUMBER\", \"error\": \"$PI_ERROR_MESSAGE\"}"
-  on_cleanup: ./scripts/cleanup-resources.sh
+  # 例: ./hooks/cleanup-resources.sh (ユーザーが作成)
+  on_cleanup: ./hooks/cleanup-resources.sh
 ```
 
 #### 環境変数

--- a/docs/security.md
+++ b/docs/security.md
@@ -292,8 +292,8 @@ hooks:
   # ✅ 安全: 環境変数を使用
   on_success: "echo 'Task completed: #$PI_ISSUE_NUMBER'"
   
-  # ✅ 安全: 信頼できるスクリプトファイル
-  on_error: "./scripts/notify-error.sh"
+  # ✅ 安全: 信頼できるスクリプトファイル（例: ./hooks/notify-error.sh をユーザーが作成）
+  on_error: "./hooks/notify-error.sh"
   
   # ⚠️ 注意: 外部サービスへの送信は機密情報に注意
   on_start: "curl -X POST https://example.com/webhook -d '{\"issue\": \"$PI_ISSUE_NUMBER\"}'"


### PR DESCRIPTION
## Summary
Closes #1007

## Changes
- docs/configuration.md: スクリプトパスを `./scripts/` から `./hooks/` に変更し、ユーザーが作成する例であることを明記
- docs/security.md: スクリプトパスを `./scripts/` から `./hooks/` に変更し、ユーザーが作成する例であることを明記

存在しないスクリプトファイルへの参照が誤解を招く可能性があったため、以下の対応を実施：
1. パスを `./hooks/` に変更（ユーザーがhookスクリプトを配置する想定パス）
2. コメントを追加してこれが例示であることを明確化

## Testing
- ドキュメントの整合性を確認
- 参照されているパスが存在しないことによる混乱を解消