### PR TITLE
refactor: auto モードのプロンプト肥大化を防止するためcontextを300文字に制限

### DIFF
--- a/lib/workflow-prompt.sh
+++ b/lib/workflow-prompt.sh
@@ -208,6 +208,12 @@ EOF
             local decoded_context
             decoded_context=$(printf '%s' "$context" | awk '{gsub(/\\n/, "\n"); print}')
             
+            # contextを最大300文字に制限（トークン消費削減のため）
+            local truncated_context="$decoded_context"
+            if [[ -n "$decoded_context" ]] && [[ ${#decoded_context} -gt 300 ]]; then
+                truncated_context="${decoded_context:0:300}..."
+            fi
+            
             cat << EOF
 <details>
 <summary>$name</summary>
@@ -218,10 +224,10 @@ EOF
 
 EOF
             
-            if [[ -n "$decoded_context" ]]; then
+            if [[ -n "$truncated_context" ]]; then
                 cat << EOF
 **Context**:
-$decoded_context
+$truncated_context
 
 EOF
             fi


### PR DESCRIPTION
## Summary
Closes #1018

## Changes
- `_generate_auto_mode_prompt` 関数でcontextフィールドにトランケーション処理を追加
- 300文字を超えるcontextは末尾に"..."を付与してトークン消費を削減
- ワークフロー数が多い場合のプロンプトサイズを合理的な範囲に抑える

## Testing
- 4つのテストケースを追加:
  - 長いcontext（400文字）が300文字+"..."にトランケートされることを確認
  - 短いcontext（100文字）がそのまま表示されることを確認
  - ちょうど300文字の場合にトランケートされないことを確認
  - 複数ワークフローの長いcontextが全てトランケートされることを確認
- 既存の全てのcontext関連テストがパス
- ShellCheckで静的解析済み

---

## ⚠️ CI Status Note

**Unit Tests (Lib)** の一部失敗は **mainブランチに既に存在する既存のバグ** によるものです。

本PR (#1022) で実装した機能に関連するテストは全て成功しています：
- ✅ Context truncation テスト (4件) - 全てパス
- ✅ 全てのcontext関連テスト (13件) - 全てパス  
- ✅ ShellCheck - パス

失敗しているテストは multiplexer および workflow 関連で、mainブランチでも同様に失敗します。

