### PR TITLE
fix: add missing sections to check_document_structure() in verify-config-docs.sh

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -699,6 +699,29 @@ improve:
 - 最新10件のログは保持（日時にかかわらず）
 - 11件目以降のログは、7日以内なら保持、7日より古ければ削除
 
+### auto
+
+`-w auto` で AI がワークフローを自動選択する際の設定
+
+| キー | 型 | デフォルト | 説明 |
+|------|------|-----------|------|
+| `provider` | string | (agent設定から推定 or `anthropic`) | AIプロバイダー |
+| `model` | string | `claude-haiku-4-5` | AIモデル（軽量・高速なモデル推奨） |
+
+#### 使用例
+
+```yaml
+auto:
+  provider: anthropic
+  model: claude-haiku-4-5
+```
+
+環境変数でも設定可能:
+```bash
+PI_RUNNER_AUTO_PROVIDER=anthropic ./scripts/run.sh 42 -w auto
+PI_RUNNER_AUTO_MODEL=claude-haiku-4-5 ./scripts/run.sh 42 -w auto
+```
+
 ### workflow
 
 **重要**: `.pi-runner.yaml` の `workflow` セクションは、**`-w` オプションを指定しない場合に使用される「デフォルトワークフロー」**を定義します。

--- a/scripts/verify-config-docs.sh
+++ b/scripts/verify-config-docs.sh
@@ -108,6 +108,10 @@ check_document_structure() {
         "improve"
         "agents"
         "github"
+        "watcher"
+        "auto"
+        "workflow"
+        "workflows"
     )
 
     for section in "${sections[@]}"; do

--- a/test/scripts/verify-config-docs.bats
+++ b/test/scripts/verify-config-docs.bats
@@ -55,6 +55,15 @@ setup() {
     [[ "$output" == *'Section "agent" found'* ]]
 }
 
+@test "verify-config-docs.sh checks all configuration sections including watcher/auto/workflow/workflows" {
+    run "$VERIFY_SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Section "watcher" found'* ]]
+    [[ "$output" == *'Section "auto" found'* ]]
+    [[ "$output" == *'Section "workflow" found'* ]]
+    [[ "$output" == *'Section "workflows" found'* ]]
+}
+
 @test "verify-config-docs.sh handles invalid option" {
     run "$VERIFY_SCRIPT" --invalid-option
     [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary
Closes #1234

## Changes
- Add `watcher`, `auto`, `workflow`, `workflows` to the `sections` array in `check_document_structure()`
- Add `### auto` section heading with configuration table to `docs/configuration.md`
- Add test case verifying all 4 new sections are detected

## Testing
- `./scripts/verify-config-docs.sh` reports all sections found ✅
- `bats test/scripts/verify-config-docs.bats` - 13/13 tests pass ✅
- `shellcheck -x scripts/verify-config-docs.sh` - 0 warnings ✅