### PR TITLE
docs: add missing options to scripts/run.sh header comments

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,6 +24,9 @@
 #   --pi-args ARGS      Alias for --agent-args (backward compatibility)
 #   --list-workflows    List available workflows
 #   --ignore-blockers   Skip dependency check and force execution
+#   --show-config       Show current configuration (debug)
+#   --list-agents       List available agent presets
+#   --show-agent-config Show agent configuration (debug)
 #   -v, --verbose       Enable verbose/debug logging
 #   --quiet             Show only error messages
 #   -h, --help          Show help message


### PR DESCRIPTION
## Summary
Closes #1142

## Changes
- Added `--show-config`, `--list-agents`, and `--show-agent-config` options to the header comment Options section in `scripts/run.sh`
- These options were already documented in the `usage()` function and SKILL.md, but were missing from the file header comments

## Testing
- Ran verification command to confirm all three options are present in the header (lines 1-50)
- All 1726 existing tests pass