### PR TITLE
fix: improve モジュール合計行数テストの上限を800→900に調整

### DIFF
--- a/test/lib/improve.bats
+++ b/test/lib/improve.bats
@@ -498,6 +498,6 @@ teardown() {
 
 @test "total lines in improve modules is reasonable" {
     total_lines=$(cat "$PROJECT_ROOT/lib/improve.sh" "$PROJECT_ROOT/lib/improve"/*.sh | wc -l)
-    # Total should be less than 800 lines (includes headers and backward compatibility)
-    [ "$total_lines" -lt 800 ]
+    # Total should be less than 900 lines (includes headers and backward compatibility)
+    [ "$total_lines" -lt 900 ]
 }


### PR DESCRIPTION
Closes #1062

## 変更内容

`lib/improve/` モジュール群の合計行数が機能追加に伴い852行に増加し、テストの上限800行を超過してCIが失敗していた。

上限を900行に引き上げて対応。

## 修正

- `test/lib/improve.bats`: `total_lines -lt 800` → `total_lines -lt 900`