### PR TITLE
perf: GitHub Actions CI の実行時間を短縮する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,18 +57,13 @@ jobs:
             /usr/local/bin/bats
             /usr/local/libexec/bats-core
             /usr/local/bin/yq
-          key: ${{ runner.os }}-deps-v2
+          key: ${{ runner.os }}-deps-v3
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq tmux
-          # Install gh CLI
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
+          # gh and jq are pre-installed on ubuntu-latest runners
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq tmux
 
       - name: Install yq
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -151,18 +146,13 @@ jobs:
             /usr/local/bin/bats
             /usr/local/libexec/bats-core
             /usr/local/bin/yq
-          key: ${{ runner.os }}-deps-v2
+          key: ${{ runner.os }}-deps-v3
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq tmux
-          # Install gh CLI
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
+          # gh and jq are pre-installed on ubuntu-latest runners
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq tmux
 
       - name: Install yq
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -201,12 +191,13 @@ jobs:
             /usr/local/bin/bats
             /usr/local/libexec/bats-core
             /usr/local/bin/yq
-          key: ${{ runner.os }}-deps-v2
+          key: ${{ runner.os }}-deps-v3
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq tmux
+          # gh and jq are pre-installed on ubuntu-latest runners
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq tmux
 
       - name: Install yq
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -214,15 +205,6 @@ jobs:
           YQ_VERSION="v4.40.5"
           sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
           sudo chmod +x /usr/local/bin/yq
-
-      - name: Install gh CLI
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
 
       - name: Install Bats
         if: steps.cache-deps.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
Closes #1163

## Changes
- gh CLI のインストールを削除（ubuntu-latest に標準搭載）
- jq のインストールを削除（ubuntu-latest に標準搭載）
- apt-get update の重複呼び出しを排除（各ジョブで2回→1回）
- apt-get に -qq フラグを追加してログ出力を削減
- tmux のみ apt-get でインストールするよう変更
- キャッシュキーを v2 → v3 に更新

## Performance Impact
- 各ジョブで gh CLI の apt リポジトリ追加 + apt-get update + apt-get install を省略（約15-30秒/ジョブ）
- jq のインストールも省略（約2-3秒/ジョブ）
- regression-tests ジョブの gh CLI 条件付きインストール（バグあり: cache-hit は bats/yq 用）も削除

## Testing
- YAML バリデーション通過
- ローカルテスト通過（個別テストファイル）
- CI で実際の実行時間短縮を確認予定