### PR TITLE
docs: AGENTS.mdに既知の制約を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,7 @@ PRをマージする前に警告が解消されている必要があります。
 
 <!-- エージェントが重要な知見を発見した際、ここに1行サマリーとリンクを追加する -->
 <!-- 例: - playwright-cli 0.0.63+: デフォルトセッション使用必須 → [詳細](docs/decisions/001-playwright-session.md) -->
+- Bats並列テスト: 16ジョブでハング、デフォルト2ジョブ推奨 → [詳細](docs/decisions/001-test-parallel-jobs-limit.md)
 
 ## 注意事項
 


### PR DESCRIPTION
## Summary
Follow-up to #1114 (Issue #1110)

## Changes
- AGENTS.mdの「既知の制約」セクションにBats並列テストの制限事項を追加
- docs/decisions/001-test-parallel-jobs-limit.md へのリンクを追加

## Context
PR #1114で修正したテスト並列実行の制限について、他のエージェントが参照できるようAGENTS.mdに記録。

Refs #1110