### PR TITLE
fix: CI workflowのgh CLIインストールがキャッシュ条件と不整合

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq tmux
+          # Install gh CLI (not cacheable, always install)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
 
       - name: Install yq
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -52,15 +58,6 @@ jobs:
           YQ_VERSION="v4.40.5"
           sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
           sudo chmod +x /usr/local/bin/yq
-
-      - name: Install gh CLI
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
 
       - name: Install Bats
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -98,6 +95,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq tmux
+          # Install gh CLI (not cacheable, always install)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
 
       - name: Install yq
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -105,15 +108,6 @@ jobs:
           YQ_VERSION="v4.40.5"
           sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
           sudo chmod +x /usr/local/bin/yq
-
-      - name: Install gh CLI
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
 
       - name: Install Bats
         if: steps.cache-deps.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
Closes #1029

## 問題
`.github/workflows/ci.yaml` でgh CLIのインストールステップがキャッシュヒット条件付きだが、キャッシュパスにgh CLIが含まれていないため、キャッシュヒット時にgh CLIがインストールされない可能性がある。

## Changes
- gh CLIインストールを「Install system dependencies」ステップに統合
- 条件付きの「Install gh CLI」ステップを削除
- 両方のジョブ（unit-tests-lib, unit-tests-scripts）に適用
- gh CLIが常にインストールされることを保証

## 理由
- gh CLIは apt-get で /usr/bin/gh にインストールされるためキャッシュ不可能
- システム依存関係として毎回インストールするのが適切

## Testing
- 全てのユニットテスト（1521テスト）が成功
- CI実行でgh CLIがキャッシュ状態に関わらず利用可能になることを確認予定