### PR TITLE
fix: cleanup.sh がシグナルファイルと pipe-pane 出力ログを削除しない

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -312,6 +312,20 @@ execute_single_cleanup() {
                     log_warn "Failed to remove watcher log file: $watcher_log"
                 }
             fi
+
+            # Signal files and pipe-pane output log cleanup (Issue #1268)
+            local status_dir
+            status_dir="$(get_status_dir)"
+            for signal_file in "${status_dir}/signal-complete-${issue_number}" \
+                               "${status_dir}/signal-error-${issue_number}" \
+                               "${status_dir}/output-${issue_number}.log"; do
+                if [[ -f "$signal_file" ]]; then
+                    log_debug "Removing: $signal_file"
+                    rm -f "$signal_file" 2>/dev/null || {
+                        log_warn "Failed to remove: $signal_file"
+                    }
+                fi
+            done
         fi
 
         # on_cleanup hookを実行（失敗しても後続処理を継続）


### PR DESCRIPTION
## Summary
Closes #1268

## Changes
- `scripts/cleanup.sh`: `execute_single_cleanup` にシグナルファイル（`signal-complete-*`, `signal-error-*`）と pipe-pane 出力ログ（`output-*.log`）の削除処理を追加
- `test/scripts/cleanup.bats`: 新規テスト追加（Issue #1268 の回帰テスト）

## Testing
- `bats test/scripts/cleanup.bats`: 29/29 テストパス
- `shellcheck -x scripts/cleanup.sh`: 警告0件