### PR TITLE
fix: インラインhook制御の環境変数名を PI_RUNNER_HOOKS_ALLOW_INLINE に統一

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1039,7 +1039,7 @@ github:
 | `allow_inline` | boolean | `false` | インラインhookコマンドの実行を許可する。`true` にすると `.pi-runner.yaml` に直接書いたコマンドが実行される |
 
 > **Note**: インラインhook（ファイルパスではなくコマンド文字列）を使用する場合は `allow_inline: true` を設定してください。
-> 環境変数 `PI_RUNNER_ALLOW_INLINE_HOOKS=true` でも上書き可能です。
+> 環境変数 `PI_RUNNER_HOOKS_ALLOW_INLINE=true` でも上書き可能です。
 
 #### セッションライフサイクル
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -41,7 +41,7 @@ hooks:
 
 ### インラインコマンド
 
-> **⚠️ セキュリティ注意**: インラインhookコマンドはデフォルトで無効化されています。使用するには `.pi-runner.yaml` で `hooks.allow_inline: true` を設定するか、環境変数 `PI_RUNNER_ALLOW_INLINE_HOOKS=true` を設定してください。セキュリティの観点から、可能な限り[スクリプトファイル](#スクリプトファイル指定)を使用することを推奨します。詳細は[セキュリティドキュメント](./security.md#インラインhookの制御)を参照してください。
+> **⚠️ セキュリティ注意**: インラインhookコマンドはデフォルトで無効化されています。使用するには `.pi-runner.yaml` で `hooks.allow_inline: true` を設定するか、環境変数 `PI_RUNNER_HOOKS_ALLOW_INLINE=true` を設定してください。セキュリティの観点から、可能な限り[スクリプトファイル](#スクリプトファイル指定)を使用することを推奨します。詳細は[セキュリティドキュメント](./security.md#インラインhookの制御)を参照してください。
 
 > **🔒 環境変数のサニタイズ**: `PI_ISSUE_TITLE` および `PI_ERROR_MESSAGE` に含まれる制御文字（改行、タブ、ヌル文字等）は自動的に除去されます。これにより、Issueタイトルやエラーメッセージに含まれる特殊文字が `bash -c` 内で意図しない動作を引き起こすことを防ぎます。
 
@@ -70,7 +70,7 @@ hooks:
 方法2: 環境変数で設定
 
 ```bash
-export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+export PI_RUNNER_HOOKS_ALLOW_INLINE=true
 ./scripts/run.sh 42
 ```
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -135,7 +135,7 @@ _execute_hook() {
     local hook="$1"
     ...
     # インラインコマンドの場合: 明示的許可が必要
-    if [[ "${PI_RUNNER_ALLOW_INLINE_HOOKS:-false}" != "true" ]]; then
+    if [[ "${PI_RUNNER_HOOKS_ALLOW_INLINE:-false}" != "true" ]]; then
         log_warn "Inline hook commands are disabled for security."
         return 0
     fi
@@ -151,7 +151,7 @@ _execute_hook() {
 - テンプレート変数（`{{...}}`）は非推奨、環境変数（`$PI_*`）を使用
 - 環境変数経由で渡される値は文字列として安全に処理される
 - デフォルトでインラインhookは拒否される
-- `PI_RUNNER_ALLOW_INLINE_HOOKS=true` を設定した場合のみ実行可能
+- `PI_RUNNER_HOOKS_ALLOW_INLINE=true` を設定した場合のみ実行可能
 - ファイルパスhookは常に許可される
 
 **環境変数の使用例**:
@@ -219,7 +219,7 @@ eval "$old_opts"
 
 ```
 [WARN] Inline hook commands are disabled for security.
-[WARN] To enable, set: export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+[WARN] To enable, set: export PI_RUNNER_HOOKS_ALLOW_INLINE=true
 ```
 
 ファイルパスで指定されたhookスクリプトは、環境変数の設定に関係なく常に実行されます。
@@ -240,7 +240,7 @@ hooks:
 方法2: 環境変数で設定
 
 ```bash
-export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+export PI_RUNNER_HOOKS_ALLOW_INLINE=true
 ./scripts/run.sh 42
 ```
 
@@ -248,7 +248,7 @@ export PI_RUNNER_ALLOW_INLINE_HOOKS=true
 
 ```bash
 # ~/.bashrc または ~/.zshrc
-export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+export PI_RUNNER_HOOKS_ALLOW_INLINE=true
 ```
 
 #### 推奨事項
@@ -268,7 +268,7 @@ _execute_hook() {
     local hook="$1"
     ...
     # インラインコマンドの場合: 明示的許可が必要
-    local allow_inline="${PI_RUNNER_ALLOW_INLINE_HOOKS:-}"
+    local allow_inline="${PI_RUNNER_HOOKS_ALLOW_INLINE:-${PI_RUNNER_ALLOW_INLINE_HOOKS:-}}"
     if [[ -z "$allow_inline" ]]; then
         # 環境変数未設定の場合、設定ファイルの hooks.allow_inline を確認
         allow_inline="$(get_config hooks_allow_inline)" || allow_inline="false"
@@ -277,7 +277,7 @@ _execute_hook() {
     if [[ "$allow_inline" != "true" ]]; then
         log_warn "Inline hook commands are disabled. Falling back to default notification."
         log_warn "To enable, add 'hooks.allow_inline: true' to .pi-runner.yaml"
-        log_warn "  or set: export PI_RUNNER_ALLOW_INLINE_HOOKS=true"
+        log_warn "  or set: export PI_RUNNER_HOOKS_ALLOW_INLINE=true"
         return 2  # 2 = blocked, triggers fallback to default notification
     fi
     

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -182,7 +182,7 @@ _execute_hook() {
     fi
     
     # インラインコマンドの場合: 設定または環境変数で許可が必要
-    local allow_inline="${PI_RUNNER_ALLOW_INLINE_HOOKS:-}"
+    local allow_inline="${PI_RUNNER_HOOKS_ALLOW_INLINE:-${PI_RUNNER_ALLOW_INLINE_HOOKS:-}}"
     if [[ -z "$allow_inline" ]]; then
         # 環境変数未設定の場合、設定ファイルの hooks.allow_inline を確認
         allow_inline="$(get_config hooks_allow_inline)" || allow_inline="false"
@@ -191,7 +191,7 @@ _execute_hook() {
     if [[ "$allow_inline" != "true" ]]; then
         log_warn "Inline hook commands are disabled. Falling back to default notification."
         log_warn "To enable, add 'hooks.allow_inline: true' to .pi-runner.yaml"
-        log_warn "  or set: export PI_RUNNER_ALLOW_INLINE_HOOKS=true"
+        log_warn "  or set: export PI_RUNNER_HOOKS_ALLOW_INLINE=true"
         log_debug "Blocked hook: $hook"
         return 2  # 2 = blocked, triggers fallback to default notification
     fi

--- a/test/lib/hooks.bats
+++ b/test/lib/hooks.bats
@@ -161,7 +161,7 @@ EOF
     mock_notify
     
     # Enable inline hooks for this test
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
     [[ "$result" == *"INLINE_HOOK_EXECUTED"* ]]
@@ -178,7 +178,7 @@ EOF
     mock_notify
     
     # Enable inline hooks for this test
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
     [[ "$result" == *"Issue 42 done"* ]]
@@ -285,7 +285,7 @@ EOF
 # セキュリティテスト
 # ====================
 
-@test "run_hook blocks inline command when PI_RUNNER_ALLOW_INLINE_HOOKS is not set (default: false)" {
+@test "run_hook blocks inline command when PI_RUNNER_HOOKS_ALLOW_INLINE is not set (default: false)" {
     cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
 hooks:
   on_success: echo "INLINE_EXECUTED_42"
@@ -295,8 +295,8 @@ EOF
     override_get_config
     mock_notify
     
-    # Do NOT set PI_RUNNER_ALLOW_INLINE_HOOKS (default is now false)
-    unset PI_RUNNER_ALLOW_INLINE_HOOKS
+    # Do NOT set PI_RUNNER_HOOKS_ALLOW_INLINE (default is now false)
+    unset PI_RUNNER_HOOKS_ALLOW_INLINE
     
     # Enable WARN level logging to capture the warning message
     export LOG_LEVEL="WARN"
@@ -313,7 +313,7 @@ EOF
     [[ "$result" == *"NOTIFY_SUCCESS"* ]]
 }
 
-@test "run_hook blocks inline command when PI_RUNNER_ALLOW_INLINE_HOOKS is false" {
+@test "run_hook blocks inline command when PI_RUNNER_HOOKS_ALLOW_INLINE is false" {
     cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
 hooks:
   on_success: echo "INLINE_EXECUTED_43"
@@ -323,7 +323,7 @@ EOF
     override_get_config
     mock_notify
     
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=false
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=false
     
     # Enable WARN level logging to capture the message
     export LOG_LEVEL="WARN"
@@ -349,14 +349,14 @@ EOF
     override_get_config
     mock_notify
     
-    # Do NOT set PI_RUNNER_ALLOW_INLINE_HOOKS env var
-    unset PI_RUNNER_ALLOW_INLINE_HOOKS
+    # Do NOT set PI_RUNNER_HOOKS_ALLOW_INLINE env var
+    unset PI_RUNNER_HOOKS_ALLOW_INLINE
     
     result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
     [[ "$result" == *"CONFIG_INLINE_ALLOWED"* ]]
 }
 
-@test "run_hook allows inline command when PI_RUNNER_ALLOW_INLINE_HOOKS is true" {
+@test "run_hook allows inline command when PI_RUNNER_HOOKS_ALLOW_INLINE is true" {
     cat > "$TEST_WORKDIR/.pi-runner.yaml" << 'EOF'
 hooks:
   on_success: echo "INLINE_ALLOWED"
@@ -366,13 +366,13 @@ EOF
     override_get_config
     mock_notify
     
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
     [[ "$result" == *"INLINE_ALLOWED"* ]]
 }
 
-@test "run_hook always allows script file hooks regardless of PI_RUNNER_ALLOW_INLINE_HOOKS" {
+@test "run_hook always allows script file hooks regardless of PI_RUNNER_HOOKS_ALLOW_INLINE" {
     mkdir -p "$TEST_WORKDIR/hooks"
     cat > "$TEST_WORKDIR/hooks/test.sh" << 'EOF'
 #!/bin/bash
@@ -389,8 +389,8 @@ EOF
     override_get_config
     mock_notify
     
-    # Do NOT set PI_RUNNER_ALLOW_INLINE_HOOKS
-    unset PI_RUNNER_ALLOW_INLINE_HOOKS
+    # Do NOT set PI_RUNNER_HOOKS_ALLOW_INLINE
+    unset PI_RUNNER_HOOKS_ALLOW_INLINE
     
     result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
     [[ "$result" == *"SCRIPT_EXECUTED"* ]]
@@ -410,7 +410,7 @@ EOF
     override_get_config
     mock_notify
     
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     # 悪意のあるIssueタイトル
     malicious_title='Fix bug"; rm -rf /tmp/test; echo "'
@@ -431,7 +431,7 @@ EOF
     override_get_config
     mock_notify
     
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     # 悪意のあるエラーメッセージ
     malicious_error='Error"; echo INJECTED; echo "'
@@ -454,7 +454,7 @@ EOF
     override_get_config
     mock_notify
     
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     # バッククォートを使った攻撃
     malicious_title='Test `echo BACKTICK_INJECTION` title'
@@ -475,7 +475,7 @@ EOF
     override_get_config
     mock_notify
     
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     # $(...)を使った攻撃
     malicious_title='Test $(echo SUBSHELL_INJECTION) title'
@@ -580,7 +580,7 @@ EOF
     override_get_config
     mock_notify
     
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
     
     # 様々な特殊文字
     malicious_title='Test; ls -la & echo "injection" | cat'

--- a/test/regression/hooks-env-sanitization.bats
+++ b/test/regression/hooks-env-sanitization.bats
@@ -28,7 +28,7 @@ setup() {
     export _CONFIG_LOADED=""
     
     # inline hookを有効化
-    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
 }
 
 teardown() {

--- a/test/regression/issue-1220-inline-hook-env.bats
+++ b/test/regression/issue-1220-inline-hook-env.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# test/regression/issue-1220-inline-hook-env.bats
+# Regression test for Issue #1220: inline hook env var naming inconsistency
+# Both PI_RUNNER_HOOKS_ALLOW_INLINE (standard) and PI_RUNNER_ALLOW_INLINE_HOOKS (legacy)
+# should work for enabling inline hooks.
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+    fi
+    export TEST_WORKDIR="$BATS_TEST_TMPDIR"
+    export PI_RUNNER_CONFIG="$TEST_WORKDIR/.pi-runner.yaml"
+
+    cat > "$PI_RUNNER_CONFIG" << 'EOF'
+hooks:
+  on_success: echo "INLINE_OK"
+EOF
+
+    # Override get_config to read from test config
+    override_get_config() {
+        get_config() {
+            case "$1" in
+                hooks_on_success) echo "echo \"INLINE_OK\"" ;;
+                hooks_allow_inline) echo "false" ;;
+                *) echo "" ;;
+            esac
+        }
+        export -f get_config
+    }
+}
+
+teardown() {
+    unset PI_RUNNER_HOOKS_ALLOW_INLINE 2>/dev/null || true
+    unset PI_RUNNER_ALLOW_INLINE_HOOKS 2>/dev/null || true
+    rm -rf "$BATS_TEST_TMPDIR"
+}
+
+@test "issue-1220: standard env var PI_RUNNER_HOOKS_ALLOW_INLINE enables inline hooks" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    # Mock notify to avoid side effects
+    send_notification() { :; }
+    export -f send_notification
+
+    unset PI_RUNNER_ALLOW_INLINE_HOOKS
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
+
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" == *"INLINE_OK"* ]]
+}
+
+@test "issue-1220: legacy env var PI_RUNNER_ALLOW_INLINE_HOOKS still works (backward compat)" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    send_notification() { :; }
+    export -f send_notification
+
+    unset PI_RUNNER_HOOKS_ALLOW_INLINE
+    export PI_RUNNER_ALLOW_INLINE_HOOKS=true
+
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" == *"INLINE_OK"* ]]
+}
+
+@test "issue-1220: standard env var takes precedence over legacy" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    send_notification() { :; }
+    export -f send_notification
+
+    # Standard says true, legacy says false - standard should win
+    export PI_RUNNER_HOOKS_ALLOW_INLINE=true
+    export PI_RUNNER_ALLOW_INLINE_HOOKS=false
+
+    result="$(run_hook "on_success" "42" "pi-42" "" "" "" "0" "")"
+    [[ "$result" == *"INLINE_OK"* ]]
+}
+
+@test "issue-1220: warn message suggests standard env var name" {
+    source "$PROJECT_ROOT/lib/hooks.sh"
+    override_get_config
+    send_notification() { :; }
+    export -f send_notification
+
+    unset PI_RUNNER_HOOKS_ALLOW_INLINE
+    unset PI_RUNNER_ALLOW_INLINE_HOOKS
+
+    run run_hook "on_success" "42" "pi-42" "" "" "" "0" ""
+    # Should suggest standard name in warning
+    [[ "$output" == *"PI_RUNNER_HOOKS_ALLOW_INLINE"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #1220

## Changes
- Standardize inline hook env var to `PI_RUNNER_HOOKS_ALLOW_INLINE` (follows `PI_RUNNER_{SECTION}_{KEY}` convention)
- Keep `PI_RUNNER_ALLOW_INLINE_HOOKS` as legacy fallback for backward compatibility
- Update `lib/hooks.sh`: prioritize standard name, fall back to legacy
- Update docs (`configuration.md`, `hooks.md`, `security.md`) to reference standard name
- Add regression test (`test/regression/issue-1220-inline-hook-env.bats`)

## Testing
- All 27 hooks tests pass
- All 4 regression tests pass (standard, legacy, precedence, warn message)
- ShellCheck clean