### PR TITLE
refactor: add BASH_SOURCE guard to scripts/cleanup.sh

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -397,4 +397,7 @@ main() {
     execute_single_cleanup "$target" "$force" "$delete_branch" "$keep_session" "$keep_worktree"
 }
 
-main "$@"
+# Only run main if script is executed directly (not sourced for testing)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/test/regression/issue-1262-bash-source-guard.bats
+++ b/test/regression/issue-1262-bash-source-guard.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# test/regression/issue-1262-bash-source-guard.bats
+# Regression test: scripts/cleanup.sh can be sourced without side effects
+
+load '../test_helper'
+
+@test "Issue #1262: cleanup.sh can be sourced without executing main" {
+    # Source cleanup.sh and verify functions are available without side effects
+    run bash -c '
+        source "'"$PROJECT_ROOT"'/scripts/cleanup.sh"
+        # If main ran, it would fail or produce errors since no config exists
+        # Verify key functions are available
+        type parse_cleanup_arguments >/dev/null 2>&1 || exit 1
+        type execute_single_cleanup >/dev/null 2>&1 || exit 1
+        type execute_all_cleanup >/dev/null 2>&1 || exit 1
+        type usage >/dev/null 2>&1 || exit 1
+        type main >/dev/null 2>&1 || exit 1
+        echo "OK"
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "Issue #1262: cleanup.sh BASH_SOURCE guard is present" {
+    grep -q 'BASH_SOURCE\[0\].*==.*\${0}' "$PROJECT_ROOT/scripts/cleanup.sh"
+}


### PR DESCRIPTION
## Summary
Closes #1262

## Changes
- Added `BASH_SOURCE[0] == $0` guard to `scripts/cleanup.sh` so it can be sourced for unit testing individual functions without triggering main execution
- Added regression test `test/regression/issue-1262-bash-source-guard.bats` to verify sourcing works without side effects

## Testing
- All 28 existing `test/scripts/cleanup.bats` tests pass
- 2 new regression tests pass
- `shellcheck -x scripts/cleanup.sh` reports 0 warnings
- Verified `./scripts/cleanup.sh --help` works correctly
- Verified sourcing exposes functions without executing main