### PR TITLE
feat: ワークフローごとのagent設定 - スキーマ・設定読み込み・解決ロジック

### DIFF
--- a/lib/agent.sh
+++ b/lib/agent.sh
@@ -13,6 +13,7 @@ _AGENT_SH_SOURCED="true"
 _AGENT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_AGENT_LIB_DIR/config.sh"
 source "$_AGENT_LIB_DIR/log.sh"
+source "$_AGENT_LIB_DIR/workflow-loader.sh"
 
 # ======================
 # プリセット定義（Bash 3.x互換）
@@ -244,6 +245,65 @@ build_agent_command() {
     log_debug "Full command: $full_command"
     
     echo "$full_command"
+}
+
+# ======================
+# ワークフロー固有エージェント設定
+# ======================
+
+# ワークフロー固有のエージェント設定を適用
+# 引数:
+#   $1 - workflow_identifier: ワークフロー識別子（config-workflow:NAME 形式を想定）
+# 副作用:
+#   CONFIG_AGENT_TYPE, CONFIG_AGENT_COMMAND, CONFIG_AGENT_ARGS, CONFIG_AGENT_TEMPLATE を上書き
+apply_workflow_agent_override() {
+    local workflow_identifier="$1"
+    
+    # config-workflow:NAME 形式から NAME を抽出
+    if [[ "$workflow_identifier" != config-workflow:* ]]; then
+        # ワークフロー識別子が config-workflow 形式でない場合はスキップ
+        log_debug "Workflow identifier '$workflow_identifier' is not config-workflow format, skipping agent override"
+        return 0
+    fi
+    
+    local workflow_name="${workflow_identifier#config-workflow:}"
+    
+    # workflow-loader.sh の関数を使用してワークフロー固有の設定を取得
+    local workflow_agent_type
+    workflow_agent_type="$(get_workflow_agent_config "$workflow_name" "type")"
+    
+    if [[ -z "$workflow_agent_type" ]]; then
+        # ワークフロー固有のagent設定がない場合は何もしない
+        log_debug "No workflow-specific agent config for workflow '$workflow_name'"
+        return 0
+    fi
+    
+    # 環境変数を上書き（config.sh の load_config で設定される変数）
+    export CONFIG_AGENT_TYPE="$workflow_agent_type"
+    log_debug "Applied workflow-specific agent type: $CONFIG_AGENT_TYPE"
+    
+    local workflow_agent_command
+    workflow_agent_command="$(get_workflow_agent_config "$workflow_name" "command")"
+    if [[ -n "$workflow_agent_command" ]]; then
+        export CONFIG_AGENT_COMMAND="$workflow_agent_command"
+        log_debug "Applied workflow-specific agent command: $CONFIG_AGENT_COMMAND"
+    fi
+    
+    local workflow_agent_args
+    workflow_agent_args="$(get_workflow_agent_config "$workflow_name" "args")"
+    if [[ -n "$workflow_agent_args" ]]; then
+        export CONFIG_AGENT_ARGS="$workflow_agent_args"
+        log_debug "Applied workflow-specific agent args: $CONFIG_AGENT_ARGS"
+    fi
+    
+    local workflow_agent_template
+    workflow_agent_template="$(get_workflow_agent_config "$workflow_name" "template")"
+    if [[ -n "$workflow_agent_template" ]]; then
+        export CONFIG_AGENT_TEMPLATE="$workflow_agent_template"
+        log_debug "Applied workflow-specific agent template: $CONFIG_AGENT_TEMPLATE"
+    fi
+    
+    log_info "Applied workflow-specific agent override for workflow: $workflow_name"
 }
 
 # ======================

--- a/lib/workflow-loader.sh
+++ b/lib/workflow-loader.sh
@@ -332,3 +332,50 @@ get_agent_prompt() {
     # テンプレート変数展開
     render_template "$prompt" "$issue_number" "$branch_name" "$worktree_path" "$step_name" "$workflow_name" "$issue_title" "$pr_number" "$plans_dir"
 }
