### PR TITLE
docs: add hooks.allow_inline configuration option to hooks.md and security.md

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -41,7 +41,7 @@ hooks:
 
 ### インラインコマンド
 
-> **⚠️ セキュリティ注意**: インラインhookコマンドはデフォルトで無効化されています。使用するには環境変数 `PI_RUNNER_ALLOW_INLINE_HOOKS=true` を設定してください。セキュリティの観点から、可能な限り[スクリプトファイル](#スクリプトファイル指定)を使用することを推奨します。詳細は[セキュリティドキュメント](./security.md#インラインhookの制御)を参照してください。
+> **⚠️ セキュリティ注意**: インラインhookコマンドはデフォルトで無効化されています。使用するには `.pi-runner.yaml` で `hooks.allow_inline: true` を設定するか、環境変数 `PI_RUNNER_ALLOW_INLINE_HOOKS=true` を設定してください。セキュリティの観点から、可能な限り[スクリプトファイル](#スクリプトファイル指定)を使用することを推奨します。詳細は[セキュリティドキュメント](./security.md#インラインhookの制御)を参照してください。
 
 > **🔒 環境変数のサニタイズ**: `PI_ISSUE_TITLE` および `PI_ERROR_MESSAGE` に含まれる制御文字（改行、タブ、ヌル文字等）は自動的に除去されます。これにより、Issueタイトルやエラーメッセージに含まれる特殊文字が `bash -c` 内で意図しない動作を引き起こすことを防ぎます。
 
@@ -57,6 +57,17 @@ hooks:
 ```
 
 **有効化方法**:
+
+方法1: `.pi-runner.yaml` で設定（推奨）
+
+```yaml
+hooks:
+  allow_inline: true
+  on_success: |
+    echo "Issue #$PI_ISSUE_NUMBER completed"
+```
+
+方法2: 環境変数で設定
 
 ```bash
 export PI_RUNNER_ALLOW_INLINE_HOOKS=true


### PR DESCRIPTION
## Summary
Closes #1217

## Changes
- Updated `docs/hooks.md` to document both `.pi-runner.yaml` config and environment variable methods for enabling inline hooks
- Updated `docs/security.md` code snippet to match actual implementation (`return 2` instead of `return 0`, config fallback logic)
- Added `.pi-runner.yaml` configuration examples in both files showing `hooks.allow_inline: true`

## Details

### docs/hooks.md (2 places)
1. Security warning section: Updated to mention both config file and environment variable methods
2. "有効化方法" section: Added two methods - config file (recommended) and environment variable

### docs/security.md (2 places)
1. "有効化方法" section: Added config file method as the recommended approach
2. Code snippet: Updated to reflect the actual implementation in `lib/hooks.sh` (lines 185-194):
   - Added config fallback logic (`get_config hooks_allow_inline`)
   - Changed return value from `0` to `2` (triggers fallback to default notification)
   - Updated log messages to reflect both configuration methods

## Testing
- ✅ `grep -c "allow_inline" docs/hooks.md` returns 2
- ✅ `grep "return 2" docs/security.md` matches implementation
- ✅ `./scripts/verify-config-docs.sh` passes