### PR TITLE
docs: AGENTS.md の回帰テストファイル一覧が実際のファイルと不一致

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,10 +192,14 @@ pi-issue-runner/
 │   │   ├── wait-for-sessions.bats
 │   │   └── watch-session.bats
 │   ├── regression/    # 回帰テスト
+│   │   ├── applescript-injection.bats
+│   │   ├── cleanup-race-condition.bats
 │   │   ├── critical-fixes.bats
 │   │   ├── eval-injection.bats
 │   │   ├── issue-1066-spaces-in-filenames.bats
-│   │   └── pr-merge-timeout.bats
+│   │   ├── multiline-json-grep.bats
+│   │   ├── pr-merge-timeout.bats
+│   │   └── workflow-name-template.bats
 │   ├── fixtures/      # テスト用フィクスチャ
 │   │   └── sample-config.yaml
 │   └── test_helper.bash  # Bats共通ヘルパー


### PR DESCRIPTION
## Summary
Closes #1096

## Changes
- AGENTS.md の `test/regression/` セクションに不足していた4ファイルを追加：
  - `applescript-injection.bats`
  - `cleanup-race-condition.bats`
  - `multiline-json-grep.bats`
  - `workflow-name-template.bats`

## Testing
- 実際の `test/regression/` ディレクトリのファイル一覧と照合し、完全一致を確認
- ディレクトリ構造のドキュメントとして正確性を確保