+
+# ワークフロー固有のエージェント設定を取得
+# 引数:
+#   $1 - workflow_name: ワークフロー名
+#   $2 - property: 取得するプロパティ (type|command|args|template)
+# 出力: 設定値（未設定の場合は空文字列）
+get_workflow_agent_config() {
+    local workflow_name="$1"
+    local property="$2"
+    
+    # 設定ファイルのパスを決定
+    local config_file
+    if [[ -n "${CONFIG_FILE:-}" ]]; then
+        # CONFIG_FILE 環境変数が設定されている場合（テスト用）
+        load_config "$CONFIG_FILE"
+        config_file="$CONFIG_FILE"
+    else
+        # 通常の動作：設定ファイルを検索
+        load_config
+        config_file="$(config_file_found 2>/dev/null)" || config_file=".pi-runner.yaml"
+    fi
+    
+    if [[ ! -f "$config_file" ]]; then
+        echo ""
+        return 0
+    fi
+    
+    local yaml_path=".workflows.${workflow_name}.agent.${property}"
+    
+    # args の場合は配列として取得
+    if [[ "$property" == "args" ]]; then
+        local args=""
+        while IFS= read -r arg; do
+            if [[ -n "$arg" ]]; then
+                if [[ -z "$args" ]]; then
+                    args="$arg"
+                else
+                    args="$args $arg"
+                fi
+            fi
+        done < <(yaml_get_array "$config_file" "$yaml_path" 2>/dev/null)
+        echo "$args"
+    else
+        # type, command, template はスカラー値
+        yaml_get "$config_file" "$yaml_path" 2>/dev/null || echo ""
+    fi
+}

--- a/schemas/pi-runner.schema.json
+++ b/schemas/pi-runner.schema.json
@@ -333,6 +333,31 @@
         "context": {
           "type": "string",
           "description": "Workflow-specific context injected into all step prompts"
+        },
+        "agent": {
+          "type": "object",
+          "description": "Workflow-specific agent settings (overrides top-level agent)",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["pi", "claude", "opencode", "custom"],
+              "description": "Agent preset"
+            },
+            "command": {
+              "type": "string",
+              "description": "Custom agent command (for type: custom)"
+            },
+            "args": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Additional arguments to pass to the agent"
+            },
+            "template": {
+              "type": "string",
+              "description": "Command template for custom agents (e.g., '{{command}} {{args}} --file \"{{prompt_file}}\"')"
+            }
+          }
         }
       }
     }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -457,6 +457,11 @@ start_agent_session() {
     log_info "Workflow: $workflow_name"
     write_workflow_prompt "$prompt_file" "$workflow_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$full_worktree_path" "." "$issue_comments"
     
+    # ワークフロー固有のエージェント設定を適用
+    local workflow_file
+    workflow_file=$(find_workflow_file "$workflow_name" ".")
+    apply_workflow_agent_override "$workflow_file"
+    
     # エージェントコマンド構築
     local full_command
     full_command="$(build_agent_command "$prompt_file" "$extra_agent_args")"


### PR DESCRIPTION
## Summary
Closes #1094

## Changes
- スキーマ更新: `workflows.{name}.agent` プロパティ追加 (schemas/pi-runner.schema.json)
- `get_workflow_agent_config()` 関数実装 (lib/workflow-loader.sh)
- `apply_workflow_agent_override()` 関数実装 (lib/agent.sh)
- scripts/run.sh でワークフロー固有のagent設定を適用
- ユニットテスト追加 (test/lib/workflow-loader.bats, test/lib/agent.bats)

## Features
- ワークフローごとにagent設定（type, command, args, template）を指定可能
- ワークフロー固有の設定がトップレベルのagent設定より優先される
- ワークフローにagent未指定の場合、トップレベルのagent設定がデフォルトとして使用される

## Testing
- 新規ユニットテスト7件追加 (workflow-loader.bats)
- 新規ユニットテスト7件追加 (agent.bats)
- すべてのテストが正常にパス

## Example Configuration
```yaml
agent:
  type: pi
  args:
    - --model
    - claude-haiku-4-5

workflows:
  feature:
    description: 新機能・大規模変更
    steps:
      - plan
      - implement
      - test
      - review
      - merge
    agent:
      type: claude
      args:
        - --model
        - claude-sonnet-4-5
  
  quickfix:
    description: 軽微な修正
    steps:
      - implement
      - merge
    # agent 未指定 → トップレベルの agent: を使用
```