### PR TITLE
docs: update test/regression/ directory structure in AGENTS.md and README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,8 @@ pi-issue-runner/
 │   │   └── watch-session.bats
 │   ├── regression/    # 回帰テスト
 │   │   ├── critical-fixes.bats
-│   │   └── eval-injection.bats
+│   │   ├── eval-injection.bats
+│   │   └── pr-merge-timeout.bats
 │   ├── fixtures/      # テスト用フィクスチャ
 │   │   └── sample-config.yaml
 │   └── test_helper.bash  # Bats共通ヘルパー

--- a/README.md
+++ b/README.md
@@ -783,6 +783,9 @@ pi-issue-runner/
 │   │   └── yaml.bats        # yaml.sh のテスト
 │   ├── scripts/             # スクリプトの統合テスト
 │   ├── regression/          # 回帰テスト
+│   │   ├── critical-fixes.bats
+│   │   ├── eval-injection.bats
+│   │   └── pr-merge-timeout.bats
 │   ├── fixtures/            # テスト用フィクスチャ
 │   └── test_helper.bash     # Bats共通ヘルパー
 └── .worktrees/              # worktree作成先（実行時に生成）
@@ -885,7 +888,9 @@ test/
 │   ├── wait-for-sessions.bats   # wait-for-sessions.sh のテスト
 │   └── watch-session.bats       # watch-session.sh のテスト
 ├── regression/                  # 回帰テスト
-│   └── critical-fixes.bats
+│   ├── critical-fixes.bats
+│   ├── eval-injection.bats
+│   └── pr-merge-timeout.bats
 ├── fixtures/                    # テスト用フィクスチャ
 │   └── sample-config.yaml
 └── test_helper.bash             # Bats共通ヘルパー（モック関数含む）


### PR DESCRIPTION
## Summary
Closes #1027

## Changes
- Added missing `pr-merge-timeout.bats` to AGENTS.md regression section
- Expanded regression section in README.md (first occurrence) to show all 3 test files
- Added missing `eval-injection.bats` and `pr-merge-timeout.bats` to README.md (second occurrence)

All documentation now accurately reflects the actual file structure:
```
test/regression/
├── critical-fixes.bats
├── eval-injection.bats
└── pr-merge-timeout.bats
```

## Testing
- Verified actual files match documentation using `diff` command
- No code changes, documentation only