### PR TITLE
fix: add improve-related hooks to JSON Schema

### DIFF
--- a/schemas/pi-runner.schema.json
+++ b/schemas/pi-runner.schema.json
@@ -207,6 +207,26 @@
         "on_cleanup": {
           "type": "string",
           "description": "Script/command to run on cleanup"
+        },
+        "on_improve_start": {
+          "type": "string",
+          "description": "Script/command to run when improve.sh starts"
+        },
+        "on_improve_end": {
+          "type": "string",
+          "description": "Script/command to run when improve.sh ends"
+        },
+        "on_iteration_start": {
+          "type": "string",
+          "description": "Script/command to run when each iteration starts"
+        },
+        "on_iteration_end": {
+          "type": "string",
+          "description": "Script/command to run when each iteration completes"
+        },
+        "on_review_complete": {
+          "type": "string",
+          "description": "Script/command to run when review completes before creating issues"
         }
       }
     },


### PR DESCRIPTION
## Summary
Closes #1116

## Changes
- Added 5 missing improve-related hooks to `schemas/pi-runner.schema.json`:
  - `on_improve_start`: Script/command to run when improve.sh starts
  - `on_improve_end`: Script/command to run when improve.sh ends
  - `on_iteration_start`: Script/command to run when each iteration starts
  - `on_iteration_end`: Script/command to run when each iteration completes
  - `on_review_complete`: Script/command to run when review completes before creating issues

These hooks were already defined in `lib/config.sh` and documented in `docs/configuration.md`, but were missing from the JSON Schema, causing validation errors for users trying to use these hooks.

## Testing
- ✅ JSON syntax validation passed
- ✅ Config tests: 63/63 passed
- ✅ Hooks tests: 26/26 passed
- ✅ verify-config-docs tests: 12/12 passed
- ✅ ShellCheck: No warnings
- ✅ Schema now defines all 9 hooks matching `lib/config.sh` and documentation