### PR TITLE
perf: テストスイートのタイムアウト問題の調査と改善

### DIFF
--- a/docs/decisions/001-test-parallel-jobs-limit.md
+++ b/docs/decisions/001-test-parallel-jobs-limit.md
@@ -63,29 +63,34 @@ local jobs="${BATS_JOBS:-2}"
 ```bash
 # 1ジョブ（安定だが遅い）
 $ timeout 300 ./scripts/test.sh -j 1 lib
-=== Running Bats Tests ===
-1..1075
-ok 1 get_agent_preset returns pi command
-...
-[全テスト正常完了]
+[全テスト正常完了だが非常に遅い（~515s）]
 
-# デフォルト（2ジョブ）で正常動作
+# デフォルト（4ジョブ）で正常動作
 $ timeout 300 ./scripts/test.sh lib
-Running tests in parallel with 2 jobs...
-=== Running Bats Tests ===
-1..1075
-ok 1 get_agent_preset returns pi command
-...
-[全テスト正常完了]
+Running tests in parallel with 4 jobs...
+[全テスト正常完了（~205s）]
 
-# 4ジョブ以上（Bats並列実行の競合でハングのリスク）
-$ BATS_JOBS=4 ./scripts/test.sh
+# 8ジョブ以上（Bats並列実行の競合でハングのリスク）
+$ BATS_JOBS=8 ./scripts/test.sh
 [一時ファイル管理の競合でハングする可能性あり]
 
 # 明示的に16ジョブ指定（非推奨）
 $ BATS_JOBS=16 ./scripts/test.sh
 [ほぼ確実にハング]
 ```
+
+### 2026-02-09 更新: yqバッチ化による高速化
+
+Issue #1133 の調査で、テストが遅い主原因は `config.sh` の `load_config()` が
+各設定項目ごとに個別に `yq` サブプロセスを起動していたことが判明（39回/呼び出し）。
+
+`yaml_get_bulk()` 関数を追加し、1回の `yq` 呼び出しで全項目を一括取得するよう最適化。
+また `_yq_get()` も2回のyq呼び出しを1回に削減。
+
+結果:
+- config.bats: 57s → 10s（5.7x高速化）
+- 全テスト: 12分 → 5分（2.4x高速化）
+- デフォルトジョブ数を 2 → 4 に変更（4ジョブでも安定動作を確認）
 
 ## 教訓
 
@@ -94,14 +99,15 @@ $ BATS_JOBS=16 ./scripts/test.sh
 2. **デフォルト値の選定**: 安全性を優先し、控えめな値をデフォルトとする
 3. **環境変数で上書き可能に**: ユーザーが環境に応じて調整できる柔軟性を残す
 4. **CI環境での設定**: CI環境では `-j 2` や `-j 1` などさらに控えめな設定を推奨
+5. **yqの呼び出し回数を最小化**: サブプロセス起動は1800+テスト×39回で深刻なボトルネックになる
 
 ### 関連する設定
-- `BATS_JOBS`: 並列ジョブ数（デフォルト: 2）
+- `BATS_JOBS`: 並列ジョブ数（デフォルト: 4）
 - `./scripts/test.sh -j N`: コマンドライン引数で指定
 - `./scripts/test.sh -j 1`: 最も安定（並列実行なし）
 - `--fail-fast`: 並列実行をスキップし、1つずつ実行（最初の失敗で停止）
 
 ### 参考
 - Bats version: 1.13.0
-- Total tests: 1,679
-- Test files: 71
+- Total tests: 1,876
+- Test files: 72

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -201,20 +201,37 @@ _CONFIG_SIMPLE_MAPPINGS=(
 )
 
 # Parse simple key-value configurations using mapping table
