### PR TITLE
fix: add explicit source of ci-classifier.sh in ci-fix/common.sh

### DIFF
--- a/lib/ci-fix/common.sh
+++ b/lib/ci-fix/common.sh
@@ -16,6 +16,7 @@ __CI_FIX_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 __CI_FIX_COMMON_LIB_DIR="$(cd "$__CI_FIX_COMMON_DIR/.." && pwd)"
 
 source "$__CI_FIX_COMMON_LIB_DIR/log.sh"
+source "$__CI_FIX_COMMON_LIB_DIR/ci-classifier.sh"
 source "$__CI_FIX_COMMON_DIR/detect.sh"
 source "$__CI_FIX_COMMON_DIR/rust.sh"
 source "$__CI_FIX_COMMON_DIR/node.sh"


### PR DESCRIPTION
## Summary
Closes #1243

## Changes
- Added explicit `source "$__CI_FIX_COMMON_LIB_DIR/ci-classifier.sh"` in `lib/ci-fix/common.sh` to make the dependency on `FAILURE_TYPE_*` constants explicit rather than relying on implicit source ordering from `lib/ci-fix.sh`.

## Testing
- `shellcheck -x lib/ci-fix/common.sh` passes with no warnings
- `bats test/lib/ci-fix.bats test/lib/ci-classifier.bats` - all 132 tests pass
- `./scripts/test.sh lib` - all 1432 tests pass
- `ci-classifier.sh` has a source guard, so duplicate sourcing is safe