### PR TITLE
fix: pass session_label as explicit argument to start_agent_session

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -438,7 +438,9 @@ setup_worktree() {
 # ============================================================================
 # Subfunction: start_agent_session
 # Purpose: Generate prompt and create agent session
-# Arguments: Multiple (see function body)
+# Arguments: $1=session_name, $2=issue_number, $3=issue_title, $4=issue_body,
+#            $5=branch_name, $6=full_worktree_path, $7=workflow_name,
+#            $8=issue_comments, $9=extra_agent_args, $10=session_label
 # Output: Shell variable assignments (eval-able)
 # ============================================================================
 start_agent_session() {
@@ -451,6 +453,7 @@ start_agent_session() {
     local workflow_name="$7"
     local issue_comments="$8"
     local extra_agent_args="$9"
+    local session_label="${10:-}"
 
     # ワークフローからプロンプトファイルを生成
     local prompt_file="$full_worktree_path/.pi-prompt.md"
@@ -614,7 +617,7 @@ main() {
     local full_worktree_path="$_WORKTREE_full_path"
     
     # Start agent session
-    start_agent_session "$session_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$full_worktree_path" "$workflow_name" "$issue_comments" "$extra_agent_args"
+    start_agent_session "$session_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$full_worktree_path" "$workflow_name" "$issue_comments" "$extra_agent_args" "$session_label"
     
     # Setup completion watcher
     setup_completion_watcher "$cleanup_mode" "$session_name" "$issue_number"

--- a/test/regression/issue-1129-session-label-arg.bats
+++ b/test/regression/issue-1129-session-label-arg.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# Regression test for Issue #1129
+# start_agent_session must receive session_label as an explicit argument,
+# not rely on implicit variable scoping from the caller.
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+@test "start_agent_session accepts session_label as 10th argument" {
+    # Verify the function signature includes session_label as ${10}
+    run grep -n 'local session_label="\${10:-}"' "$PROJECT_ROOT/scripts/run.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'local session_label="${10:-}"'* ]]
+}
+
+@test "start_agent_session call site passes session_label as argument" {
+    # Verify the call site passes session_label as the 10th argument
+    run grep -n 'start_agent_session.*\$session_label' "$PROJECT_ROOT/scripts/run.sh"
+    [ "$status" -eq 0 ]
+    # Should find the call with "$session_label" as the last argument
+    [[ "$output" == *'"$session_label"'* ]]
+}
+
+@test "start_agent_session function comment documents session_label" {
+    # Verify the function comment includes $10=session_label
+    run grep -A5 'Subfunction: start_agent_session' "$PROJECT_ROOT/scripts/run.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'$10=session_label'* ]]
+}


### PR DESCRIPTION
## Summary
Closes #1129

## Changes
- Add `session_label` as the 10th parameter to `start_agent_session()` function
- Pass `$session_label` explicitly from `main()` call site instead of relying on implicit Bash variable scoping
- Update function documentation comment with full argument list
- Add regression test (`test/regression/issue-1129-session-label-arg.bats`)

## Testing
- All existing tests pass (test 32 is a pre-existing failure unrelated to this change)
- New regression tests verify the function signature, call site, and documentation