### PR TITLE
fix: add improve-related hook events to check_hooks_config()

### DIFF
--- a/scripts/verify-config-docs.sh
+++ b/scripts/verify-config-docs.sh
@@ -145,6 +145,11 @@ check_hooks_config() {
         "on_success"
         "on_error"
         "on_cleanup"
+        "on_improve_start"
+        "on_improve_end"
+        "on_iteration_start"
+        "on_iteration_end"
+        "on_review_complete"
     )
 
     for event in "${hook_events[@]}"; do

--- a/test/scripts/verify-config-docs.bats
+++ b/test/scripts/verify-config-docs.bats
@@ -98,6 +98,11 @@ setup() {
     [[ "$output" == *'Hook event "on_success" is documented'* ]]
     [[ "$output" == *'Hook event "on_error" is documented'* ]]
     [[ "$output" == *'Hook event "on_cleanup" is documented'* ]]
+    [[ "$output" == *'Hook event "on_improve_start" is documented'* ]]
+    [[ "$output" == *'Hook event "on_improve_end" is documented'* ]]
+    [[ "$output" == *'Hook event "on_iteration_start" is documented'* ]]
+    [[ "$output" == *'Hook event "on_iteration_end" is documented'* ]]
+    [[ "$output" == *'Hook event "on_review_complete" is documented'* ]]
 }
 
 @test "verify-config-docs.sh checks hooks configuration example" {


### PR DESCRIPTION
## Summary
Closes #1235

## Changes
- Added 5 missing improve-related hook events to `check_hooks_config()` in `scripts/verify-config-docs.sh`:
  - `on_improve_start`
  - `on_improve_end`
  - `on_iteration_start`
  - `on_iteration_end`
  - `on_review_complete`
- Updated test assertions in `test/scripts/verify-config-docs.bats` to verify all 9 hook events

## Testing
- `./scripts/verify-config-docs.sh` - all 9 hook events verified ✅
- `bats test/scripts/verify-config-docs.bats` - 12/12 tests pass ✅
- `shellcheck -x scripts/verify-config-docs.sh` - 0 warnings ✅