### PR TITLE
fix: add --verbose/-v and --quiet options to run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,6 +24,8 @@
 #   --pi-args ARGS      Alias for --agent-args (backward compatibility)
 #   --list-workflows    List available workflows
 #   --ignore-blockers   Skip dependency check and force execution
+#   -v, --verbose       Enable verbose/debug logging
+#   --quiet             Show only error messages
 #   -h, --help          Show help message
 #
 # Exit codes:
@@ -68,6 +70,8 @@ Options:
     --show-config       現在の設定を表示（デバッグ用）
     --list-agents       利用可能なエージェントプリセット一覧を表示
     --show-agent-config エージェント設定を表示（デバッグ用）
+    -v, --verbose       詳細ログを表示
+    --quiet             エラーのみ表示
     -h, --help          このヘルプを表示
 
 Examples:
@@ -195,6 +199,14 @@ parse_run_arguments() {
                 ;;
             --ignore-blockers)
                 ignore_blockers=true
+                shift
+                ;;
+            -v|--verbose)
+                enable_verbose
+                shift
+                ;;
+            --quiet)
+                enable_quiet
                 shift
                 ;;
             --agent-args|--pi-args)


### PR DESCRIPTION
## Summary
Closes #1086

## Changes
- Added `-v` / `--verbose` option to enable debug logging
- Added `--quiet` option to show only error messages
- Updated usage documentation in both header comments and help function
- Aligned with other scripts (sweep.sh, list.sh, next.sh, run-batch.sh, dashboard.sh)

## Implementation Details
- Added option parsing in `parse_run_arguments()` function
- Uses existing `enable_verbose()` and `enable_quiet()` from `lib/log.sh`
- Updated documentation in both English (header) and Japanese (usage function)

## Testing
- ✅ All 30 run.bats tests pass
- ✅ Manual testing confirms both options work correctly
- ✅ ShellCheck passed with no warnings
- ✅ No regression in existing functionality
- ✅ Help text displays new options correctly

## Verification
```bash
./scripts/run.sh --help | grep -E '(verbose|quiet)'
# Output:
#     -v, --verbose       詳細ログを表示
#     --quiet             エラーのみ表示
```