### PR TITLE
refactor: sweep.sh の source パスを tmux.sh に統一（一貫性改善）

### DIFF
--- a/scripts/sweep.sh
+++ b/scripts/sweep.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/config.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
-source "$SCRIPT_DIR/../lib/multiplexer.sh"
+source "$SCRIPT_DIR/../lib/tmux.sh"
 source "$SCRIPT_DIR/../lib/marker.sh"
 source "$SCRIPT_DIR/../lib/status.sh"
 
@@ -109,7 +109,7 @@ check_session_markers() {
     
     # セッション出力を取得（最後の100行）
     local output
-    if ! output=$(mux_get_session_output "$session_name" 100 2>/dev/null); then
+    if ! output=$(get_session_output "$session_name" 100 2>/dev/null); then
         log_warn "Failed to get output for session: $session_name"
         echo ""
         return
@@ -189,7 +189,7 @@ main() {
     
     # セッション一覧を取得
     local sessions
-    sessions="$(mux_list_sessions)"
+    sessions="$(list_sessions)"
     
     if [[ -z "$sessions" ]]; then
         log_info "No active sessions found."
@@ -211,7 +211,7 @@ main() {
         
         # Issue番号を抽出
         local issue_num
-        issue_num=$(mux_extract_issue_number "$session" 2>/dev/null) || {
+        issue_num=$(extract_issue_number "$session" 2>/dev/null) || {
             log_debug "Could not extract issue number from: $session (skipping)"
             continue
         }


### PR DESCRIPTION
## Summary
Closes #1097

## Changes
- `scripts/sweep.sh` の source パスを `lib/multiplexer.sh` から `lib/tmux.sh` に変更
- `mux_*` プレフィックス付き関数を公式API関数に変更:
  - `mux_get_session_output` → `get_session_output`
  - `mux_list_sessions` → `list_sessions`
  - `mux_extract_issue_number` → `extract_issue_number`

## Rationale
全てのスクリプトが `lib/tmux.sh`（公式API・後方互換ラッパー）を使用するパターンに統一します。
`sweep.sh` のみが `lib/multiplexer.sh` を直接 source していた不整合を解消します。

## Testing
- ✅ ShellCheck: 全58ファイルパス
- ✅ sweep.bats: 10/10テストパス
- ✅ 関連テスト（tmux.bats, multiplexer.bats）: 全テストパス
- ✅ 動作に変更なし（wrapper関数は内部で同じ `mux_*` 関数を呼び出す）