### PR TITLE
docs: add missing hooks-env-sanitization.bats to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ pi-issue-runner/
 │   │   ├── cleanup-race-condition.bats
 │   │   ├── critical-fixes.bats
 │   │   ├── eval-injection.bats
+│   │   ├── hooks-env-sanitization.bats
 │   │   ├── issue-1066-spaces-in-filenames.bats
 │   │   ├── multiline-json-grep.bats
 │   │   ├── pr-merge-timeout.bats


### PR DESCRIPTION
## Summary
Closes #1141

## Changes
- Added `hooks-env-sanitization.bats` to the regression test section in AGENTS.md
- File was missing from the documentation despite existing in `test/regression/` directory

## Testing
- Verified file exists: `test/regression/hooks-env-sanitization.bats`
- Ran validation command to confirm no missing entries for this file
- Entry added in correct alphabetical order between `eval-injection.bats` and `issue-1066-spaces-in-filenames.bats`