### PR TITLE
fix: multiplexer-zellij.sh の mux_get_session_output() で tmpfile がリークする可能性

### DIFF
--- a/lib/multiplexer-zellij.sh
+++ b/lib/multiplexer-zellij.sh
@@ -226,17 +226,18 @@ mux_get_session_output() {
     # Zellijはdump-screenでファイルに出力する必要がある
     local tmp_file
     tmp_file=$(mktemp)
+    # RETURN trapでtmpfileを確実にクリーンアップ（シグナル中断時のリーク防止）
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp_file' 2>/dev/null" RETURN
     
     # セッションにアクションを送信
     ZELLIJ_SESSION_NAME="$session_name" zellij action dump-screen --full "$tmp_file" 2>/dev/null || {
-        rm -f "$tmp_file"
         log_warn "Could not capture output from session: $session_name"
         return 1
     }
     
     # 最後のN行を表示
     tail -n "$lines" "$tmp_file" 2>/dev/null || true
-    rm -f "$tmp_file"
 }
 
 # アクティブなセッション数をカウント


### PR DESCRIPTION
## Summary
Closes #1271

## Changes
- `mux_get_session_output()` で `trap RETURN` を使用して tmpfile のクリーンアップを保証
- 手動の `rm -f` 呼び出しを削除し、trap による一元管理に変更
- シグナル（SIGTERM/SIGINT）による中断時の tmpfile リークを防止

## Technical Details
- `trap "rm -f '$tmp_file' 2>/dev/null" RETURN` で早期展開を使用
- `set -u` 環境での unbound variable エラーを回避するため、double quotes で即座にパスを展開
- SC2064 は意図的な早期展開のため `shellcheck disable` で抑制

## Testing
- `shellcheck -x lib/multiplexer-zellij.sh` → 警告0件
- `bats test/lib/multiplexer-zellij.bats` → 36テスト全パス
- `bats test/lib/multiplexer.bats` → 8テスト全パス