### PR TITLE
refactor: change PI_RUNNER_ALLOW_INLINE_HOOKS default to false

### DIFF
--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -173,7 +173,7 @@ _execute_hook() {
     fi
     
     # インラインコマンドの場合: 明示的許可が必要
-    if [[ "${PI_RUNNER_ALLOW_INLINE_HOOKS:-true}" != "true" ]]; then
+    if [[ "${PI_RUNNER_ALLOW_INLINE_HOOKS:-false}" != "true" ]]; then
         log_warn "Inline hook commands are disabled."
         log_warn "To enable, set: export PI_RUNNER_ALLOW_INLINE_HOOKS=true"
         log_warn "Hook: $hook"


### PR DESCRIPTION
## Summary
Closes #1149

## Changes
- Changed `PI_RUNNER_ALLOW_INLINE_HOOKS` default from `true` to `false` in `lib/hooks.sh` `_execute_hook()` function
- Inline hook commands now require explicit opt-in via `PI_RUNNER_ALLOW_INLINE_HOOKS=true`
- Script file hooks remain unaffected and always allowed

## Security Rationale
- Defense-in-depth: environment variables like `PI_RUNNER_HOOKS_ON_*` could override hook values, so defaulting inline execution to disabled reduces attack surface
- Users who need inline hooks can explicitly enable them

## Testing
- All 26 hooks.bats tests pass
- All regression tests pass
- ShellCheck clean
- Existing tests already set `PI_RUNNER_ALLOW_INLINE_HOOKS=true` explicitly where needed
- `docs/hooks.md` already documents the default-disabled behavior