### PR TITLE
docs: SKILL.md に run.sh の複数オプションが未記載（-i, -v, --quiet, --label）

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -15,6 +15,7 @@ GitHub Issueを入力として、Git worktreeを作成し、ターミナルマ�
 scripts/run.sh <issue-number> [options]
 
 Options:
+  -i, --issue <number>   Issue番号（位置引数の代替）
   -w, --workflow <name>  ワークフロー名（省略時: workflows セクションがあれば auto、なければ default）
   --list-workflows       利用可能なワークフロー一覧を表示
   --no-attach            バックグラウンドで起動
@@ -25,10 +26,13 @@ Options:
   --base <branch>        ベースブランチ
   --agent-args <args>    エージェントに渡す追加の引数
   --pi-args <args>       --agent-args のエイリアス（後方互換性）
+  -l, --label <label>    セッションラベル（識別用タグ）
   --ignore-blockers      依存関係チェックをスキップして強制実行
   --show-config          現在の設定を表示（デバッグ用）
   --list-agents          利用可能なエージェントプリセット一覧を表示
   --show-agent-config    エージェント設定を表示（デバッグ用）
+  -v, --verbose          詳細ログを表示
+  --quiet                エラーのみ表示
 
 # バッチ実行（依存関係順）
 scripts/run-batch.sh <issue>... [options]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -22,6 +22,7 @@
 #   --force             Remove and recreate existing session/worktree
 #   --agent-args ARGS   Additional arguments for the agent
 #   --pi-args ARGS      Alias for --agent-args (backward compatibility)
+#   -l, --label LABEL   Session label (identification tag)
 #   --list-workflows    List available workflows
 #   --ignore-blockers   Skip dependency check and force execution
 #   --show-config       Show current configuration (debug)
@@ -68,6 +69,7 @@ Options:
     --force             既存セッション/worktreeを削除して再作成
     --agent-args ARGS   エージェントに渡す追加の引数
     --pi-args ARGS      --agent-args のエイリアス（後方互換性）
+    -l, --label LABEL   セッションラベル（識別用タグ）
     --list-workflows    利用可能なワークフロー一覧を表示
     --ignore-blockers   依存関係チェックをスキップして強制実行
     --show-config       現在の設定を表示（デバッグ用）


### PR DESCRIPTION
## Summary
Closes #1189

## Changes
- SKILL.md に , , ,  の4つのオプションを追加
- run.sh の usage() 関数と header コメントに  オプションを追加（実装済みだったが未記載）
- 実装済みだが文書化されていなかった4つのオプションを文書化

## Details
run.sh では以下の4つのオプションが実装されていましたが、SKILL.md に記載がありませんでした：

| オプション | 説明 |
|-----------|------|
| `-i, --issue NUMBER` | Issue番号（位置引数の代替） |
| `-l, --label LABEL` | セッションラベル（識別用タグ） |
| `-v, --verbose` | 詳細ログを表示 |
| `--quiet` | エラーのみ表示 |

また、`--label` オプションは実装されていましたが run.sh 自身の usage() にも記載がなかったため、併せて追加しました。

## Testing
- `./scripts/run.sh --help` で4つのオプションが表示されることを確認
- SKILL.md の Options セクションに4つのオプションが記載されていることを確認
- 既存のテストが引き続きパスすることを確認（1件の pre-existing な失敗を除く）