### PR TITLE
docs: Bash バージョン要件を 4.0+ から 4.3+ に修正（nameref 使用のため）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## 技術スタック
 
-- **言語**: Bash 4.0以上
+- **言語**: Bash 4.3以上
 - **依存ツール**: `gh` (GitHub CLI), `tmux`, `git`, `jq`, `yq` (YAMLパーサー、オプション)
 - **テストフレームワーク**: Bats (Bash Automated Testing System)
 - **静的解析**: ShellCheck

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GitHub Issueを入力として、Git worktreeを作成し、ターミナルマ�
 
 ## 前提条件
 
-- **Bash 4.0以上** (macOSの場合: `brew install bash`)
+- **Bash 4.3以上** (macOSの場合: `brew install bash`)
 - `gh` (GitHub CLI、認証済み)
 - `tmux` または `zellij` (ターミナルマルチプレクサ)
 - `pi`
@@ -362,7 +362,7 @@ workflows:
       - review
       - merge
     context: |
-      Bash 4.0+ / ShellCheck 準拠 / Bats テスト必須
+      Bash 4.3+ / ShellCheck 準拠 / Bats テスト必須
   fix:
     description: バグ修正・リファクタリング・セキュリティ修正
     steps:
@@ -651,7 +651,7 @@ workflows:
       - merge
     context: |
       ## 技術スタック
-      - Bash 4.0+ / ShellCheck 準拠
+      - Bash 4.3+ / ShellCheck 準拠
       - テスト: Bats (Bash Automated Testing System)
       ## 方針
       - 新しい lib/ には対応する test/lib/*.bats を必ず作成

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -891,7 +891,7 @@ Options:
 
 ### 必須
 
-- **Bash** 4.0以上
+- **Bash** 4.3以上
 - **Git** 2.17以上（worktreeサポート）
 - **GitHub CLI** 2.0以上（認証済み）
 - **tmux** 2.1以上 または **Zellij** 0.32以上
@@ -913,7 +913,7 @@ Options:
 ### 互換性
 
 - macOS / Linux対応
-- Bash 4.0+互換
+- Bash 4.3+互換
 
 ### セキュリティ
 


### PR DESCRIPTION
## Summary
Closes #1258

## Changes
- AGENTS.md: Bash 4.0以上 → Bash 4.3以上 (1箇所)
- README.md: Bash 4.0以上/4.0+ → Bash 4.3以上/4.3+ (3箇所)
- docs/SPECIFICATION.md: Bash 4.0以上/4.0+互換 → Bash 4.3以上/4.3+互換 (2箇所)

## Rationale
コードベース全体で `local -n` (nameref) を50箇所以上使用しており、これはBash 4.3で導入された機能です。
ドキュメントの要件を実際の必要バージョンに合わせて修正しました。

## Verification
```bash
# nameref使用箇所の確認
grep -rn "local -n\|declare -n" lib/*.sh scripts/*.sh lib/ci-fix/*.sh lib/improve/*.sh | wc -l
# 結果: 50件

# ドキュメント修正確認
grep -rn "Bash 4\.0" AGENTS.md README.md docs/SPECIFICATION.md
# 結果: 0件（全て4.3に更新済み）

grep -rn "Bash 4\.3" AGENTS.md README.md docs/SPECIFICATION.md
# 結果: 6件
```

## Testing
- [x] ドキュメント修正のみのため、既存機能への影響なし
- [x] 全6箇所の記載を確認・修正済み