### PR TITLE
fix: ci-fix/node.sh の _validate_node() フォールバック grep パターンが誤マッチする問題を修正

### DIFF
--- a/lib/ci-fix/node.sh
+++ b/lib/ci-fix/node.sh
@@ -92,14 +92,14 @@ _validate_node() {
         fi
     else
         # Fallback: check if package.json contains "lint" or "test" script keys
-        if grep -q '"lint"' package.json 2>/dev/null; then
+        if grep -qE '"lint"\s*:' package.json 2>/dev/null; then
             log_info "Running npm run lint..."
             if ! npm run lint 2>&1; then
                 log_error "Lint check failed"
                 return 1
             fi
         fi
-        if grep -q '"test"' package.json 2>/dev/null; then
+        if grep -qE '"test"\s*:' package.json 2>/dev/null; then
             log_info "Running npm test..."
             if ! npm test 2>&1; then
                 log_error "Test failed"

--- a/test/regression/issue-1270-node-grep-pattern.bats
+++ b/test/regression/issue-1270-node-grep-pattern.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# Regression test for Issue #1270
+# grep fallback in _validate_node() should not match "test:unit" or "lint:fix"
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+    fi
+    export WORK_DIR="$BATS_TEST_TMPDIR/node-project"
+    mkdir -p "$WORK_DIR"
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR"
+}
+
+@test "issue-1270: grep pattern does not match 'test:unit' as 'test'" {
+    # "test:unit" should NOT match the pattern for "test"
+    echo '"test:unit": "vitest"' > "$WORK_DIR/package.json"
+    run grep -qE '"test"\s*:' "$WORK_DIR/package.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "issue-1270: grep pattern does not match 'lint:fix' as 'lint'" {
+    # "lint:fix" should NOT match the pattern for "lint"
+    echo '"lint:fix": "eslint --fix ."' > "$WORK_DIR/package.json"
+    run grep -qE '"lint"\s*:' "$WORK_DIR/package.json"
+    [ "$status" -ne 0 ]
+}
+
+@test "issue-1270: grep pattern matches exact 'test' key" {
+    echo '"test": "vitest"' > "$WORK_DIR/package.json"
+    run grep -qE '"test"\s*:' "$WORK_DIR/package.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "issue-1270: grep pattern matches exact 'lint' key" {
+    echo '"lint": "eslint ."' > "$WORK_DIR/package.json"
+    run grep -qE '"lint"\s*:' "$WORK_DIR/package.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "issue-1270: grep pattern matches 'test' with spaces before colon" {
+    echo '"test" : "vitest"' > "$WORK_DIR/package.json"
+    run grep -qE '"test"\s*:' "$WORK_DIR/package.json"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
Closes #1270

## Changes
- `lib/ci-fix/node.sh`: フォールバック grep パターンを `grep -q '"lint"'` → `grep -qE '"lint"\s*:'` に変更（2箇所）
- `"test:unit"` や `"lint:fix"` のような部分文字列への誤マッチを防止

## Testing
- shellcheck -x lib/ci-fix/node.sh: 警告0件
- bats test/lib/ci-fix.bats: 全93テストパス
- 回帰テスト追加: test/regression/issue-1270-node-grep-pattern.bats（5テスト）