### PR TITLE
refactor: improve/execution.sh - fix SCRIPT_DIR dependency and document global array

### DIFF
--- a/lib/improve/execution.sh
+++ b/lib/improve/execution.sh
@@ -18,10 +18,22 @@ if [[ -n "${_EXECUTION_SH_SOURCED:-}" ]]; then
 fi
 _EXECUTION_SH_SOURCED="true"
 
-# Define script directory with fallback (allows standalone sourcing)
-_IMPROVE_EXEC_SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts}"
+# Define script directory explicitly from this file's location
+# Note: Previously used ${SCRIPT_DIR:-...} fallback, but this could use
+# unexpected values if SCRIPT_DIR was set elsewhere. Now always compute
+# from this file's actual location for safety.
+_IMPROVE_EXEC_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts"
 
 # Global: Track active sessions for cleanup on exit
+# Note: This array maintains state across function calls within a single
+# improve.sh execution. Each issue number is added when its session starts
+# (execute_improve_issues_in_parallel) and removed when it completes
+# (_wait_for_available_slot). The array is also used for cleanup on
+# interruption (cleanup_improve_on_exit).
+#
+# TODO: Consider refactoring to file-based tracking using status files
+# (e.g., querying .worktrees/.status/*.json instead of maintaining in-memory
+# state) for better testability and support for concurrent improve processes.
 declare -a ACTIVE_ISSUE_NUMBERS=()
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Closes #1087

## Changes
- **Fixed `_IMPROVE_EXEC_SCRIPT_DIR`**: Removed dependency on external `SCRIPT_DIR` variable
  - Previously used `${SCRIPT_DIR:-...}` fallback which could use unexpected values
  - Now always computes from `BASH_SOURCE` location for safety
  
- **Documented `ACTIVE_ISSUE_NUMBERS` global array**:
  - Added comprehensive comments explaining lifecycle and usage
  - Documented when items are added (execute) and removed (wait/cleanup)
  - Added TODO for future file-based tracking refactoring

- **Updated Tests**:
  - All tests now mock scripts at actual computed location
  - Tests properly backup and restore original scripts
  - Removed dependency on external `SCRIPT_DIR` variable

## Testing
- ✅ All 42 execution.bats tests pass
- ✅ All 168 improve module tests pass  
- ✅ ShellCheck passes with no warnings
- ✅ Tests properly handle script mocking with backup/restore

## Impact
- Improves safety by eliminating potential for unexpected `SCRIPT_DIR` values
- Better documentation helps future maintenance
- No breaking changes - backward compatible