### PR TITLE
refactor: remove unused _expand_hook_template function

### DIFF
--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -94,25 +94,6 @@ run_hook() {
     log_info "Hook completed for event: $event"
 }
 
-# テンプレート変数を展開（非推奨）
-# 
-# @deprecated このテンプレート展開機能は非推奨です。
-# セキュリティ上の理由により、環境変数（PI_ISSUE_NUMBER等）を使用してください。
-# 詳細: docs/hooks.md のマイグレーションガイドを参照
-_expand_hook_template() {
-    local hook="$1"
-    
-    # 非推奨警告（テンプレート変数が含まれる場合のみ）
-    if [[ "$hook" =~ \{\{[a-z_]+\}\} ]]; then
-        log_warn "Template variables ({{...}}) are deprecated for security reasons."
-        log_warn "Please use environment variables instead: \$PI_ISSUE_NUMBER, \$PI_ISSUE_TITLE, etc."
-        log_warn "See docs/hooks.md for migration guide."
-    fi
-    
-    # テンプレート展開せず、そのまま返す（環境変数を使用するため）
-    echo "$hook"
-}
-
 # hookを実行（ファイルまたはインラインコマンド）
 _execute_hook() {
     local hook="$1"

--- a/test/lib/hooks.bats
+++ b/test/lib/hooks.bats
@@ -107,46 +107,6 @@ EOF
 }
 
 # ====================
-# _expand_hook_template テスト（非推奨）
-# ====================
-
-@test "_expand_hook_template shows deprecation warning for template variables" {
-    source "$PROJECT_ROOT/lib/hooks.sh"
-    override_get_config
-    mock_notify
-    
-    # Enable WARN level logging to capture the warning
-    export LOG_LEVEL="WARN"
-    
-    result="$(_expand_hook_template 'Issue #{{issue_number}} completed' 2>&1)"
-    [[ "$result" == *"deprecated"* ]]
-    [[ "$result" == *"environment variables"* ]]
-}
-
-@test "_expand_hook_template returns hook unchanged (no template expansion)" {
-    source "$PROJECT_ROOT/lib/hooks.sh"
-    override_get_config
-    mock_notify
-    
-    # Suppress warnings for this test
-    export LOG_LEVEL="ERROR"
-    
-    result="$(_expand_hook_template 'Issue #{{issue_number}} completed')"
-    [ "$result" = 'Issue #{{issue_number}} completed' ]
-}
-
-@test "_expand_hook_template does not warn when no template variables" {
-    source "$PROJECT_ROOT/lib/hooks.sh"
-    override_get_config
-    mock_notify
-    
-    export LOG_LEVEL="WARN"
-    
-    result="$(_expand_hook_template 'echo "No templates here"' 2>&1)"
-    [[ "$result" != *"deprecated"* ]]
-}
-
-# ====================
 # run_hook テスト（デフォルト動作）
 # ====================
 


### PR DESCRIPTION
## Summary
Closes #1043

## Changes
- Removed `_expand_hook_template()` function from `lib/hooks.sh` (19 lines)
- Removed related tests from `test/lib/hooks.bats` (40 lines)
- Total: 59 lines of dead code removed

## Context
The `_expand_hook_template()` function was marked as @deprecated but was never actually used in the codebase:
- No production code calls this function
- Template variable expansion has been migrated to environment variables (`PI_ISSUE_NUMBER`, `PI_ISSUE_TITLE`, etc.)
- The function was a passthrough that didn't perform any template expansion

## Testing
- ✅ All 23 tests in `test/lib/hooks.bats` pass
- ✅ `shellcheck -x lib/hooks.sh` passes with zero warnings
- ✅ No references to `_expand_hook_template` remain in the codebase