### PR TITLE
docs: add --label/-l option to run.sh usage

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -62,6 +62,7 @@ Options:
     --base BRANCH       ベースブランチ（デフォルト: HEAD）
     -w, --workflow NAME ワークフロー名（デフォルト: default）
                         利用可能: default, simple
+    -l, --label LABEL   セッションラベル（識別用タグ）
     --no-attach         セッション作成後にアタッチしない
     --no-cleanup        エージェント終了後の自動クリーンアップを無効化
     --reattach          既存セッションがあればアタッチ


### PR DESCRIPTION
## Summary
Closes #1188

## Changes
- Added `--label/-l` option documentation to `usage()` function in `scripts/run.sh`
- The option was already implemented in `parse_run_arguments()` but was missing from the help text

## Testing
- Verified `./scripts/run.sh --help` displays the option correctly
- All existing tests pass (`bats test/scripts/run.bats`)