### PR TITLE
docs: watch-session.sh に --no-auto-attach オプションを追記

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -315,10 +315,11 @@ Arguments:
     session-name    監視するセッション名
 
 Options:
-    --marker <text>   完了マーカー（デフォルト: ###TASK_COMPLETE_<issue>###）
-    --interval <sec>  監視間隔（デフォルト: 2秒）
-    --cleanup-args    cleanup.shに渡す追加引数
-    -h, --help        このヘルプを表示
+    --marker <text>       完了マーカー（デフォルト: ###TASK_COMPLETE_<issue>###）
+    --interval <sec>      監視間隔（デフォルト: 2秒）
+    --cleanup-args        cleanup.shに渡す追加引数
+    --no-auto-attach      エラー検知時にTerminalを自動で開かない
+    -h, --help            このヘルプを表示
 ```
 
 #### 動作概要


### PR DESCRIPTION
## Summary
Closes #1227

## Changes
- SPECIFICATION.md の watch-session.sh セクションに `--no-auto-attach` オプションを追加
- スクリプトの実装には存在するが、ドキュメントに記載されていなかったオプション
- エラー検知時にTerminalを自動で開かない機能を制御
- オプションの並びと間隔を調整し、可読性を向上

## Testing
- `grep "no-auto-attach" docs/SPECIFICATION.md` でオプションの記載を確認
- スクリプトの usage() とドキュメントの diff が0件であることを確認