### PR TITLE
fix: 回帰テスト(test/regression/)がCIおよびtest.shで実行されていない

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,3 +129,56 @@ jobs:
         env:
           BATS_JOBS: 4
           BATS_FAST_MODE: 1
+
+  regression-tests:
+    name: Regression Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        id: cache-deps
+        with:
+          path: |
+            /usr/local/bin/bats
+            /usr/local/libexec/bats-core
+            /usr/local/bin/yq
+          key: ${{ runner.os }}-deps-v2
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq tmux
+
+      - name: Install yq
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          YQ_VERSION="v4.40.5"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Install gh CLI
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
+
+      - name: Install Bats
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          cd /tmp/bats-core
+          sudo ./install.sh /usr/local
+
+      - name: Run regression tests
+        run: |
+          echo "=== Running Bats tests (regression) ==="
+          ./scripts/test.sh regression
+        env:
+          BATS_JOBS: 4
+          BATS_FAST_MODE: 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,6 +56,7 @@ Options:
 Target:
     lib               test/lib/*.bats のみ実行
     scripts           test/scripts/*.bats のみ実行
+    regression        test/regression/*.bats のみ実行
     skills            test/skills/**/*.bats のみ実行
     (default)         全Batsテストを実行
 
@@ -167,11 +168,14 @@ run_bats_tests() {
         scripts)
             test_files=("$TEST_DIR"/scripts/*.bats)
             ;;
+        regression)
+            test_files=("$TEST_DIR"/regression/*.bats)
+            ;;
         skills)
             test_files=("$TEST_DIR"/skills/**/*.bats)
             ;;
         *)
-            test_files=("$TEST_DIR"/lib/*.bats "$TEST_DIR"/scripts/*.bats "$TEST_DIR"/skills/**/*.bats)
+            test_files=("$TEST_DIR"/lib/*.bats "$TEST_DIR"/scripts/*.bats "$TEST_DIR"/regression/*.bats "$TEST_DIR"/skills/**/*.bats)
             ;;
     esac
     


### PR DESCRIPTION
## Summary
Closes #1026

## Changes
- `scripts/test.sh`: `test/regression/*.bats` をデフォルト実行に追加
- `scripts/test.sh`: `regression` ターゲットを追加（`./scripts/test.sh regression` で回帰テストのみ実行可能）
- `.github/workflows/ci.yaml`: `regression-tests` ジョブを追加

## Testing
- ✅ `./scripts/test.sh regression` で51個の回帰テストが実行されることを確認
- ✅ `./scripts/test.sh` のデフォルト実行に回帰テストが含まれることを確認（1572テスト）
- ✅ ShellCheck passed (56 files)

## Details
回帰テストディレクトリ（`test/regression/`）に3つのファイル（計51テスト、589行）が存在していましたが、`scripts/test.sh` のデフォルト実行およびCI（`.github/workflows/ci.yaml`）のどちらでも実行されていませんでした。

この修正により、過去に修正したバグ（evalインジェクション、PRマージタイムアウト等）の回帰を検出できるようになります。