### PR TITLE
fix: merge duplicate apply_workflow_agent_override() definitions

### DIFF
--- a/test/regression/issue-1145-duplicate-agent-override.bats
+++ b/test/regression/issue-1145-duplicate-agent-override.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Regression test for Issue #1145
+# Ensures apply_workflow_agent_override() handles both config-workflow:NAME
+# and YAML file path formats (previously the YAML file path handler was
+# shadowed by a duplicate function definition)
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+    export TEST_DIR="$BATS_TEST_TMPDIR"
+
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/yaml.sh"
+    source "$PROJECT_ROOT/lib/config.sh"
+    source "$PROJECT_ROOT/lib/workflow-loader.sh"
+    source "$PROJECT_ROOT/lib/agent.sh"
+
+    reset_yaml_cache
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+@test "issue-1145: YAML file workflow agent override sets AGENT_TYPE_OVERRIDE" {
+    # Create a workflow YAML file with agent section
+    cat > "$TEST_DIR/test-workflow.yaml" << 'YAML_EOF'
+name: test-workflow
+description: Test workflow
+steps:
+  - implement
+agent:
+  type: claude
+  command: claude-code
+  args:
+    - "--model"
+    - "opus"
+  template: custom-agent.md
+YAML_EOF
+
+    # Apply override with YAML file path
+    apply_workflow_agent_override "$TEST_DIR/test-workflow.yaml"
+
+    # YAML file path format should set AGENT_*_OVERRIDE variables
+    [ "${AGENT_TYPE_OVERRIDE:-}" = "claude" ]
+    [ "${AGENT_COMMAND_OVERRIDE:-}" = "claude-code" ]
+    [ "${AGENT_ARGS_OVERRIDE:-}" = "--model opus" ]
+    [ "${AGENT_TEMPLATE_OVERRIDE:-}" = "custom-agent.md" ]
+}
+
+@test "issue-1145: config-workflow format sets CONFIG_AGENT_* variables" {
+    cat > "$TEST_DIR/.pi-runner.yaml" << 'YAML_EOF'
+workflows:
+  my-workflow:
+    steps:
+      - implement
+    agent:
+      type: opencode
+      command: my-opencode
+YAML_EOF
+
+    export CONFIG_FILE="$TEST_DIR/.pi-runner.yaml"
+    load_config "$CONFIG_FILE"
+
+    apply_workflow_agent_override "config-workflow:my-workflow"
+
+    [ "${CONFIG_AGENT_TYPE:-}" = "opencode" ]
+    [ "${CONFIG_AGENT_COMMAND:-}" = "my-opencode" ]
+}
+
+@test "issue-1145: non-file non-config-workflow identifier is skipped gracefully" {
+    apply_workflow_agent_override "builtin:default"
+
+    # No variables should be set
+    [ -z "${AGENT_TYPE_OVERRIDE:-}" ]
+    [ -z "${CONFIG_AGENT_TYPE:-}" ]
+}

--- a/test/scripts/run.bats
+++ b/test/scripts/run.bats
@@ -411,11 +411,11 @@ EOF
     local workflow_file="config-workflow:test-workflow"
     apply_workflow_agent_override "$workflow_file"
     
-    # 環境変数が設定されているか確認
-    [ -n "${AGENT_TYPE_OVERRIDE:-}" ]
-    [ "${AGENT_TYPE_OVERRIDE}" = "opencode" ]
-    [ -n "${AGENT_COMMAND_OVERRIDE:-}" ]
-    [ "${AGENT_COMMAND_OVERRIDE}" = "my-opencode" ]
+    # 環境変数が設定されているか確認（config-workflow形式はCONFIG_*変数を上書き）
+    [ -n "${CONFIG_AGENT_TYPE:-}" ]
+    [ "${CONFIG_AGENT_TYPE}" = "opencode" ]
+    [ -n "${CONFIG_AGENT_COMMAND:-}" ]
+    [ "${CONFIG_AGENT_COMMAND}" = "my-opencode" ]
 }
 
 @test "workflow-specific agent override: get_agent_type respects override" {


### PR DESCRIPTION
## Summary
Closes #1145

## Changes
- Removed the first (dead code) definition of `apply_workflow_agent_override()` at L102 which was shadowed by the second definition at L335
- Merged YAML file path handling logic into the single remaining definition
- The unified function now handles both formats:
  - `config-workflow:NAME`: sets `CONFIG_AGENT_*` variables
  - YAML file paths: sets `AGENT_*_OVERRIDE` variables  
  - Other identifiers: skipped gracefully
- Updated test assertion in `test/scripts/run.bats` to check `CONFIG_AGENT_*` variables (correct behavior for config-workflow format)
- Added regression test `test/regression/issue-1145-duplicate-agent-override.bats`

## Testing
- `shellcheck -x lib/agent.sh` passes clean (SC2329 resolved)
- `bats test/lib/agent.bats` - all 35 tests pass
- `bats test/scripts/run.bats` - all 36 tests pass
- `bats test/regression/issue-1145-duplicate-agent-override.bats` - all 3 tests pass
- `./scripts/test.sh --shellcheck` - all 58 files pass