### PR TITLE
docs: SPECIFICATION.mdのtest.shデフォルトジョブ数を16→4に修正、ターゲットを追加

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -514,7 +514,7 @@ Options:
     -f, --fail-fast   最初の失敗で終了
     -s, --shellcheck  ShellCheckを実行
     -a, --all         全てのチェック（bats + shellcheck）を実行
-    -j, --jobs N      並列実行のジョブ数（デフォルト: 16）
+    -j, --jobs N      並列実行のジョブ数（デフォルト: 4）
     --fast            高速モード（重いテストをスキップ）
     -h, --help        このヘルプを表示
 ```
@@ -525,6 +525,8 @@ Options:
 |-----------|------|
 | `lib` | test/lib/*.bats のみ実行 |
 | `scripts` | test/scripts/*.bats のみ実行 |
+| `regression` | test/regression/*.bats のみ実行 |
+| `skills` | test/skills/**/*.bats のみ実行 |
 | (デフォルト) | 全Batsテストを実行 |
 
 #### 使用例


### PR DESCRIPTION
## Summary
Closes #1226

## Changes
- `--jobs` のデフォルト値を実装に合わせて 16 → 4 に修正
- test.sh のターゲット一覧に `regression` と `skills` を追加

## Testing
- 検証コマンドで整合性を確認済み
- 実装（scripts/test.sh）とドキュメントが一致することを確認