### PR TITLE
docs: add CLI reference for 9 missing scripts to SPECIFICATION.md

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -246,6 +246,32 @@ Options:
     -h, --help      このヘルプを表示
 ```
 
+### mux-all.sh - 全セッション表示
+
+```bash
+./scripts/mux-all.sh [options]
+
+Options:
+    -a, --all           全ての *-issue-* セッションを対象
+    -p, --prefix NAME   特定のプレフィックスを指定（例: dict）
+    -w, --watch         ウォッチモード（tmux: xpanes / zellij: ネイティブペイン）
+    -k, --kill          既存のモニターセッションを削除して再作成
+    -h, --help          このヘルプを表示
+
+Description:
+    全てのpi-issue-runnerセッションを表示します。
+    現在のマルチプレクサに応じて最適な表示方法を使用します。
+
+    モード:
+        デフォルト          tmux: link-window / zellij: ネイティブペイン
+        -w, --watch         tmux: xpanesでタイル表示 / zellij: ネイティブペイン
+
+Examples:
+    mux-all.sh -a             # 全セッションを表示
+    mux-all.sh -p dict        # dict-issue-* セッションを表示
+    mux-all.sh -k             # モニターセッションを再作成
+```
+
 ### status.sh - 状態確認
 
 ```bash
@@ -294,6 +320,33 @@ Examples:
     ./scripts/stop.sh 42
 ```
 
+### sweep.sh - 全セッションのマーカーチェック・cleanup
+
+```bash
+./scripts/sweep.sh [options]
+
+Options:
+    --dry-run           対象セッションの表示のみ（実行しない）
+    --force             cleanup時にPRマージ確認をスキップ
+    --check-errors      ERRORマーカーもチェック（デフォルトはCOMPLETEのみ）
+    -v, --verbose       詳細ログ出力
+    -h, --help          このヘルプを表示
+
+Description:
+    全てのアクティブなpi-issue-runnerセッションをスキャンし、
+    COMPLETEマーカーが出力されているセッションに対して
+    cleanup.shを実行します。
+    
+    watch-session.shがクラッシュしたりタイミング問題で
+    クリーンアップが実行されなかったセッションの検出と
+    クリーンアップに使用します。
+
+Examples:
+    sweep.sh --dry-run
+    sweep.sh --force
+    sweep.sh --check-errors
+```
+
 ### cleanup.sh - クリーンアップ
 
 ```bash
@@ -313,6 +366,129 @@ Options:
     --age <days>      指定日数より古いステータスファイルを削除（--orphansと併用）
     --dry-run         削除せずに対象を表示（--orphans/--delete-plans/--rotate-plans/--allと使用）
     -h, --help        このヘルプを表示
