### PR TITLE
fix: escape regex metacharacters in marker matching

### DIFF
--- a/lib/marker.sh
+++ b/lib/marker.sh
@@ -34,8 +34,12 @@ count_markers_outside_codeblock() {
             continue
         fi
         
-        # マーカー行の検出（前後の空白を含む）
-        if [[ "$line" =~ ^[[:space:]]*${marker}[[:space:]]*$ ]]; then
+        # マーカー行の検出（前後の空白を除去してから完全一致を確認）
+        # 正規表現ではなくglobパターンマッチを使用（正規表現メタ文字のエスケープ不要）
+        local trimmed_line
+        trimmed_line="${line#"${line%%[![:space:]]*}"}"  # 先頭の空白を除去
+        trimmed_line="${trimmed_line%"${trimmed_line##*[![:space:]]}"}"  # 末尾の空白を除去
+        if [[ "$trimmed_line" == "$marker" ]]; then
             # コードブロック外の場合のみカウント
             if [[ "$in_codeblock" == "false" ]]; then
                 count=$((count + 1))

--- a/test/lib/marker.bats
+++ b/test/lib/marker.bats
@@ -162,3 +162,61 @@ console.log(x);
     result=$(count_markers_outside_codeblock "$output" "###TASK_COMPLETE_42###")
     [ "$result" -eq 0 ]
 }
+
+# 回帰テスト: 正規表現メタ文字を含むマーカーの安全な処理
+@test "count_markers_outside_codeblock handles marker with regex metacharacters (dots)" {
+    local output="...MARKER..."
+    local result
+    result=$(count_markers_outside_codeblock "$output" "...MARKER...")
+    [ "$result" -eq 1 ]
+}
+
+@test "count_markers_outside_codeblock handles marker with regex metacharacters (asterisks)" {
+    local output="***MARKER***"
+    local result
+    result=$(count_markers_outside_codeblock "$output" "***MARKER***")
+    [ "$result" -eq 1 ]
+}
+
+@test "count_markers_outside_codeblock handles marker with regex metacharacters (plus)" {
+    local output="+++MARKER+++"
+    local result
+    result=$(count_markers_outside_codeblock "$output" "+++MARKER+++")
+    [ "$result" -eq 1 ]
+}
+
+@test "count_markers_outside_codeblock handles marker with regex metacharacters (parentheses)" {
+    local output="(MARKER)"
+    local result
+    result=$(count_markers_outside_codeblock "$output" "(MARKER)")
+    [ "$result" -eq 1 ]
+}
+
+@test "count_markers_outside_codeblock handles marker with regex metacharacters (brackets)" {
+    local output="[MARKER]"
+    local result
+    result=$(count_markers_outside_codeblock "$output" "[MARKER]")
+    [ "$result" -eq 1 ]
+}
+
+@test "count_markers_outside_codeblock handles marker with regex metacharacters (question mark)" {
+    local output="MARKER?"
+    local result
+    result=$(count_markers_outside_codeblock "$output" "MARKER?")
+    [ "$result" -eq 1 ]
+}
+
+@test "count_markers_outside_codeblock does not match similar marker with dots" {
+    local output="...MARKER..."
+    local result
+    # Should NOT match "XXXMARKERXXX" (different number of characters)
+    result=$(count_markers_outside_codeblock "$output" "XXXMARKERXXX")
+    [ "$result" -eq 0 ]
+}
+
+@test "count_markers_outside_codeblock handles marker with mixed metacharacters" {
+    local output="  [**MARKER**(42)]  "
+    local result
+    result=$(count_markers_outside_codeblock "$output" "[**MARKER**(42)]")
+    [ "$result" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
Closes #1076

## Problem
The `count_markers_outside_codeblock()` function in `lib/marker.sh` used the `=~` regex operator with an unescaped `$marker` variable. This created a potential security issue where markers containing regex metacharacters (like `.`, `*`, `+`, `(`, `)`, `[`, `]`) could cause unintended pattern matching.

While the current marker format `###TASK_COMPLETE_<number>###` is safe, the `--marker` option in `watch-session.sh` allows custom markers that could contain special characters.

## Solution
Replaced regex pattern matching with glob pattern matching:
- Changed from `=~` to `==` for exact string comparison
- Trim leading/trailing whitespace using parameter expansion
- No regex metacharacter escaping needed

## Changes
- **lib/marker.sh**: Replace regex matching with glob pattern matching
- **test/lib/marker.bats**: Add 8 regression tests for markers with regex metacharacters

## Testing
- ✅ All 1640 existing tests pass
- ✅ 8 new regression tests cover various special characters (dots, asterisks, plus, parentheses, brackets, question mark, mixed)
- ✅ Integration tests with `watch-session.sh` pass
- ✅ ShellCheck passes with no warnings

## Security Impact
- Prevents unintended regex matches with custom markers
- Safe handling of user-provided marker strings via `--marker` option
- Defensive programming for future-proofing