### PR TITLE
fix: /tmp ハードコードパスを TMPDIR 環境変数対応にする

### DIFF
--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -36,7 +36,7 @@ daemonize() {
     # nohup + サブシェル + 即時バックグラウンド実行 + disown の組み合わせ
     # これにより、親プロセスが終了しても子プロセスは生き続ける
     local pid_file
-    pid_file="$(mktemp /tmp/daemon_pid.XXXXXX)"
+    pid_file="$(mktemp "${TMPDIR:-/tmp}/daemon_pid.XXXXXX")"
     # RETURN trapでPIDファイルを確実にクリーンアップ（異常終了時も実行される）
     trap 'rm -f "$pid_file" 2>/dev/null' RETURN
     

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -292,7 +292,7 @@ execute_single_cleanup() {
         }
         
         # Watcher ログファイルも削除 (Issue #1068)
-        local watcher_log="/tmp/pi-watcher-${session_name}.log"
+        local watcher_log="${TMPDIR:-/tmp}/pi-watcher-${session_name}.log"
         if [[ -f "$watcher_log" ]]; then
             log_debug "Removing watcher log file: $watcher_log"
             rm -f "$watcher_log" 2>/dev/null || {

--- a/scripts/restart-watcher.sh
+++ b/scripts/restart-watcher.sh
@@ -115,7 +115,7 @@ main() {
     fi
 
     # 新しいwatcherを起動
-    local watcher_log="/tmp/pi-watcher-${session_name}.log"
+    local watcher_log="${TMPDIR:-/tmp}/pi-watcher-${session_name}.log"
     local watcher_script="$SCRIPT_DIR/watch-session.sh"
     
     if [[ ! -f "$watcher_script" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -470,7 +470,7 @@ setup_completion_watcher() {
 
     if [[ "$cleanup_mode" != "none" ]]; then
         log_info "Starting completion watcher..."
-        local watcher_log="/tmp/pi-watcher-${session_name}.log"
+        local watcher_log="${TMPDIR:-/tmp}/pi-watcher-${session_name}.log"
         local watcher_script
         watcher_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/watch-session.sh"
         

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -120,7 +120,7 @@ main() {
     if [[ -n "$watcher_pid" ]]; then
         if is_watcher_running "$issue_number"; then
             echo "Status: Running (PID: $watcher_pid)"
-            local watcher_log="/tmp/pi-watcher-${session_name}.log"
+            local watcher_log="${TMPDIR:-/tmp}/pi-watcher-${session_name}.log"
             echo "Log: $watcher_log"
         else
             echo "Status: Not running ⚠️"


### PR DESCRIPTION
## Summary
Closes #1085

## Changes
複数のスクリプトで `/tmp` パスがハードコードされていた問題を修正しました。`${TMPDIR:-/tmp}` パターンを使用することで、macOS などの環境で `$TMPDIR` 環境変数を尊重するようになります。

### 修正ファイル
- `lib/daemon.sh`: `mktemp` のパスを TMPDIR 対応に変更
- `scripts/run.sh`: watcher ログパスを TMPDIR 対応に変更
- `scripts/cleanup.sh`: watcher ログパスを TMPDIR 対応に変更
- `scripts/restart-watcher.sh`: watcher ログパスを TMPDIR 対応に変更
- `scripts/status.sh`: watcher ログパスを TMPDIR 対応に変更

## Testing
- ✅ daemon.sh unit tests: 18/18 passed
- ✅ ShellCheck: No warnings
- ✅ Manual verification: TMPDIR is properly respected
- ✅ Backward compatibility: Defaults to /tmp when TMPDIR is unset

## Impact
- セキュリティの向上: システムのセキュリティポリシーに準拠
- 互換性の向上: macOS の `$TMPDIR` (通常 `/var/folders/...`) を尊重
- 後方互換性: `TMPDIR` が設定されていない環境では従来通り `/tmp` を使用