### PR TITLE
docs: add missing commands to README.md (pi-test, pi-verify-config-docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-restart-watcher` | Watcher再起動 |
 | `pi-mux-all` | 全セッション表示（タイル表示） |
 | `pi-generate-config` | プロジェクト解析・設定生成 |
+| `pi-test` | テスト一括実行 |
+| `pi-verify-config-docs` | 設定ドキュメントの整合性検証 |
 
 | オプション | 説明 |
 |-----------|------|


### PR DESCRIPTION
## Summary
Closes #1042

## Changes
- Added `pi-test` command to README.md command table with description "テスト一括実行"
- Added `pi-verify-config-docs` command to README.md command table with description "設定ドキュメントの整合性検証"

## Testing
- Verified that both commands are now present in README.md
- Verified that all commands from install.sh are documented in README.md
- This is a documentation-only change with no code modifications