### PR TITLE
fix: _validate_bash() がハードコードされたパス (scripts/*.sh lib/*.sh) を使用している

### DIFF
--- a/lib/ci-fix/bash.sh
+++ b/lib/ci-fix/bash.sh
@@ -71,10 +71,21 @@ _validate_bash() {
         fi
     fi
     if command -v bats &>/dev/null; then
-        log_info "Running bats..."
-        if ! bats test/ 2>&1; then
-            log_error "Bats test failed"
-            return 1
+        # test/ または tests/ ディレクトリが存在する場合のみ実行
+        local test_dir=""
+        if [[ -d "test" ]]; then
+            test_dir="test"
+        elif [[ -d "tests" ]]; then
+            test_dir="tests"
+        fi
+        if [[ -n "$test_dir" ]]; then
+            log_info "Running bats in $test_dir/..."
+            if ! bats "$test_dir/" 2>&1; then
+                log_error "Bats test failed"
+                return 1
+            fi
+        else
+            log_warn "No test directory found for bats"
         fi
     fi
     return 0


### PR DESCRIPTION
## Summary
Closes #1244

## Changes
- `_validate_bash()` の bats 実行部分で `test/` をハードコードしていたのを、`test/` または `tests/` ディレクトリの存在を動的に確認するように変更
- ディレクトリが存在しない場合は warn ログを出力してスキップ（正常終了）
- shellcheck 部分は既に `find` による動的検出に修正済み

## Testing
- `bats test/lib/ci-fix.bats` - 全93テストパス
- 新規テスト追加:
  - `_validate_bash skips bats when no test directory exists`
  - `_validate_bash uses tests/ directory when test/ does not exist`
- `shellcheck -x lib/ci-fix/bash.sh` - 警告なし