### PR TITLE
docs: clarify script-name.sh as template placeholder

### DIFF
--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -6,6 +6,9 @@ All shell scripts (`.sh` files) in this project should follow this standardized 
 
 ### Template
 
+> **Note**: The following is a template for creating new scripts.
+> Replace `script-name` with your actual script name (e.g., `run.sh`, `cleanup.sh`, etc.).
+
 ```bash
 #!/usr/bin/env bash
 # ============================================================================


### PR DESCRIPTION
## Summary
Closes #1181

## Changes
- Added a note to `docs/coding-standards.md` template section explicitly stating that `script-name.sh` is a placeholder
- Provided examples of actual script names (e.g., `run.sh`, `cleanup.sh`) to guide new developers

## Testing
- Documentation change only, no functional code affected
- Verified the note appears correctly in the template section