### PR TITLE
docs: add missing regression tests to AGENTS.md directory structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,10 +205,13 @@ pi-issue-runner/
 │   ├── regression/    # 回帰テスト
 │   │   ├── applescript-injection.bats
 │   │   ├── cleanup-race-condition.bats
+│   │   ├── config-master-table-dry.bats
 │   │   ├── critical-fixes.bats
 │   │   ├── eval-injection.bats
 │   │   ├── hooks-env-sanitization.bats
 │   │   ├── issue-1066-spaces-in-filenames.bats
+│   │   ├── issue-1129-session-label-arg.bats
+│   │   ├── issue-1145-duplicate-agent-override.bats
 │   │   ├── multiline-json-grep.bats
 │   │   ├── pr-merge-timeout.bats
 │   │   └── workflow-name-template.bats


### PR DESCRIPTION
## Summary
Closes #1190

## Changes
- Added 3 missing regression test files to AGENTS.md directory structure:
  - `config-master-table-dry.bats`
  - `issue-1129-session-label-arg.bats`
  - `issue-1145-duplicate-agent-override.bats`
- Files are listed in alphabetical order
- Documentation now matches actual test files

## Testing
- Verified all 3 files exist in `test/regression/`
- Confirmed documentation matches actual files with diff command
- All files are properly ordered alphabetically