### PR TITLE
fix: replace hardcoded "tmux session" with multiplexer-agnostic term in workflow-prompt.sh

### DIFF
--- a/lib/workflow-prompt.sh
+++ b/lib/workflow-prompt.sh
@@ -133,7 +133,7 @@ The marker format combines these parts (no spaces):
 - Issue number: \`${issue_number}\`
 - Suffix: \`###\`
 
-Combine them and output as a single line. This marker is monitored by an external process that will automatically clean up the worktree and terminate this tmux session.
+Combine them and output as a single line. This marker is monitored by an external process that will automatically clean up the worktree and terminate this session.
 
 Do NOT skip this step.
 EOF


### PR DESCRIPTION
## Summary
Closes #1170

## Changes
- Changed `terminate this tmux session` to `terminate this session` in `lib/workflow-prompt.sh` line 136
- This makes the completion marker prompt consistent with the multiplexer abstraction layer (tmux/Zellij)

## Testing
- `grep 'tmux session' lib/workflow-prompt.sh` returns 0 results
- `shellcheck -x lib/workflow-prompt.sh` passes
- `bats test/lib/workflow-prompt.bats` - 26/27 pass (1 pre-existing failure unrelated to this change)