### PR TITLE
refactor: add explicit source for lib/status.sh in watch-session.sh and list.sh

### DIFF
--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/config.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/status.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
 source "$SCRIPT_DIR/../lib/worktree.sh"
 source "$SCRIPT_DIR/../lib/notify.sh"

--- a/scripts/watch-session.sh
+++ b/scripts/watch-session.sh
@@ -33,6 +33,7 @@ set -euo pipefail
 WATCHER_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$WATCHER_SCRIPT_DIR/../lib/config.sh"
 source "$WATCHER_SCRIPT_DIR/../lib/log.sh"
+source "$WATCHER_SCRIPT_DIR/../lib/status.sh"
 source "$WATCHER_SCRIPT_DIR/../lib/tmux.sh"
 source "$WATCHER_SCRIPT_DIR/../lib/notify.sh"
 source "$WATCHER_SCRIPT_DIR/../lib/worktree.sh"


### PR DESCRIPTION
## Summary
Closes #1117

## Changes
- Add explicit `source` statement for `lib/status.sh` in `scripts/watch-session.sh`
- Add explicit `source` statement for `lib/status.sh` in `scripts/list.sh`
- Removes implicit dependency on `cleanup-orphans.sh` → `status.sh` (for watch-session.sh)
- Removes implicit dependency on `notify.sh` → `status.sh` (for list.sh)

## Impact
- Improves code clarity and maintainability
- Makes dependencies explicit
- No functional changes
- All tests pass (1679/1680, 1 unrelated failure)

## Testing
- ✅ ShellCheck: 0 warnings
- ✅ watch-session.sh tests: 45/45 passed
- ✅ list.sh tests: 5/5 passed
- ✅ Syntax validation passed