### PR TITLE
fix: worktree作成前にgit fetchを実行してorigin/mainを最新化する

### DIFF
--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -34,6 +34,15 @@ create_worktree() {
     # ベースディレクトリ作成
     mkdir -p "$(get_config worktree_base_dir)"
     
+    # リモートブランチの場合はfetchで最新化
+    if [[ "$base_branch" == origin/* ]]; then
+        local remote="${base_branch%%/*}"
+        log_info "Fetching latest from $remote..."
+        if ! git fetch "$remote" 2>/dev/null; then
+            log_warn "git fetch $remote failed, using cached $base_branch"
+        fi
+    fi
+    
     # worktree作成
     log_info "Creating worktree: $worktree_dir (branch: feature/$branch_name)"
     


### PR DESCRIPTION
## Summary
Closes #1153

## Changes
- `create_worktree()` で `base_branch` が `origin/*` の場合に `git fetch` を実行して最新化
- fetch失敗時はワーニングを出してキャッシュ版で続行（ネットワーク不通時の耐障害性）
- ローカルブランチの場合はfetchしない

## Testing
- `test/lib/worktree.bats` にテスト3件追加
  - origin/*の場合にfetchが実行される
  - ローカルブランチの場合にfetchが実行されない
  - fetch失敗時にワーニングを出して続行する
- 全既存テストがパスすることを確認