### PR TITLE
refactor: cleanup_improve_logs() 関数（129行）を分割する

### DIFF
--- a/lib/cleanup-improve-logs.sh
+++ b/lib/cleanup-improve-logs.sh
@@ -25,128 +25,116 @@ if ! declare -f log_debug > /dev/null 2>&1; then
     log_error() { echo "[ERROR] $*" >&2; }
 fi
 
-# improve-logsディレクトリをクリーンアップ（直近N件を保持、N日以内を保持）
+# 対象ログファイルを更新日時の降順で検索・一覧取得
 # 引数:
-#   $1 - dry_run: "true"の場合は削除せずに表示のみ
-#   $2 - age_days: 日数制限（オプション、指定時は設定を上書き）
-cleanup_improve_logs() {
-    local dry_run="${1:-false}"
-    local age_days="${2:-}"
-    
-    load_config
-    
-    local logs_dir
-    logs_dir="$(get_config improve_logs_dir)"
-    
-    if [[ ! -d "$logs_dir" ]]; then
-        log_debug "No improve-logs directory found: $logs_dir"
-        return 0
-    fi
-    
-    local keep_recent
-    keep_recent="$(get_config improve_logs_keep_recent)"
-    
-    local keep_days
-    keep_days="$(get_config improve_logs_keep_days)"
-    
-    # age_days パラメータが指定された場合は設定を上書き
-    if [[ -n "$age_days" ]]; then
-        keep_days="$age_days"
-    fi
-    
-    # ログファイルを更新日時の降順でソート
-    local log_files=""
+#   $1 - logs_dir: 検索対象ディレクトリ
+# 出力: ファイルパスを更新日時の降順で1行1ファイル出力
+_find_improve_log_files() {
+    local logs_dir="$1"
+
     local unsorted_files
     unsorted_files=$(find "$logs_dir" -name "iteration-*-*.log" -type f 2>/dev/null)
-    
+
     if [[ -z "$unsorted_files" ]]; then
-        log_info "No improve-logs found in $logs_dir"
         return 0
     fi
-    
+
     # OSを検出して適切なstatコマンドを使用
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        # macOS/BSD: stat -f '%m %N' (modification time in seconds, filename)
-        log_files=$(echo "$unsorted_files" | while IFS= read -r file; do
+        echo "$unsorted_files" | while IFS= read -r file; do
             local mtime
             mtime=$(stat -f '%m' "$file" 2>/dev/null)
             echo "$mtime $file"
-        done | sort -rn | awk '{print $2}')
+        done | sort -rn | awk '{print $2}'
     else
-        # Linux/GNU: stat -c '%Y %n' (modification time in seconds, filename)
-        log_files=$(echo "$unsorted_files" | while IFS= read -r file; do
+        echo "$unsorted_files" | while IFS= read -r file; do
             local mtime
             mtime=$(stat -c '%Y' "$file" 2>/dev/null)
             echo "$mtime $file"
-        done | sort -rn | awk '{print $2}')
+        done | sort -rn | awk '{print $2}'
     fi
-    
-    local total_count
-    total_count=$(echo "$log_files" | wc -l | tr -d ' ')
-    
-    local deleted=0
-    local line_num=0
-    local cutoff_time=""
-    
-    # keep_days が設定されている場合はカットオフ時刻を計算
-    if [[ "$keep_days" -gt 0 ]]; then
+}
+
+# 個別ファイルのクリーンアップ条件を判定
+# 引数:
+#   $1 - log_file: 対象ファイル
+#   $2 - position: ソート済みリスト中の位置（1始まり）
+#   $3 - keep_recent: 保持する直近ファイル数（0=無制限）
+#   $4 - keep_days: 保持する日数（0=無制限）
+#   $5 - cutoff_time: カットオフ時刻（epoch秒、空文字列=日数制限なし）
+# 出力: 削除理由（削除すべき場合）。保持する場合は空文字列
+_should_cleanup_file() {
+    local log_file="$1"
+    local position="$2"
+    local keep_recent="$3"
+    local keep_days="$4"
+    local cutoff_time="$5"
+
+    local should_delete=false
+    local reason=""
+
+    # keep_recent の制限をチェック
+    if [[ "$keep_recent" -gt 0 && "$position" -gt "$keep_recent" ]]; then
+        should_delete=true
+        reason="exceeds keep_recent limit ($keep_recent)"
+    fi
+
+    # keep_days の制限をチェック
+    if [[ "$keep_days" -gt 0 && -n "$cutoff_time" ]]; then
+        local file_mtime
         if [[ "$OSTYPE" == "darwin"* ]]; then
-            # macOS/BSD: date -v
-            cutoff_time=$(date -v-"${keep_days}d" +%s)
+            file_mtime=$(stat -f '%m' "$log_file" 2>/dev/null)
         else
-            # Linux/GNU: date -d
-            cutoff_time=$(date -d "${keep_days} days ago" +%s)
+            file_mtime=$(stat -c '%Y' "$log_file" 2>/dev/null)
+        fi
+
+        if [[ "$file_mtime" -lt "$cutoff_time" ]]; then
+            should_delete=true
+            if [[ -n "$reason" ]]; then
+                reason="$reason and older than ${keep_days} days"
+            else
+                reason="older than ${keep_days} days"
+            fi
         fi
     fi
-    
-    # 各ログファイルを処理
-    while IFS= read -r log_file; do
-        [[ -z "$log_file" ]] && continue
-        line_num=$((line_num + 1))
-        
-        local should_delete=false
-        local reason=""
-        
-        # keep_recent の制限をチェック
-        if [[ "$keep_recent" -gt 0 && "$line_num" -gt "$keep_recent" ]]; then
-            should_delete=true
-            reason="exceeds keep_recent limit ($keep_recent)"
-        fi
-        
-        # keep_days の制限をチェック
-        if [[ "$keep_days" -gt 0 && -n "$cutoff_time" ]]; then
-            local file_mtime
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-                file_mtime=$(stat -f '%m' "$log_file" 2>/dev/null)
-            else
-                file_mtime=$(stat -c '%Y' "$log_file" 2>/dev/null)
-            fi
-            
-            if [[ "$file_mtime" -lt "$cutoff_time" ]]; then
-                should_delete=true
-                if [[ -n "$reason" ]]; then
-                    reason="$reason and older than ${keep_days} days"
-                else
-                    reason="older than ${keep_days} days"
-                fi
-            fi
-        fi
-        
-        # 削除または保持の判定
-        if [[ "$should_delete" == "true" ]]; then
-            deleted=$((deleted + 1))
-            if [[ "$dry_run" == "true" ]]; then
-                log_info "[DRY-RUN] Would delete: $log_file ($reason)"
-            else
-                log_info "Deleting: $log_file ($reason)"
-                rm -f "$log_file"
-            fi
-        else
-            log_debug "Keeping: $log_file"
-        fi
-    done <<< "$log_files"
-    
-    # サマリ
+
+    if [[ "$should_delete" == "true" ]]; then
+        echo "$reason"
+    fi
+}
+
+# ログファイルの削除処理
+# 引数:
+#   $1 - log_file: 削除対象ファイル
+#   $2 - reason: 削除理由
+#   $3 - dry_run: "true"の場合は削除せずに表示のみ
+_remove_improve_log() {
+    local log_file="$1"
+    local reason="$2"
+    local dry_run="$3"
+
+    if [[ "$dry_run" == "true" ]]; then
+        log_info "[DRY-RUN] Would delete: $log_file ($reason)"
+    else
+        log_info "Deleting: $log_file ($reason)"
+        rm -f "$log_file"
+    fi
+}
+
+# クリーンアップ結果のサマリを出力
+# 引数:
+#   $1 - deleted: 削除したファイル数
+#   $2 - total_count: 総ファイル数
+#   $3 - keep_recent: 保持する直近ファイル数
+#   $4 - keep_days: 保持する日数
+#   $5 - dry_run: "true"の場合はドライランモード
+_log_cleanup_summary() {
+    local deleted="$1"
+    local total_count="$2"
+    local keep_recent="$3"
+    local keep_days="$4"
+    local dry_run="$5"
+
     if [[ $deleted -eq 0 ]]; then
         if [[ "$keep_recent" -eq 0 && "$keep_days" -eq 0 ]]; then
             log_info "Cleanup disabled (keep_recent=0, keep_days=0)"
@@ -158,4 +146,98 @@ cleanup_improve_logs() {
     else
         log_info "Deleted $deleted log file(s), kept $((total_count - deleted))"
     fi
+}
+
+# カットオフ時刻を計算（クロスプラットフォーム対応）
+# 引数:
+#   $1 - keep_days: 保持する日数（0の場合は空文字列を返す）
+# 出力: カットオフ時刻（epoch秒）または空文字列
+_calculate_cutoff_time() {
+    local keep_days="$1"
+
+    if [[ "$keep_days" -le 0 ]]; then
+        return 0
+    fi
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        date -v-"${keep_days}d" +%s
+    else
+        date -d "${keep_days} days ago" +%s
+    fi
+}
+
+# ログファイルリストを走査し、条件に基づいて削除を実行
+# 引数:
+#   $1 - log_files: 改行区切りのファイルリスト
+#   $2 - keep_recent / $3 - keep_days / $4 - cutoff_time / $5 - dry_run
+# 出力: 削除したファイル数を標準出力に返す
+_process_improve_log_files() {
+    local log_files="$1"
+    local keep_recent="$2"
+    local keep_days="$3"
+    local cutoff_time="$4"
+    local dry_run="$5"
+
+    local deleted=0
+    local line_num=0
+
+    while IFS= read -r log_file; do
+        [[ -z "$log_file" ]] && continue
+        line_num=$((line_num + 1))
+
+        local reason
+        reason=$(_should_cleanup_file "$log_file" "$line_num" "$keep_recent" "$keep_days" "$cutoff_time")
+
+        if [[ -n "$reason" ]]; then
+            _remove_improve_log "$log_file" "$reason" "$dry_run"
+            deleted=$((deleted + 1))
+        else
+            log_debug "Keeping: $log_file"
+        fi
+    done <<< "$log_files"
+
+    echo "$deleted"
+}
+
+# improve-logsディレクトリをクリーンアップ（直近N件を保持、N日以内を保持）
+# 引数:
+#   $1 - dry_run: "true"の場合は削除せずに表示のみ
+#   $2 - age_days: 日数制限（オプション、指定時は設定を上書き）
+cleanup_improve_logs() {
+    local dry_run="${1:-false}"
+    local age_days="${2:-}"
+
+    load_config
+
+    local logs_dir
+    logs_dir="$(get_config improve_logs_dir)"
+
+    if [[ ! -d "$logs_dir" ]]; then
+        log_debug "No improve-logs directory found: $logs_dir"
+        return 0
+    fi
+
+    local keep_recent keep_days
+    keep_recent="$(get_config improve_logs_keep_recent)"
+    keep_days="$(get_config improve_logs_keep_days)"
+    [[ -n "$age_days" ]] && keep_days="$age_days"
+
+    local log_files
+    log_files=$(_find_improve_log_files "$logs_dir")
+
+    if [[ -z "$log_files" ]]; then
+        log_info "No improve-logs found in $logs_dir"
+        return 0
+    fi
+
+    local total_count
+    total_count=$(echo "$log_files" | wc -l | tr -d ' ')
+
+    local cutoff_time
+    cutoff_time=$(_calculate_cutoff_time "$keep_days")
+
+    local deleted
+    deleted=$(_process_improve_log_files "$log_files" "$keep_recent" "$keep_days" "$cutoff_time" "$dry_run")
+
+    _log_cleanup_summary "$deleted" "$total_count" "$keep_recent" "$keep_days" "$dry_run"
 }


### PR DESCRIPTION
## Summary
Closes #1182

## Changes
- `cleanup_improve_logs()` (129行) を7つの小関数に分割:
  - `_find_improve_log_files()`: ログファイル検索・ソート (25行)
  - `_should_cleanup_file()`: クリーンアップ条件判定 (39行)
  - `_remove_improve_log()`: 削除処理 (12行)
  - `_log_cleanup_summary()`: サマリ出力 (19行)
  - `_calculate_cutoff_time()`: カットオフ時刻計算 (13行)
  - `_process_improve_log_files()`: ファイルリスト走査 (27行)
  - `cleanup_improve_logs()`: オーケストレーション (38行)
- 全関数が50行以内
- ヘルパー関数の個別ユニットテスト7件追加（計16テスト）

## Testing
- `bats test/lib/cleanup-improve-logs.bats` — 16/16 パス
- `shellcheck -x lib/cleanup-improve-logs.sh` — 警告0件
- 既存テスト全てパス（回帰なし）