### PR TITLE
docs: scripts/sweep.sh がドキュメント・install.sh に未登録

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-attach` | セッションアタッチ |
 | `pi-status` | 状態確認 |
 | `pi-stop` | セッション停止 |
+| `pi-sweep` | 全セッションのマーカーチェック・cleanup |
 | `pi-cleanup` | クリーンアップ |
 | `pi-force-complete` | セッション強制完了 |
 | `pi-improve` | 継続的改善 |

--- a/SKILL.md
+++ b/SKILL.md
@@ -52,6 +52,10 @@ scripts/dashboard.sh --watch             # 自動更新（5秒ごと）
 scripts/attach.sh <session>              # セッションにアタッチ
 scripts/status.sh <session>              # 状態確認
 scripts/stop.sh <session>                # セッション停止
+scripts/sweep.sh                         # 全セッションのマーカーチェック・cleanup
+scripts/sweep.sh --dry-run               # 対象セッション表示のみ
+scripts/sweep.sh --force                 # PRマージ確認をスキップ
+scripts/sweep.sh --check-errors          # ERRORマーカーもチェック
 scripts/cleanup.sh <session>             # 手動クリーンアップ
 scripts/force-complete.sh <session>      # セッション強制完了
 scripts/force-complete.sh 42 --error     # エラーとして完了

--- a/install.sh
+++ b/install.sh
@@ -139,6 +139,7 @@ pi-list:scripts/list.sh
 pi-attach:scripts/attach.sh
 pi-status:scripts/status.sh
 pi-stop:scripts/stop.sh
+pi-sweep:scripts/sweep.sh
 pi-cleanup:scripts/cleanup.sh
 pi-force-complete:scripts/force-complete.sh
 pi-improve:scripts/improve.sh


### PR DESCRIPTION
## Summary
Closes #1041

## Changes
- `install.sh` に `pi-sweep:scripts/sweep.sh` マッピングを追加
- `README.md` のコマンド一覧に `pi-sweep` を追加（説明: 全セッションのマーカーチェック・cleanup）
- `SKILL.md` のクイックリファレンスに sweep の使用例を追加

## Testing
- `install.sh` の構文チェック完了
- `scripts/sweep.sh` が存在し、実行可能であることを確認
- 既存のテストコードは影響なし（ドキュメント修正のみ）