### PR TITLE
fix: align CI retry file path with lib/ci-retry.sh

### DIFF
--- a/agents/merge.md
+++ b/agents/merge.md
@@ -101,7 +101,7 @@ if gh pr checks "$PR_NUMBER" 2>/dev/null | grep -q .; then
     cd "{{worktree_path}}"
     
     # リトライ回数を追跡（ファイルベース）
-    RETRY_FILE="/tmp/pi-runner-ci-retry-{{issue_number}}"
+    RETRY_FILE="{{worktree_path}}/../.status/ci-retry-{{issue_number}}"
     RETRY_COUNT=$(cat "$RETRY_FILE" 2>/dev/null || echo "0")
     MAX_RETRIES=3
     


### PR DESCRIPTION
## Summary
Closes #1065

## Problem
`agents/merge.md` was using `/tmp/pi-runner-ci-retry-{{issue_number}}` for CI retry state tracking, while `lib/ci-retry.sh` uses `.worktrees/.status/ci-retry-<issue>`. This caused:
- Retry state not shared between systems
- State lost on system reboot
- Files not cleaned up by `sweep.sh` and `cleanup.sh`

## Changes
- Updated `agents/merge.md` line 104 to use `{{worktree_path}}/../.status/ci-retry-{{issue_number}}`
- This aligns with `lib/ci-retry.sh`'s `get_retry_state_file()` function

## Benefits
- ✅ Consistent retry state across the system
- ✅ Survives system reboots
- ✅ Properly cleaned up by `sweep.sh` and `cleanup.sh`

## Testing
- All CI retry tests pass (18/18)
- Template tests pass (24/24)
- Path structure verified to align with `lib/ci-retry.sh`