### PR TITLE
refactor: split large functions in watch-session.sh, verify-config-docs.sh, wait-for-sessions.sh

### DIFF
--- a/scripts/wait-for-sessions.sh
+++ b/scripts/wait-for-sessions.sh
@@ -144,6 +144,154 @@ main() {
     wait_for_sessions "${issues[@]}"
 }
 
+# Run auto-cleanup for a completed/errored issue
+# Usage: _run_issue_cleanup <issue>
+_run_issue_cleanup() {
+    local issue="$1"
+
+    if [[ "$cleanup" == "true" ]]; then
+        if [[ "$quiet" != "true" ]]; then
+            echo "    Cleaning up worktree for Issue #$issue..."
+        fi
+        "$SCRIPT_DIR/cleanup.sh" "pi-issue-$issue" --force 2>/dev/null || true
+    fi
+}
+
+# Process a single issue's status in the wait loop
+# Usage: process_issue_status <issue> <completed_list_var> <errored_list_var> <all_done_var> <has_error_var>
+# Returns: 0 normally, 1 if fail-fast triggered
+process_issue_status() {
+    local issue="$1"
+    local -n _completed_ref="$2"
+    local -n _errored_ref="$3"
+    local -n _all_done_ref="$4"
+    local -n _has_error_ref="$5"
+
+    # 既に完了/エラー判定済みはスキップ
+    if echo " $_completed_ref " | grep -q " $issue "; then
+        return 0
+    fi
+    if echo " $_errored_ref " | grep -q " $issue "; then
+        return 0
+    fi
+
+    local status
+    status="$(get_status "$issue")"
+
+    case "$status" in
+        complete)
+            _completed_ref="$_completed_ref $issue"
+            if [[ "$quiet" != "true" ]]; then
+                echo "[✓] Issue #$issue 完了"
+            fi
+            _run_issue_cleanup "$issue"
+            ;;
+        error)
+            _errored_ref="$_errored_ref $issue"
+            _has_error_ref=true
+            local error_msg
+            error_msg="$(get_error_message "$issue")"
+            if [[ "$quiet" != "true" ]]; then
+                echo "[✗] Issue #$issue エラー: $error_msg"
+            fi
+            _run_issue_cleanup "$issue"
+            if [[ "$fail_fast" == "true" ]]; then
+                log_error "Fail-fast enabled. Exiting due to error in issue #$issue"
+                return 1
+            fi
+            ;;
+        running)
+            _all_done_ref=false
+            ;;
+        unknown)
+            # tmuxセッションが存在するか確認
+            local session_name="pi-issue-$issue"
+            if session_exists "$session_name"; then
+                # セッションはあるがステータス不明 → まだ開始中
+                _all_done_ref=false
+            else
+                # セッションがない → 完了済みとして扱う
+                _completed_ref="$_completed_ref $issue"
+                if [[ "$quiet" != "true" ]]; then
+                    echo "[✓] Issue #$issue 完了（セッション終了済み）"
+                fi
+                _run_issue_cleanup "$issue"
+            fi
+            ;;
+    esac
+    return 0
+}
+
+# Check if all sessions are done and report results
+# Usage: check_completion_status <all_done> <has_error> <errored_list> <issues_str>
+# Returns: 0 if all done successfully, 1 if errors, 255 if not all done yet
+check_completion_status() {
+    local all_done="$1"
+    local has_error="$2"
+    local errored_list="$3"
+    local issues_str="$4"
+
+    if [[ "$all_done" != "true" ]]; then
+        return 255  # Not done yet
+    fi
+
+    if [[ "$has_error" == "true" ]]; then
+        local error_count
+        error_count=$(echo "$errored_list" | wc -w | tr -d ' ')
+        if [[ "$quiet" != "true" ]]; then
+            log_error "$error_count session(s) failed"
+        fi
+        return 1
+    fi
+
+    local total_count
+    total_count=$(echo "$issues_str" | wc -w | tr -d ' ')
+    if [[ "$quiet" != "true" ]]; then
+        log_info "All $total_count session(s) completed successfully"
+    fi
+    return 0
+}
+
+# Check if timeout has been reached
+# Usage: check_wait_timeout <start_time> <issues_str> <completed_list> <errored_list>
+# Returns: 0 if not timed out, 2 if timed out
+check_wait_timeout() {
+    local start_time="$1"
+    local issues_str="$2"
+    local completed_list="$3"
+    local errored_list="$4"
+
+    local current_time
+    current_time=$(date +%s)
+    local elapsed=$((current_time - start_time))
+
+    if [[ $elapsed -ge $timeout ]]; then
+        local running_count=0
+        for issue in $issues_str; do
+            if ! echo " $completed_list " | grep -q " $issue " && ! echo " $errored_list " | grep -q " $issue "; then
+                ((running_count++)) || true
+            fi
+        done
+        if [[ "$quiet" != "true" ]]; then
+            log_error "Timeout after ${elapsed}s. $running_count session(s) still running."
+        fi
+        return 2
+    fi
+
+    # 進捗表示（verboseモード）
+    if [[ "$quiet" != "true" ]] && [[ "${LOG_LEVEL:-INFO}" == "DEBUG" ]]; then
+        local completed_count
+        local errored_count
+        local total
+        completed_count=$(echo "$completed_list" | wc -w | tr -d ' ')
+        errored_count=$(echo "$errored_list" | wc -w | tr -d ' ')
+        total=$(echo "$issues_str" | wc -w | tr -d ' ')
+        log_debug "Progress: $completed_count/$total complete, $errored_count errors, ${elapsed}s elapsed"
+    fi
+
+    return 0
+}
+
 # セッション完了を待機
 # 引数: Issue番号の配列
 # 戻り値: 0=全完了, 1=エラー発生, 2=タイムアウト
