### PR TITLE
fix: lib/hooks.sh の _execute_hook() に重複する log_debug 行がある

### DIFF
--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -199,7 +199,6 @@ _execute_hook() {
     # インラインコマンドとして実行（bash -c を使用、eval は使用しない）
     # 環境変数は既に run_hook で設定済み
     log_debug "Executing inline hook command"
-    log_debug "Executing inline hook"
     bash -c "$hook"
 }
 


### PR DESCRIPTION
## Summary
Closes #1218

## Changes
- Removed duplicate `log_debug` line in `_execute_hook()` function (lib/hooks.sh line 201-202)
- Kept `log_debug "Executing inline hook command"` (more descriptive)
- Removed `log_debug "Executing inline hook"` (redundant)

## Testing
- `bats test/lib/hooks.bats` - all 27 tests pass