+```
+
+### ci-fix-helper.sh - CI修正ヘルパー
+
+```bash
+./scripts/ci-fix-helper.sh <command> [arguments]
+
+Commands:
+    detect <pr_number>
+        CI失敗タイプを検出して出力
+        Returns: failure_type (lint|format|test|build|unknown)
+
+    fix <failure_type> [worktree_path]
+        指定された失敗タイプの自動修正を試行
+        Returns: 0=成功, 1=失敗, 2=AI修正が必要
+
+    handle <issue_number> <pr_number> [worktree_path]
+        CI失敗の完全な処理フロー
+        - 失敗検出
+        - 自動修正試行
+        - 変更のコミット＆プッシュ
+        Returns: 0=修正成功, 1=エスカレーション必要
+
+    validate [worktree_path]
+        ローカル検証を実行（clippy + test）
+        Returns: 0=成功, 1=失敗
+
+    escalate <pr_number> <failure_log>
+        PRをDraft化してエスカレーション
+        Returns: 0=成功, 1=失敗
+
+Examples:
+    # CI失敗タイプを検出
+    ./scripts/ci-fix-helper.sh detect 123
+
+    # フォーマット修正を試行
+    ./scripts/ci-fix-helper.sh fix format /path/to/worktree
+
+    # 完全な処理フロー
+    ./scripts/ci-fix-helper.sh handle 42 123 /path/to/worktree
+
+    # ローカル検証
+    ./scripts/ci-fix-helper.sh validate /path/to/worktree
+```
+
+### context.sh - コンテキスト管理
+
+```bash
+./scripts/context.sh <subcommand> [options]
+
+Subcommands:
+    show <issue>          Issue固有のコンテキストを表示
+    show-project          プロジェクトコンテキストを表示
+    add <issue> <text>    Issue固有のコンテキストに追記
+    add-project <text>    プロジェクトコンテキストに追記
+    edit <issue>          エディタでIssue固有コンテキストを編集
+    edit-project          エディタでプロジェクトコンテキストを編集
+    list                  コンテキストがあるIssue一覧
+    clean [--days N]      古いコンテキストを削除（デフォルト: 30日）
+    export <issue>        Markdown形式でエクスポート
+    remove <issue>        Issue固有のコンテキストを削除
+    remove-project        プロジェクトコンテキストを削除
+    init <issue> [title]  Issue固有のコンテキストを初期化
+    init-project          プロジェクトコンテキストを初期化
+
+Options:
+    -h, --help            このヘルプを表示
+
+Examples:
+    # コンテキストを表示
+    context.sh show 42
+    context.sh show-project
+
+    # コンテキストに追記
+    context.sh add 42 "JWT認証は依存ライブラリの問題で失敗"
+    context.sh add-project "ShellCheck SC2155を修正する際は変数宣言と代入を分離"
+
+    # エディタで編集
+    context.sh edit 42
+    context.sh edit-project
+
+    # 一覧表示
+    context.sh list
+
+    # クリーンアップ
+    context.sh clean --days 30
+
+    # コンテキストを削除
+    context.sh remove 42
+    context.sh remove-project
+
+    # コンテキストを初期化
+    context.sh init 42 "My Feature"
+    context.sh init-project
+```
+
+### dashboard.sh - ダッシュボード表示
+
+```bash
+./scripts/dashboard.sh [options]
+
+Options:
+    --json              JSON形式で出力
+    --no-color          色なし出力（CI環境向け）
+    --compact           コンパクト表示（サマリーのみ）
+    --section <name>    特定セクションのみ表示
+                        (summary|progress|blocked|ready)
+    -w, --watch         自動更新モード（5秒ごと）
+    -v, --verbose       詳細情報を表示
+    -h, --help          このヘルプを表示
+
+Examples:
+    dashboard.sh                    # 標準表示
+    dashboard.sh --compact          # サマリーのみ
+    dashboard.sh --json             # JSON出力
+    dashboard.sh --watch            # 自動更新
+    dashboard.sh --section summary  # サマリーのみ表示
+
+Sections:
+    summary     サマリー統計
+    progress    進行中のIssue
+    blocked     ブロックされたIssue
+    ready       実行可能なIssue
 ```
 
 ### watch-session.sh - セッション監視と自動クリーンアップ
@@ -353,6 +529,27 @@ Options:
 
 ※ このスクリプトは通常、`run.sh` がバックグラウンドで自動的に起動します。
 直接呼び出す必要はありません。
+
+### restart-watcher.sh - Watcher再起動
+
+```bash
+./scripts/restart-watcher.sh <session-name|issue-number>
+
+Arguments:
+    session-name    セッション名（例: pi-issue-42）
+    issue-number    GitHub Issue番号（例: 42）
+
+Options:
+    -h, --help      このヘルプを表示
+
+Description:
+    指定されたセッションのwatcherプロセスを再起動します。
+    既存のwatcherが実行中の場合は停止してから新しいwatcherを起動します。
+
+Examples:
+    restart-watcher.sh pi-issue-42
+    restart-watcher.sh 42
+```
 
 ### improve.sh - 継続的改善
 
@@ -411,6 +608,43 @@ Options:
 ./scripts/nudge.sh pi-issue-42
 ./scripts/nudge.sh 42 --message "続きをお願いします"
 ./scripts/nudge.sh --session pi-issue-42 --message "完了しましたか？"
+```
+
+### next.sh - 次のタスク取得
+
+```bash
+./scripts/next.sh [options]
+
+Options:
+    -n, --count <N>     提案するIssue数（デフォルト: 1）
+    -l, --label <name>  特定ラベルでフィルタ
+    --json              JSON形式で出力
+    --dry-run           提案のみ（実行コマンドを表示しない）
+    -v, --verbose       詳細な判断理由を表示
+    -h, --help          このヘルプを表示
+
+Description:
+    次に実行すべきGitHub Issueをインテリジェントに提案します。
+    依存関係・優先度・ブロッカー状況を考慮して最適なIssueを選択します。
+
+Prioritization Logic:
+    1. Blocker status    - OPENなブロッカーがないIssueを優先
+    2. Dependency depth  - 依存が少ない（レイヤーが浅い）Issueを優先
+    3. Priority labels   - priority:high > medium > low
+    4. Issue number      - 同スコアなら番号が小さい方を優先
+
+Examples:
+    next.sh                    # 次の1件を提案
+    next.sh -n 3               # 次の3件を提案
+    next.sh -l feature         # featureラベル付きから提案
+    next.sh --json             # JSON形式で出力
+    next.sh -v                 # 詳細な判断理由を表示
+
+Exit codes:
+    0 - Success
+    1 - No candidates found
+    2 - GitHub API error
+    3 - Invalid arguments
 ```
 
 ### run-batch.sh - バッチ実行
