### PR TITLE
fix: install.sh/uninstall.sh に pi-sweep コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-restart-watcher` | Watcher再起動 |
 | `pi-mux-all` | 全セッション表示（タイル表示） |
 | `pi-generate-config` | プロジェクト解析・設定生成 |
+| `pi-sweep` | 全セッションのマーカーチェック・cleanup |
 | `pi-test` | テスト一括実行 |
 | `pi-verify-config-docs` | 設定ドキュメントの整合性検証 |
 

--- a/install.sh
+++ b/install.sh
@@ -154,6 +154,7 @@ pi-next:scripts/next.sh
 pi-restart-watcher:scripts/restart-watcher.sh
 pi-mux-all:scripts/mux-all.sh
 pi-generate-config:scripts/generate-config.sh
+pi-sweep:scripts/sweep.sh
 pi-test:scripts/test.sh
 pi-verify-config-docs:scripts/verify-config-docs.sh
 "

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -28,6 +28,7 @@ pi-init
 pi-nudge
 pi-context
 pi-generate-config
+pi-sweep
 pi-verify-config-docs
 "
 


### PR DESCRIPTION
## Summary
Closes #1051

## Changes
- install.sh に `pi-sweep:scripts/sweep.sh` を追加
- uninstall.sh に `pi-sweep` を追加
- README.md のグローバルコマンド一覧に `pi-sweep` を追加

## Testing
- install.sh の動作確認: ✅ pi-sweep コマンドが正しく作成される
- uninstall.sh の動作確認: ✅ pi-sweep コマンドが正しく削除される
- ShellCheck: ✅ エラーなし
- scripts/sweep.sh: ✅ 正常に動作