### PR TITLE
refactor: mux-all.sh の tmux 直接呼び出しをマルチプレクサ抽象化レイヤー経由に変更

### DIFF
--- a/scripts/mux-all.sh
+++ b/scripts/mux-all.sh
@@ -29,6 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/config.sh"
 source "$SCRIPT_DIR/../lib/log.sh"
 source "$SCRIPT_DIR/../lib/tmux.sh"
+# multiplexer.sh is loaded via tmux.sh, providing mux_* functions
 
 MONITOR_SESSION="pi-monitor"
 KILL_EXISTING=false
@@ -72,11 +73,17 @@ list_tmux_sessions() {
     local all="$2"
     
     if [[ "$all" == "true" ]]; then
+        # NOTE: -a/--all モードでは設定済みプレフィックスに関わらず全 *-issue-* セッションを
+        # 返す必要があるため、mux_list_sessions（プレフィックスフィルタ付き）ではなく
+        # tmux list-sessions を直接使用している
         tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -- "-issue-" | grep -v "^pi-monitor" || true
     elif [[ -n "$prefix" ]]; then
+        # NOTE: -p/--prefix モードでは任意のプレフィックスを指定できるため、
+        # mux_list_sessions（設定プレフィックス固定）ではなく直接フィルタリング
         tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^${prefix}-issue-" | grep -v "^pi-monitor" || true
     else
-        list_sessions | grep -v "^pi-monitor" || true
+        # デフォルト: 抽象化レイヤー経由でセッション一覧を取得
+        mux_list_sessions | grep -v "^pi-monitor" || true
     fi
 }
 
@@ -113,14 +120,14 @@ tmux_link_mode() {
     local sessions="$1"
     
     # Kill existing monitor session if requested
-    if tmux has-session -t "$MONITOR_SESSION" 2>/dev/null; then
+    if mux_session_exists "$MONITOR_SESSION"; then
         if [[ "$KILL_EXISTING" == "true" ]]; then
             log_info "Killing existing monitor session..."
-            tmux kill-session -t "$MONITOR_SESSION"
+            mux_kill_session "$MONITOR_SESSION" 10
         else
             log_info "Attaching to existing monitor session..."
             log_info "Use -k to recreate"
-            tmux attach-session -t "$MONITOR_SESSION"
+            mux_attach_session "$MONITOR_SESSION"
             return 0
         fi
     fi
@@ -130,10 +137,14 @@ tmux_link_mode() {
     
     log_info "Creating monitor session: $MONITOR_SESSION"
     
-    # Create monitor session grouped with first target session
+    # NOTE: 以下は tmux 固有の操作（セッショングループ化 + link-window）
+    # mux_create_session はコマンド実行用のため、ここでは -t オプションで
+    # 既存セッションとグループ化する tmux 固有APIを直接使用する
     tmux new-session -d -s "$MONITOR_SESSION" -t "$first_session"
     
     # Link remaining sessions as windows
+    # NOTE: link-window は tmux 固有の機能（他セッションのウィンドウを参照リンク）
+    # マルチプレクサ抽象化レイヤーには該当する汎用APIが存在しない
     local count=1
     while IFS= read -r session; do
         [[ -z "$session" ]] && continue
@@ -145,7 +156,7 @@ tmux_link_mode() {
     done <<< "$sessions"
 
     log_info "Attached. Use Ctrl+b w for window list, Ctrl+b d to detach"
-    tmux attach-session -t "$MONITOR_SESSION"
+    mux_attach_session "$MONITOR_SESSION"
 }
 
 # zellij: ネイティブペインモード（xpanes不要）
@@ -279,7 +290,7 @@ main() {
     mux_type="${mux_type:-tmux}"
     
     # Check multiplexer
-    check_tmux || exit 1
+    mux_check || exit 1
 
     # Get sessions based on multiplexer type
     local sessions


### PR DESCRIPTION
## Summary
Closes #1172

## Changes
- セッション存在チェック: `tmux has-session` → `mux_session_exists`
- セッション終了: `tmux kill-session` → `mux_kill_session`
- セッションアタッチ: `tmux attach-session` → `mux_attach_session`
- マルチプレクサチェック: `check_tmux` → `mux_check`
- デフォルトセッション一覧: `list_sessions` → `mux_list_sessions`
- tmux固有操作(`new-session -t`, `link-window`)にはコメントで意図を明記
- `-a`/`-p` モードの直接呼び出しにはコメントで理由を明記
- テストモックを状態追跡対応に更新

## Testing
- `bats test/scripts/mux-all.bats` - 19/19 pass
- `bats test/lib/multiplexer*.bats test/lib/tmux.bats` - all pass
- `shellcheck -x scripts/mux-all.sh` - no warnings
- Regression tests unaffected