@@ -483,6 +717,36 @@ Options:
 ./scripts/init.sh --force      # 既存ファイルを上書き
 ```
 
+### generate-config.sh - プロジェクト解析・設定生成
+
+```bash
+./scripts/generate-config.sh [options]
+
+Options:
+    -o, --output FILE   出力ファイルパス (default: .pi-runner.yaml)
+    --dry-run           ファイルに書き込まず標準出力に表示
+    --force             既存ファイルを上書き
+    --no-ai             AI生成をスキップし、静的テンプレートのみ使用
+    --validate          既存の設定をスキーマで検証
+    -h, --help          このヘルプを表示
+
+Description:
+    プロジェクトの構造をAIで解析し、最適な .pi-runner.yaml を生成します。
+    AI (pi --print) が利用できない場合は静的テンプレートにフォールバックします。
+
+Environment Variables:
+    PI_COMMAND                  piコマンドのパス (default: pi)
+    PI_RUNNER_AUTO_PROVIDER     AIプロバイダー (default: anthropic)
+    PI_RUNNER_AUTO_MODEL        AIモデル (default: claude-haiku-4-5)
+
+Examples:
+    generate-config.sh                  # AI解析して .pi-runner.yaml を生成
+    generate-config.sh --dry-run        # 結果をプレビュー
+    generate-config.sh --no-ai          # 静的テンプレートで生成
+    generate-config.sh --validate       # 既存設定を検証
+    generate-config.sh -o custom.yaml   # カスタム出力先
+```
+
 ### force-complete.sh - セッション強制完了
 
 ```bash
@@ -548,6 +812,31 @@ Options:
 ./scripts/test.sh -f          # fail-fast モード
 ./scripts/test.sh -s          # ShellCheckのみ実行
 ./scripts/test.sh -a          # Batsテスト + ShellCheck
+```
+
+### verify-config-docs.sh - 設定ドキュメントの整合性検証
+
+```bash
+./scripts/verify-config-docs.sh [options]
+
+Options:
+    -v, --verbose  詳細出力を表示
+    -h, --help     このヘルプを表示
+
+Description:
+    lib/config.sh と docs/configuration.md の整合性を検証します。
+    設定項目の定義とドキュメントの記載が一致していることを確認します。
+
+Examples:
+    # 検証を実行
+    ./scripts/verify-config-docs.sh
+
+    # 詳細出力付き
+    ./scripts/verify-config-docs.sh --verbose
+
+Exit codes:
+    0  All checks passed
+    1  Configuration mismatch detected
 ```
 
 ### wait-for-sessions.sh - 複数セッション完了待機


### PR DESCRIPTION
## Summary
Closes #1224

## Changes
- Added comprehensive CLI documentation to `docs/SPECIFICATION.md` for 9 previously undocumented scripts:
  - `ci-fix-helper.sh` - CI修正ヘルパー（lib/ci-fix.shのラッパー）
  - `context.sh` - コンテキスト管理
  - `dashboard.sh` - ダッシュボード表示
  - `generate-config.sh` - プロジェクト解析・設定生成
  - `mux-all.sh` - 全セッション表示（マルチプレクサ対応）
  - `next.sh` - 次のタスク取得
  - `restart-watcher.sh` - Watcher再起動
  - `sweep.sh` - 全セッションのマーカーチェック・cleanup
  - `verify-config-docs.sh` - 設定ドキュメントの整合性検証

Each entry includes:
- Command usage syntax
- Options and arguments
- Description
- Examples where applicable

## Testing
- Verified all 9 scripts are now documented in SPECIFICATION.md
- Existing tests pass (2 pre-existing test failures unrelated to documentation changes)