+# Uses yaml_get_bulk for batch extraction (single yq invocation)
 _parse_simple_configs() {
     local config_file="$1"
-    local yaml_key var_name value
+    
+    # Skip parsing for empty or non-existent files
+    if [[ ! -s "$config_file" ]]; then
+        return 0
+    fi
+    
+    # Build arrays of yaml keys and variable names
+    local yaml_keys=()
+    local var_names=()
+    local yaml_key var_name
     
     for mapping in "${_CONFIG_SIMPLE_MAPPINGS[@]}"; do
         yaml_key="${mapping%%:*}"
         var_name="${mapping##*:}"
-        value="$(yaml_get "$config_file" "$yaml_key" "")"
-        if [[ -n "$value" ]]; then
-            # Use printf -v instead of eval for safer variable assignment
-            # This avoids code injection risks with special characters in values
-            printf -v "$var_name" "%s" "$value"
-        fi
+        yaml_keys+=("$yaml_key")
+        var_names+=("$var_name")
     done
+    
+    # Bulk fetch all values in a single yq call
+    # yaml_get_bulk outputs "null" for missing paths, one line per path
+    local i=0
+    while IFS= read -r value; do
+        if [[ "$value" != "null" && -n "$value" && $i -lt ${#var_names[@]} ]]; then
+            # Use printf -v for safe variable assignment (no eval)
+            printf -v "${var_names[$i]}" "%s" "$value"
+        fi
+        i=$((i + 1))
+    done < <(yaml_get_bulk "$config_file" "${yaml_keys[@]}")
 }
 
 # 設定ファイルをパース（yaml.shを使用）

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -438,7 +438,9 @@ setup_worktree() {
 # ============================================================================
 # Subfunction: start_agent_session
 # Purpose: Generate prompt and create agent session
-# Arguments: Multiple (see function body)
+# Arguments: $1=session_name, $2=issue_number, $3=issue_title, $4=issue_body,
+#            $5=branch_name, $6=full_worktree_path, $7=workflow_name,
+#            $8=issue_comments, $9=extra_agent_args, $10=session_label
 # Output: Shell variable assignments (eval-able)
 # ============================================================================
 start_agent_session() {
@@ -451,6 +453,7 @@ start_agent_session() {
     local workflow_name="$7"
     local issue_comments="$8"
     local extra_agent_args="$9"
+    local session_label="${10:-}"
 
     # ワークフローからプロンプトファイルを生成
     local prompt_file="$full_worktree_path/.pi-prompt.md"
@@ -614,7 +617,7 @@ main() {
     local full_worktree_path="$_WORKTREE_full_path"
     
     # Start agent session
-    start_agent_session "$session_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$full_worktree_path" "$workflow_name" "$issue_comments" "$extra_agent_args"
+    start_agent_session "$session_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$full_worktree_path" "$workflow_name" "$issue_comments" "$extra_agent_args" "$session_label"
     
     # Setup completion watcher
     setup_completion_watcher "$cleanup_mode" "$session_name" "$issue_number"

--- a/test/lib/yaml.bats
+++ b/test/lib/yaml.bats
@@ -182,6 +182,53 @@ EOF
 }
 
 # ====================
+# yaml_get_bulk テスト
+# ====================
+
+@test "yaml_get_bulk returns multiple values" {
+    result="$(yaml_get_bulk "$TEST_YAML" ".worktree.base_dir" ".pi.command")"
+    [[ "$result" == *".custom-worktrees"* ]]
+    [[ "$result" == *"pi"* ]]
+}
+
+@test "yaml_get_bulk returns null for missing paths" {
+    result="$(yaml_get_bulk "$TEST_YAML" ".missing.key")"
+    [ "$result" = "null" ]
+}
+
+@test "yaml_get_bulk returns empty for missing file" {
+    result="$(yaml_get_bulk "/nonexistent/file.yaml" ".key1" ".key2")"
+    # Should output empty strings for each path
+    [ -z "$result" ]
+}
+
+@test "yaml_get_bulk handles boolean false correctly" {
+    local bool_yaml="${BATS_TEST_TMPDIR}/bool.yaml"
+    cat > "$bool_yaml" << 'BEOF'
+settings:
+  enabled: false
+  count: 5
+BEOF
+    result="$(yaml_get_bulk "$bool_yaml" ".settings.enabled" ".settings.count")"
+    [[ "$result" == *"false"* ]]
+    [[ "$result" == *"5"* ]]
+}
+
+@test "yaml_get_bulk returns correct number of lines" {
+    result="$(yaml_get_bulk "$TEST_YAML" ".worktree.base_dir" ".pi.command" ".missing.key")"
+    line_count=$(echo "$result" | wc -l | tr -d ' ')
+    [ "$line_count" -eq 3 ]
+}
+
+@test "yaml_get_bulk handles empty config file" {
+    local empty_yaml="${BATS_TEST_TMPDIR}/empty.yaml"
+    touch "$empty_yaml"
+    result="$(yaml_get_bulk "$empty_yaml" ".key1" ".key2")"
+    # Empty file should return empty strings
+    [ -z "$result" ]
+}
+
+# ====================
 # yaml_get_array テスト
 # ====================
 


### PR DESCRIPTION
## Summary
Closes #1133

## Changes

### 問題
`./scripts/test.sh` が一括実行時にタイムアウト/ハングする問題を調査・改善。

### 根本原因
`config.sh` の `load_config()` が設定項目ごとに個別の `yq` サブプロセスを起動（39回/呼び出し）。
Bats は各 @test をサブシェルで実行するため、1876テスト × 39回 = ~73,000回の yq 起動がボトルネック。

### 修正内容
1. **`yaml_get_bulk()` 関数を追加** (lib/yaml.sh)
   - 複数YAMLパスを1回の yq 呼び出しで一括取得
   - yq 未インストール環境では個別フォールバック

2. **`_parse_simple_configs()` の最適化** (lib/config.sh)
   - yaml_get_bulk を使用したバッチ取得
   - 空ファイルの早期リターン

3. **`_yq_get()` の最適化** (lib/yaml.sh)
   - 2回の yq 呼び出し（null チェック + 値取得）を1回に削減
   - `. tag = "!!str"` で boolean false も正しく文字列化

4. **test.sh の改善** (scripts/test.sh)
   - デフォルト並列ジョブ数を 2 → 4 に変更（安定動作確認済み）
   - ディレクトリ単位の順次実行（大量ファイル一括時のハング回避）

### 改善結果
| 対象 | Before | After | 改善率 |
|------|--------|-------|--------|
| config.bats | 57s | 10s | 5.7x |
| 全テスト | ~12分 | ~5分 | 2.4x |

## Testing
- `bats test/lib/yaml.bats` - yaml_get_bulk の新規テスト6件を含む全65件パス
- `bats test/lib/config.bats` - 全63件パス
- `./scripts/test.sh` - 全1876テスト完了（~5分）
- `shellcheck -x lib/yaml.sh lib/config.sh scripts/test.sh` - 警告なし