@@ -151,137 +299,35 @@ wait_for_sessions() {
     local issues_str="$*"
     local start_time
     start_time=$(date +%s)
-    
+
     # 完了/エラー済みのIssueをスペース区切りで保持（Bash 3.x互換）
     local completed_list=""
     local errored_list=""
-    
+
     while true; do
         local all_done=true
         local has_error=false
-        
+
         for issue in $issues_str; do
-            # 既に完了/エラー判定済みはスキップ
-            if echo " $completed_list " | grep -q " $issue "; then
-                continue
+            if ! process_issue_status "$issue" completed_list errored_list all_done has_error; then
+                return 1  # fail-fast triggered
             fi
-            if echo " $errored_list " | grep -q " $issue "; then
-                continue
-            fi
-            
-            local status
-            status="$(get_status "$issue")"
-            
-            case "$status" in
-                complete)
-                    completed_list="$completed_list $issue"
-                    if [[ "$quiet" != "true" ]]; then
-                        echo "[✓] Issue #$issue 完了"
-                    fi
-                    # 自動クリーンアップ
-                    if [[ "$cleanup" == "true" ]]; then
-                        if [[ "$quiet" != "true" ]]; then
-                            echo "    Cleaning up worktree for Issue #$issue..."
-                        fi
-                        "$SCRIPT_DIR/cleanup.sh" "pi-issue-$issue" --force 2>/dev/null || true
-                    fi
-                    ;;
-                error)
-                    errored_list="$errored_list $issue"
-                    has_error=true
-                    local error_msg
-                    error_msg="$(get_error_message "$issue")"
-                    if [[ "$quiet" != "true" ]]; then
-                        echo "[✗] Issue #$issue エラー: $error_msg"
-                    fi
-                    # 自動クリーンアップ（エラー時も実行）
-                    if [[ "$cleanup" == "true" ]]; then
-                        if [[ "$quiet" != "true" ]]; then
-                            echo "    Cleaning up worktree for Issue #$issue..."
-                        fi
-                        "$SCRIPT_DIR/cleanup.sh" "pi-issue-$issue" --force 2>/dev/null || true
-                    fi
-                    if [[ "$fail_fast" == "true" ]]; then
-                        log_error "Fail-fast enabled. Exiting due to error in issue #$issue"
-                        return 1
-                    fi
-                    ;;
-                running)
-                    all_done=false
-                    ;;
-                unknown)
-                    # tmuxセッションが存在するか確認
-                    local session_name="pi-issue-$issue"
-                    if session_exists "$session_name"; then
-                        # セッションはあるがステータス不明 → まだ開始中
-                        all_done=false
-                    else
-                        # セッションがない → 完了済みとして扱う
-                        completed_list="$completed_list $issue"
-                        if [[ "$quiet" != "true" ]]; then
-                            echo "[✓] Issue #$issue 完了（セッション終了済み）"
-                        fi
-                        # 自動クリーンアップ
-                        if [[ "$cleanup" == "true" ]]; then
-                            if [[ "$quiet" != "true" ]]; then
-                                echo "    Cleaning up worktree for Issue #$issue..."
-                            fi
-                            "$SCRIPT_DIR/cleanup.sh" "pi-issue-$issue" --force 2>/dev/null || true
-                        fi
-                    fi
-                    ;;
-            esac
         done
