### PR TITLE
fix: sweep.sh がシグナルファイル検出後にファイルを削除しない

### DIFF
--- a/scripts/sweep.sh
+++ b/scripts/sweep.sh
@@ -209,6 +209,14 @@ execute_cleanup() {
     
     log_info "Executing cleanup for session: $session_name (Issue #$issue_number)"
     
+    # シグナルファイルを削除（cleanup.sh 実行前に削除して重複検出を防止）
+    local status_dir
+    status_dir="$(get_status_dir 2>/dev/null)" || true
+    if [[ -n "$status_dir" ]]; then
+        rm -f "${status_dir}/signal-complete-${issue_number}" 2>/dev/null || true
+        rm -f "${status_dir}/signal-error-${issue_number}" 2>/dev/null || true
+    fi
+    
     # cleanup.shを実行
     local cleanup_args=""
     if [[ "$force" == "true" ]]; then


### PR DESCRIPTION
## Summary
Closes #1269

## Changes
- `scripts/sweep.sh` の `execute_cleanup` 関数にシグナルファイル削除処理を追加
  - `cleanup.sh` 実行前に `signal-complete-{issue}` と `signal-error-{issue}` を削除
  - `watch-session.sh` と同様のパターンで実装
- テスト追加（2件）: シグナルファイル削除の動作確認

## Testing
- `bats test/scripts/sweep.bats` 全18テストパス
- `shellcheck -x scripts/sweep.sh` 警告0件