### PR TITLE
fix: run.sh の usage() で -l, --label オプションの重複定義を削除

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -70,7 +70,6 @@ Options:
     --force             既存セッション/worktreeを削除して再作成
     --agent-args ARGS   エージェントに渡す追加の引数
     --pi-args ARGS      --agent-args のエイリアス（後方互換性）
-    -l, --label LABEL   セッションラベル（識別用タグ）
     --list-workflows    利用可能なワークフロー一覧を表示
     --ignore-blockers   依存関係チェックをスキップして強制実行
     --show-config       現在の設定を表示（デバッグ用）

--- a/test/regression/issue-1198-duplicate-label-usage.bats
+++ b/test/regression/issue-1198-duplicate-label-usage.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+# test/regression/issue-1198-duplicate-label-usage.bats
+# 回帰テスト: run.sh の usage() で -l, --label オプションが重複定義されていないことを確認
+
+load '../test_helper'
+
+@test "regression #1198: -l, --label appears exactly once in help output" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [ "$status" -eq 0 ]
+
+    local count
+    count=$(echo "$output" | grep -c '\-l, --label' || true)
+    [ "$count" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
Closes #1198

## Changes
- `scripts/run.sh` の `usage()` 関数から重複していた `-l, --label LABEL` 行（旧73行目）を削除
- 回帰テスト `test/regression/issue-1198-duplicate-label-usage.bats` を追加

## Testing
- `./scripts/run.sh --help 2>&1 | grep -c '\-l, --label'` → 1（重複なし）
- `bats test/scripts/run.bats` → 全36テストパス
- `bats test/regression/issue-1198-duplicate-label-usage.bats` → パス
- ShellCheck 警告なし