### PR TITLE
fix: remove duplicate pi-sweep entries in install.sh and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ cd ~/.pi/agent/skills/pi-issue-runner
 | `pi-restart-watcher` | Watcher再起動 |
 | `pi-mux-all` | 全セッション表示（タイル表示） |
 | `pi-generate-config` | プロジェクト解析・設定生成 |
-| `pi-sweep` | 全セッションのマーカーチェック・cleanup |
 | `pi-test` | テスト一括実行 |
 | `pi-verify-config-docs` | 設定ドキュメントの整合性検証 |
 

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,6 @@ pi-next:scripts/next.sh
 pi-restart-watcher:scripts/restart-watcher.sh
 pi-mux-all:scripts/mux-all.sh
 pi-generate-config:scripts/generate-config.sh
-pi-sweep:scripts/sweep.sh
 pi-test:scripts/test.sh
 pi-verify-config-docs:scripts/verify-config-docs.sh
 "


### PR DESCRIPTION
## Summary
Closes #1064

## Changes
- Removed duplicate `pi-sweep:scripts/sweep.sh` entry from install.sh COMMANDS array
- Removed duplicate `pi-sweep` row from README.md command table

## Verification
```bash
# Confirmed exactly 1 occurrence in each file
grep -c "pi-sweep" install.sh  # Returns: 1
grep -c "pi-sweep" README.md   # Returns: 1
```

## Testing
- ✅ ShellCheck passed with no warnings
- ✅ Bash syntax validation passed