### PR TITLE
fix: remove hardcoded -i 4 from shfmt in _fix_format_bash()

### DIFF
--- a/lib/ci-fix/bash.sh
+++ b/lib/ci-fix/bash.sh
@@ -28,7 +28,9 @@ _fix_format_bash() {
     # shfmtがあれば使用
     if command -v shfmt &> /dev/null; then
         log_info "Running shfmt..."
-        if shfmt -w -i 4 . 2>&1; then
+        # shfmt はデフォルトで .editorconfig を参照する
+        # -i オプションを指定しないことで、プロジェクト固有の設定を尊重
+        if shfmt -w . 2>&1; then
             log_info "shfmt fix applied successfully"
             return 0
         else

--- a/test/regression/shfmt-hardcoded-indent.bats
+++ b/test/regression/shfmt-hardcoded-indent.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# test/regression/shfmt-hardcoded-indent.bats
+# Issue #1245: shfmt should not hardcode -i 4
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+    fi
+    source "$PROJECT_ROOT/lib/ci-fix/bash.sh"
+}
+
+@test "_fix_format_bash does not pass -i option to shfmt" {
+    mkdir -p "$BATS_TEST_TMPDIR/mocks"
+    cat > "$BATS_TEST_TMPDIR/mocks/shfmt" << 'MOCK_EOF'
+#!/usr/bin/env bash
+# Fail if -i option is passed (hardcoded indent size)
+for arg in "$@"; do
+    if [[ "$arg" == "-i" || "$arg" =~ ^-i[0-9] ]]; then
+        echo "ERROR: shfmt should not receive -i option (hardcoded indent size)" >&2
+        exit 1
+    fi
+done
+echo "shfmt executed without -i option"
+exit 0
+MOCK_EOF
+    chmod +x "$BATS_TEST_TMPDIR/mocks/shfmt"
+    export PATH="$BATS_TEST_TMPDIR/mocks:$PATH"
+
+    run _fix_format_bash
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"shfmt executed without -i option"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #1245

## Changes
- Removed `-i 4` option from `shfmt` in `_fix_format_bash()` (`lib/ci-fix/bash.sh`)
- `shfmt` now respects `.editorconfig` settings or defaults to tabs (shfmt default)
- Added regression test to verify `-i` option is not passed to shfmt

## Testing
- `shellcheck -x lib/ci-fix/bash.sh` passes
- `bats test/lib/ci-fix.bats` - all 88 tests pass
- `bats test/regression/shfmt-hardcoded-indent.bats` - regression test passes