### PR TITLE
docs: nudge.sh のコメントとヘルプテキストをマルチプレクサ対応に更新

### DIFF
--- a/scripts/nudge.sh
+++ b/scripts/nudge.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # ============================================================================
-# nudge.sh - Send a continuation message to a tmux session
+# nudge.sh - Send a continuation message to a session
 #
-# Sends a message to an existing pi-issue-runner tmux session to prompt
+# Sends a message to an existing pi-issue-runner session to prompt
 # the agent to continue working on the task.
 #
 # Usage: ./scripts/nudge.sh <session-name|issue-number> [options]
 #
 # Arguments:
-#   session-name    tmux session name (e.g., pi-issue-42)
+#   session-name    Session name (e.g., pi-issue-42)
 #   issue-number    GitHub Issue number (e.g., 42)
 #
 # Options:
@@ -42,7 +42,7 @@ usage() {
 Usage: $(basename "$0") <session-name|issue-number> [options]
 
 Arguments:
-    session-name    tmuxセッション名（例: pi-issue-42）
+    session-name    セッション名（例: pi-issue-42）
     issue-number    GitHub Issue番号（例: 42）
 
 Options:


### PR DESCRIPTION
## Summary
Closes #1171

## Changes
- `scripts/nudge.sh` のファイルヘッダーコメントとヘルプテキストをマルチプレクサ対応に更新
- tmux固有の表現（'tmux session'、'tmuxセッション名'）を汎用的な表現（'session'、'セッション名'）に変更
- 実装はすでにtmux/Zellij両対応だが、ドキュメントが追従していなかった問題を修正

## Testing
- `bats test/scripts/nudge.bats` で全29テストがパス
- tmux固有の表現がコメント/ヘルプから除去されていることを確認