### PR TITLE
refactor: convert get_config() to table-driven approach

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -333,13 +333,15 @@ get_config() {
     local key="$1"
     local canonical_key="$key"
     
-    # Handle deprecated keys
+    # Handle deprecated keys (temporarily disable nounset for array subscript access)
+    set +u
     if [[ -n "${_CONFIG_DEPRECATED_KEYS[$key]:-}" ]]; then
         canonical_key="${_CONFIG_DEPRECATED_KEYS[$key]}"
     fi
     
     # Look up the variable name from the mapping table
     local var_name="${_CONFIG_KEY_MAP[$canonical_key]:-}"
+    set -u
     
     if [[ -n "$var_name" ]]; then
         # Use indirect expansion to get the variable value
@@ -361,10 +363,10 @@ reload_config() {
 show_config() {
     echo "=== Configuration ==="
     
-    # Iterate over all config keys in sorted order
+    # Iterate over all config keys in sorted order (quote array subscript)
     local key var_name
     for key in $(printf '%s\n' "${!_CONFIG_KEY_MAP[@]}" | sort); do
-        var_name="${_CONFIG_KEY_MAP[$key]}"
+        var_name="${_CONFIG_KEY_MAP["$key"]}"
         echo "$key: ${!var_name}"
     done
 }


### PR DESCRIPTION
## Summary
Closes #1008

## Changes
- Replace 102-line case statement with associative array lookup
- Create `_CONFIG_KEY_MAP` for config key to variable name mapping
- Create `_CONFIG_DEPRECATED_KEYS` for backward compatibility
- Refactor `show_config()` to iterate over mapping table
- Reduce code by 58 lines (131 deleted, 73 added)

## Benefits
- **Maintainability**: Adding new config keys now requires only updating the mapping table
- **Consistency**: Single source of truth for config key mappings
- **Safety**: Uses indirect expansion instead of eval
- **Backward compatibility**: Deprecated keys (tmux_*) still work

## Testing
- ✅ All 59 config tests pass
- ✅ ShellCheck passes with no warnings
- ✅ Related tests (workflow, status, agent) all pass
- ✅ Special characters handled correctly (quotes, backslashes, dollar signs)