### PR TITLE
fix: daemon.sh の is_daemon_running/stop_daemon が set +e/set -e で呼び出し元のエラー処理を破壊する

### DIFF
--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -140,12 +140,8 @@ is_daemon_running() {
     if [[ -z "$pid" ]] || [[ "$pid" == "0" ]]; then
         return 1
     fi
-    # set -e を一時的に無効化して kill の結果をチェック
-    set +e
-    kill -0 "$pid" 2>/dev/null
-    local result=$?
-    set -e
-    return $result
+    kill -0 "$pid" 2>/dev/null || return 1
+    return 0
 }
 
 # デーモンプロセスを安全に終了
@@ -158,16 +154,8 @@ stop_daemon() {
         return 1
     fi
     
-    # set -e を一時的に無効化
-    set +e
-    kill -"$signal" "$pid" 2>/dev/null
-    local result=$?
-    set -e
-    
-    if [[ $result -eq 0 ]]; then
-        return 0
-    fi
-    return 1
+    kill -"$signal" "$pid" 2>/dev/null || return 1
+    return 0
 }
 
 # 指定したコマンドラインで実行中のデーモンプロセスのPIDを検索

--- a/test/regression/issue-1260-daemon-set-e-corruption.bats
+++ b/test/regression/issue-1260-daemon-set-e-corruption.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# test/regression/issue-1260-daemon-set-e-corruption.bats
+# 回帰テスト: daemon.sh の is_daemon_running/stop_daemon が
+# set +e/set -e パターンで呼び出し元のエラー処理を破壊する問題
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        BATS_TEST_TMPDIR="$(mktemp -d)"
+        export BATS_TEST_TMPDIR
+    fi
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR"
+}
+
+@test "Issue #1260: is_daemon_running does not corrupt set -e in if context" {
+    # set -e コンテキストの if 文で呼んだ場合に
+    # スクリプトが予期せず終了しないことを確認
+    run bash -c '
+        set -euo pipefail
+        source "'"$PROJECT_ROOT"'/lib/daemon.sh"
+        if is_daemon_running 99999; then
+            echo "running"
+        else
+            echo "not running"
+        fi
+        echo "script continued"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not running"* ]]
+    [[ "$output" == *"script continued"* ]]
+}
+
+@test "Issue #1260: stop_daemon does not corrupt set -e in if context" {
+    run bash -c '
+        set -euo pipefail
+        source "'"$PROJECT_ROOT"'/lib/daemon.sh"
+        if stop_daemon 99999; then
+            echo "stopped"
+        else
+            echo "not stopped"
+        fi
+        echo "script continued"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not stopped"* ]]
+    [[ "$output" == *"script continued"* ]]
+}
+
+@test "Issue #1260: is_daemon_running preserves caller set +e state" {
+    # 呼び出し元が set +e の場合、関数呼び出し後も set +e のままであること
+    run bash -c '
+        set -euo pipefail
+        source "'"$PROJECT_ROOT"'/lib/daemon.sh"
+        set +e
+        is_daemon_running 99999
+        # set +e が維持されているか確認（false がスクリプトを終了させないはず）
+        false
+        echo "set +e preserved"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"set +e preserved"* ]]
+}
+
+@test "Issue #1260: stop_daemon preserves caller set +e state" {
+    run bash -c '
+        set -euo pipefail
+        source "'"$PROJECT_ROOT"'/lib/daemon.sh"
+        set +e
+        stop_daemon 99999
+        false
+        echo "set +e preserved"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"set +e preserved"* ]]
+}
+
+@test "Issue #1260: daemon functions do not contain set +e/set -e pattern" {
+    # ソースコード中に set +e / set -e パターンが存在しないことを確認
+    source "$PROJECT_ROOT/lib/daemon.sh"
+    
+    # is_daemon_running と stop_daemon の関数定義を取得
+    local func_body
+    func_body=$(declare -f is_daemon_running stop_daemon)
+    
+    # set +e / set -e パターンが含まれていないことを確認
+    ! echo "$func_body" | grep -q 'set +e'
+    ! echo "$func_body" | grep -q 'set -e'
+}


### PR DESCRIPTION
## Summary
Closes #1260

## Changes
- `is_daemon_running()`: `set +e`/`set -e` パターンを `|| return 1` に置換
- `stop_daemon()`: 同様に `|| return 1` パターンに変更
- 回帰テスト追加: `test/regression/issue-1260-daemon-set-e-corruption.bats` (5テストケース)

## Testing
- `shellcheck -x lib/daemon.sh` → 警告0件
- `bats test/lib/daemon.bats` → 全18テストパス
- `bats test/regression/issue-1260-daemon-set-e-corruption.bats` → 全5テストパス
- `set -e` コンテキストからの呼び出し手動検証OK