-        
+
         # 全て完了判定
-        if [[ "$all_done" == "true" ]]; then
-            if [[ "$has_error" == "true" ]]; then
-                # エラー数をカウント
-                local error_count
-                error_count=$(echo "$errored_list" | wc -w | tr -d ' ')
-                if [[ "$quiet" != "true" ]]; then
-                    log_error "$error_count session(s) failed"
-                fi
-                return 1
-            fi
-            # 完了数をカウント
-            local total_count
-            total_count=$(echo "$issues_str" | wc -w | tr -d ' ')
-            if [[ "$quiet" != "true" ]]; then
-                log_info "All $total_count session(s) completed successfully"
-            fi
-            return 0
+        local status_result=0
+        check_completion_status "$all_done" "$has_error" "$errored_list" "$issues_str" || status_result=$?
+        if [[ $status_result -ne 255 ]]; then
+            return $status_result
         fi
-        
+
         # タイムアウトチェック
-        local current_time
-        current_time=$(date +%s)
-        local elapsed=$((current_time - start_time))
-        
-        if [[ $elapsed -ge $timeout ]]; then
-            local running_count=0
-            for issue in $issues_str; do
-                if ! echo " $completed_list " | grep -q " $issue " && ! echo " $errored_list " | grep -q " $issue "; then
-                    ((running_count++)) || true
-                fi
-            done
-            if [[ "$quiet" != "true" ]]; then
-                log_error "Timeout after ${elapsed}s. $running_count session(s) still running."
-            fi
-            return 2
+        local timeout_result=0
+        check_wait_timeout "$start_time" "$issues_str" "$completed_list" "$errored_list" || timeout_result=$?
+        if [[ $timeout_result -ne 0 ]]; then
+            return $timeout_result
         fi
-        
-        # 進捗表示（verboseモード）
-        if [[ "$quiet" != "true" ]] && [[ "${LOG_LEVEL:-INFO}" == "DEBUG" ]]; then
-            local completed_count
-            local errored_count
-            local total
-            completed_count=$(echo "$completed_list" | wc -w | tr -d ' ')
-            errored_count=$(echo "$errored_list" | wc -w | tr -d ' ')
-            total=$(echo "$issues_str" | wc -w | tr -d ' ')
-            log_debug "Progress: $completed_count/$total complete, $errored_count errors, ${elapsed}s elapsed"
-        fi
-        
+
         sleep "$interval"
     done
 }


### PR DESCRIPTION
## Summary
Closes #1143

## Changes
- **watch-session.sh**: Split `main()` (143 lines) into `capture_baseline()`, `check_initial_markers()`, `run_watch_loop()` + `main()` (42 lines)
- **verify-config-docs.sh**: Split `main()` (141 lines) into `check_config_items()`, `check_default_values()`, `check_document_structure()`, `check_hooks_config()` + `main()` (26 lines)
- **wait-for-sessions.sh**: Split `wait_for_sessions()` (137 lines) into `_run_issue_cleanup()`, `process_issue_status()`, `check_completion_status()`, `check_wait_timeout()` + `wait_for_sessions()` (31 lines)

All functions are now under 80 lines. No behavioral changes.

## Testing
- All 71 existing tests pass (watch-session, verify-config-docs, wait-for-sessions)
- ShellCheck: 0 new warnings
- No behavioral changes, pure refactoring