### PR TITLE
fix: classify_ci_failure() が Bash/Node/Go/Python のテスト失敗パターンを検出できない

### DIFF
--- a/test/lib/ci-classifier.bats
+++ b/test/lib/ci-classifier.bats
@@ -125,6 +125,142 @@ failures:
     [ "$output" = "build" ]
 }
 
+# ===================
+# Bats テスト失敗パターン
+# ===================
+
+@test "classify_ci_failure detects Bats 'not ok' failures" {
+    local log="not ok 5 get_config returns default value"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
+@test "classify_ci_failure detects Bats summary failures" {
+    local log="49 tests, 1 failure"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
+@test "classify_ci_failure detects Bats plural failures" {
+    local log="10 tests, 3 failures"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
+# ===================
+# Go テスト失敗パターン
+# ===================
+
+@test "classify_ci_failure detects Go FAIL prefix" {
+    local log="--- FAIL: TestExample (0.00s)"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
+@test "classify_ci_failure detects Go FAIL tab pattern" {
+    local log=$'FAIL\texample.com/pkg\t0.005s'
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
+# ===================
+# Node/Jest テスト失敗パターン
+# ===================
+
+@test "classify_ci_failure detects Jest test failures" {
+    local log="Tests: 3 failed, 10 passed"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
+# ===================
+# ESLint パターン
+# ===================
+
+@test "classify_ci_failure detects ESLint errors" {
+    local log="✖ 5 problems (3 errors, 2 warnings)"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "lint" ]
+}
+
+@test "classify_ci_failure detects ESLint single problem" {
+    local log="✖ 1 problem (1 error, 0 warnings)"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "lint" ]
+}
+
+# ===================
+# Node ビルドエラーパターン
+# ===================
+
+@test "classify_ci_failure detects npm ERR" {
+    local log="npm ERR! code ELIFECYCLE"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "build" ]
+}
+
+@test "classify_ci_failure detects SyntaxError" {
+    local log="SyntaxError: Unexpected token"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "build" ]
+}
+
+@test "classify_ci_failure detects ModuleNotFoundError" {
+    local log="ModuleNotFoundError: No module named 'requests'"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "build" ]
+}
+
+# ===================
+# Go ビルドエラーパターン
+# ===================
+
+@test "classify_ci_failure detects Go build errors" {
+    local log="go build: cannot load example.com/pkg"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "build" ]
+}
+
+# ===================
+# Bash フォーマットパターン
+# ===================
+
+@test "classify_ci_failure detects shfmt format errors" {
+    local log="shfmt: scripts/run.sh: formatting differs"
+    
+    run classify_ci_failure "$log"
+    [ "$status" -eq 0 ]
+    [ "$output" = "format" ]
+}
+
+# ===================
+# unknown パターン
+# ===================
+
 @test "classify_ci_failure returns unknown for unrecognized errors" {
     local log="Some random error message that doesn't match any pattern"
     


### PR DESCRIPTION
## Summary
Closes #1232

## Changes
- `lib/ci-classifier.sh`: `classify_ci_failure()` に各言語のCI失敗パターンを追加
  - **Format**: shfmt (Bash)
  - **Lint**: ESLint の `problems (N errors)` パターン
  - **Test**: Bats (`not ok N`, `N tests, N failure(s)`), Go (`--- FAIL:`, `FAIL\t`), Jest (`Tests:.*failed`)
  - **Build**: Node (`npm ERR!`, `SyntaxError`, `ModuleNotFoundError`), Go (`go build.*cannot`)
- `test/lib/ci-classifier.bats`: 各言語パターンのテストケースを13件追加

## Testing
- `bats test/lib/ci-classifier.bats`: 28 tests, 0 failures
- `shellcheck -x lib/ci-classifier.sh`: 0 warnings
- 既存テストへの影響なし