### PR TITLE
fix: ci-fix/bash.sh の find | xargs がスペースを含むファイルパスで破損する

### DIFF
--- a/lib/ci-fix/bash.sh
+++ b/lib/ci-fix/bash.sh
@@ -27,18 +27,19 @@ _fix_lint_bash() {
 _fix_format_bash() {
     # shfmtがあれば使用
     if command -v shfmt &> /dev/null; then
-        local sh_files
-        sh_files=$(find . -maxdepth 3 -name "*.sh" -not -path "./.git/*" -not -path "./node_modules/*" 2>/dev/null || true)
-        if [[ -z "$sh_files" ]]; then
+        local sh_files_arr=()
+        while IFS= read -r -d "" f; do
+            sh_files_arr+=("$f")
+        done < <(find . -maxdepth 3 -name "*.sh" -not -path "./.git/*" -not -path "./node_modules/*" -print0 2>/dev/null || true)
+        if [[ ${#sh_files_arr[@]} -eq 0 ]]; then
             log_warn "No .sh files found for shfmt"
             return 2  # 自動修正不可
         fi
-        local file_count
-        file_count=$(echo "$sh_files" | wc -l | tr -d " ")
+        local file_count=${#sh_files_arr[@]}
         log_info "Running shfmt on ${file_count} files..."
         # shfmt はデフォルトで .editorconfig を参照する
         # -i オプションを指定しないことで、プロジェクト固有の設定を尊重
-        if echo "$sh_files" | xargs shfmt -w 2>&1; then
+        if shfmt -w "${sh_files_arr[@]}" 2>&1; then
             log_info "shfmt fix applied successfully"
             return 0
         else
@@ -56,13 +57,14 @@ _fix_format_bash() {
 # Returns: 0=検証成功, 1=検証失敗
 _validate_bash() {
     if command -v shellcheck &>/dev/null; then
-        local sh_files
-        sh_files=$(find . -maxdepth 3 -name "*.sh" -not -path "./.git/*" -not -path "./node_modules/*" 2>/dev/null || true)
-        if [[ -n "$sh_files" ]]; then
-            local file_count
-            file_count=$(echo "$sh_files" | wc -l | tr -d " ")
+        local sh_files_arr=()
+        while IFS= read -r -d "" f; do
+            sh_files_arr+=("$f")
+        done < <(find . -maxdepth 3 -name "*.sh" -not -path "./.git/*" -not -path "./node_modules/*" -print0 2>/dev/null || true)
+        if [[ ${#sh_files_arr[@]} -gt 0 ]]; then
+            local file_count=${#sh_files_arr[@]}
             log_info "Running shellcheck on ${file_count} files..."
-            if ! echo "$sh_files" | xargs shellcheck -x 2>&1; then
+            if ! shellcheck -x "${sh_files_arr[@]}" 2>&1; then
                 log_error "ShellCheck failed"
                 return 1
             fi

--- a/test/regression/issue-1259-ci-fix-bash-spaces.bats
+++ b/test/regression/issue-1259-ci-fix-bash-spaces.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# Regression test for Issue #1259
+# https://github.com/kawasakiisao/pi-issue-runner/issues/1259
+#
+# ci-fix/bash.sh の find | xargs がスペースを含むファイルパスで破損する問題の回帰テスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+
+    source "$PROJECT_ROOT/lib/ci-fix/bash.sh"
+
+    # テスト用ディレクトリを作成（スペースを含む）
+    export TEST_PROJECT_DIR="$BATS_TEST_TMPDIR/project with spaces"
+    mkdir -p "$TEST_PROJECT_DIR/dir with spaces"
+    mkdir -p "$TEST_PROJECT_DIR/normal-dir"
+
+    # テスト用 .sh ファイルを作成
+    cat > "$TEST_PROJECT_DIR/dir with spaces/my script.sh" << 'SCRIPT'
+#!/usr/bin/env bash
+echo "hello"
+SCRIPT
+
+    cat > "$TEST_PROJECT_DIR/normal-dir/normal.sh" << 'SCRIPT'
+#!/usr/bin/env bash
+echo "world"
+SCRIPT
+
+    cat > "$TEST_PROJECT_DIR/top level script.sh" << 'SCRIPT'
+#!/usr/bin/env bash
+echo "top"
+SCRIPT
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# Issue #1259: _fix_format_bash でスペースを含むパスの処理
+# ====================
+
+@test "Issue #1259: _fix_format_bash handles files with spaces in path" {
+    # shfmt のモックを作成（引数にスペース付きファイルが正しく渡されることを確認）
+    mkdir -p "$BATS_TEST_TMPDIR/mock-bin"
+    cat > "$BATS_TEST_TMPDIR/mock-bin/shfmt" << 'MOCK'
+#!/usr/bin/env bash
+# 各引数をファイルとして記録
+for arg in "$@"; do
+    if [[ "$arg" != "-w" ]]; then
+        echo "$arg" >> "$BATS_TEST_TMPDIR/shfmt-args.txt"
+    fi
+done
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/mock-bin/shfmt"
+    export PATH="$BATS_TEST_TMPDIR/mock-bin:$PATH"
+
+    cd "$TEST_PROJECT_DIR"
+    run _fix_format_bash
+    [ "$status" -eq 0 ]
+
+    # shfmt に渡された引数を確認
+    [ -f "$BATS_TEST_TMPDIR/shfmt-args.txt" ]
+
+    # スペースを含むファイルが1つの引数として渡されていること
+    run grep "dir with spaces/my script.sh" "$BATS_TEST_TMPDIR/shfmt-args.txt"
+    [ "$status" -eq 0 ]
+
+    run grep "top level script.sh" "$BATS_TEST_TMPDIR/shfmt-args.txt"
+    [ "$status" -eq 0 ]
+
+    run grep "normal-dir/normal.sh" "$BATS_TEST_TMPDIR/shfmt-args.txt"
+    [ "$status" -eq 0 ]
+}
+
+# ====================
+# Issue #1259: _validate_bash でスペースを含むパスの処理
+# ====================
+
+@test "Issue #1259: _validate_bash handles files with spaces in path" {
+    # shellcheck のモックを作成
+    mkdir -p "$BATS_TEST_TMPDIR/mock-bin"
+    cat > "$BATS_TEST_TMPDIR/mock-bin/shellcheck" << 'MOCK'
+#!/usr/bin/env bash
+# 各引数をファイルとして記録
+for arg in "$@"; do
+    if [[ "$arg" != "-x" ]]; then
+        echo "$arg" >> "$BATS_TEST_TMPDIR/shellcheck-args.txt"
+    fi
+done
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/mock-bin/shellcheck"
+    export PATH="$BATS_TEST_TMPDIR/mock-bin:$PATH"
+
+    cd "$TEST_PROJECT_DIR"
+    run _validate_bash
+    [ "$status" -eq 0 ]
+
+    # shellcheck に渡された引数を確認
+    [ -f "$BATS_TEST_TMPDIR/shellcheck-args.txt" ]
+
+    # スペースを含むファイルが1つの引数として渡されていること
+    run grep "dir with spaces/my script.sh" "$BATS_TEST_TMPDIR/shellcheck-args.txt"
+    [ "$status" -eq 0 ]
+
+    run grep "top level script.sh" "$BATS_TEST_TMPDIR/shellcheck-args.txt"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
Closes #1259

## Changes
- `_fix_format_bash()`: `find | xargs shfmt` を `find -print0` + 配列パターンに置き換え
- `_validate_bash()`: `find | xargs shellcheck` を同様に修正
- スペースを含むファイルパスが正しく処理されるようになった

## Testing
- `shellcheck -x lib/ci-fix/bash.sh`: 警告0件
- `bats test/lib/ci-fix.bats`: 全93テストパス
- 回帰テスト追加: `test/regression/issue-1259-ci-fix-bash-spaces.bats` (2テスト)