### PR TITLE
docs: fix link formatting and add public-api.md reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,7 @@ gh auth login
 - [概要](docs/overview.md) - システム全体の概要
 - [アーキテクチャ](docs/architecture.md) - システム設計
 - [仕様書](docs/SPECIFICATION.md) - 詳細仕様
+- [公開API](docs/public-api.md) - 外部から利用可能なライブラリ関数
 - [ワークフロー](docs/workflows.md) - ワークフロー定義の詳細
 - [Hook機能](docs/hooks.md) - イベントフック詳細
 - [Git Worktree管理](docs/worktree-management.md) - worktree運用

--- a/docs/README.md
+++ b/docs/README.md
@@ -233,7 +233,10 @@ GitHub Issueを入力として、独立したworktree環境でpiインスタン�
 
 ### Q: どのドキュメントから読めば良い？
 
-A: 初めての方は [SPECIFICATION.md](./SPECIFICATION.md) から、実装する方は [architecture.md](./architecture.md) から読むことをお勧めします。
+A: 役割に応じて以下から読むことをお勧めします：
+
+- 初めての方: [SPECIFICATION.md](./SPECIFICATION.md)
+- 実装する方: [architecture.md](./architecture.md)
 
 ### Q: ドキュメントが古い・間違っている
 


### PR DESCRIPTION
## Summary
Closes #1131

## Changes
- Split multi-link line in docs/README.md FAQ section into list format for better parser compatibility
- Add missing reference to docs/public-api.md in root README.md documentation section

## Testing
- Verified all linked documentation files exist
- Checked link formatting follows project conventions