### PR TITLE
fix: replace echo with printf in has_dangerous_patterns() and classify_ci_failure()

### DIFF
--- a/lib/ci-classifier.sh
+++ b/lib/ci-classifier.sh
@@ -81,7 +81,7 @@ classify_ci_failure() {
     # フォーマットエラーをチェック（各言語対応）
     # Rust: Diff in, would have been reformatted
     # Bash: shfmt
-    if echo "$log_content" | grep -qE '(Diff in|would have been reformatted|fmt check failed|shfmt)'; then
+    if printf '%s\n' "$log_content" | grep -qE '(Diff in|would have been reformatted|fmt check failed|shfmt)'; then
         echo "$FAILURE_TYPE_FORMAT"
         return 0
     fi
@@ -92,7 +92,7 @@ classify_ci_failure() {
     # Bash: SC[0-9]{4} (ShellCheck)
     # Python: pylint, flake8
     # Note: 汎用 "warning:" は除外（DeprecationWarning等の誤分類を防止）
-    if echo "$log_content" | grep -qE '(clippy::|error: could not compile.*clippy|problems? \([0-9]+ errors?|SC[0-9]{4}|pylint|flake8.*E[0-9])'; then
+    if printf '%s\n' "$log_content" | grep -qE '(clippy::|error: could not compile.*clippy|problems? \([0-9]+ errors?|SC[0-9]{4}|pylint|flake8.*E[0-9])'; then
         echo "$FAILURE_TYPE_LINT"
         return 0
     fi
@@ -102,7 +102,7 @@ classify_ci_failure() {
     # Node: SyntaxError, ModuleNotFoundError
     # Go: go build.*cannot
     # General: compilation failed
-    if echo "$log_content" | grep -qE '(error\[E|cannot find|unresolved import|expected.*found|SyntaxError|ModuleNotFoundError|go build.*cannot|compilation failed)'; then
+    if printf '%s\n' "$log_content" | grep -qE '(error\[E|cannot find|unresolved import|expected.*found|SyntaxError|ModuleNotFoundError|go build.*cannot|compilation failed)'; then
         echo "$FAILURE_TYPE_BUILD"
         return 0
     fi
@@ -113,7 +113,7 @@ classify_ci_failure() {
     # Go: --- FAIL:, FAIL\t
     # Node/Jest: Tests:.*failed
     # Note: 汎用 "FAILED" は除外（ビルドエラーとの誤分類を防止）
-    if echo "$log_content" | grep -qE '(test result: FAILED|failures:|not ok [0-9]|[0-9]+ tests?, [0-9]+ failures?|--- FAIL:|FAIL\t|Tests:.*failed)'; then
+    if printf '%s\n' "$log_content" | grep -qE '(test result: FAILED|failures:|not ok [0-9]|[0-9]+ tests?, [0-9]+ failures?|--- FAIL:|FAIL\t|Tests:.*failed)'; then
         echo "$FAILURE_TYPE_TEST"
         return 0
     fi
@@ -121,7 +121,7 @@ classify_ci_failure() {
     # 汎用パターン（最終フォールバック）
     # warning:.*unused は Rust/C の未使用警告に限定
     # npm ERR! はテスト・ビルド両方で出るため、上記で分類できなかった場合のみ
-    if echo "$log_content" | grep -qE '(warning:.*unused|npm ERR!)'; then
+    if printf '%s\n' "$log_content" | grep -qE '(warning:.*unused|npm ERR!)'; then
         echo "$FAILURE_TYPE_LINT"
         return 0
     fi

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -200,37 +200,37 @@ has_dangerous_patterns() {
     local text="$1"
     
     # コマンド置換 $(...) - grepを使用して安全に検出
-    if echo "$text" | grep -qE '\$\([^)]+\)'; then
+    if printf '%s\n' "$text" | grep -qE '\$\([^)]+\)'; then
         log_warn "Dangerous pattern detected: command substitution \$(...)  "
         return 0  # 危険あり = true
     fi
     
     # バッククォート `...`
-    if echo "$text" | grep -q '`[^`]*`'; then
+    if printf '%s\n' "$text" | grep -q '`[^`]*`'; then
         log_warn "Dangerous pattern detected: backtick command \`...\`"
         return 0  # 危険あり = true
     fi
     
     # 変数展開 ${...}
-    if echo "$text" | grep -qE '\$\{[^}]+\}'; then
+    if printf '%s\n' "$text" | grep -qE '\$\{[^}]+\}'; then
         log_warn "Dangerous pattern detected: variable expansion \${...}"
         return 0  # 危険あり = true
     fi
     
     # プロセス置換 <(...)
-    if echo "$text" | grep -qE '<\([^)]+\)'; then
+    if printf '%s\n' "$text" | grep -qE '<\([^)]+\)'; then
         log_warn "Dangerous pattern detected: process substitution <(...)"
         return 0  # 危険あり = true
     fi
     
     # プロセス置換 >(...)
-    if echo "$text" | grep -qE '>\([^)]+\)'; then
+    if printf '%s\n' "$text" | grep -qE '>\([^)]+\)'; then
         log_warn "Dangerous pattern detected: process substitution >(...)"
         return 0  # 危険あり = true
     fi
     
     # 算術展開 $((...))
-    if echo "$text" | grep -qE '\$\(\([^)]+\)\)'; then
+    if printf '%s\n' "$text" | grep -qE '\$\(\([^)]+\)\)'; then
         log_warn "Dangerous pattern detected: arithmetic expansion \$((...))"
         return 0  # 危険あり = true
     fi

--- a/test/lib/ci-classifier.bats
+++ b/test/lib/ci-classifier.bats
@@ -449,6 +449,24 @@ test result: FAILED. 0 passed; 1 failed;"
     [ "$output" = "build" ]
 }
 
+@test "classify_ci_failure handles input starting with -n" {
+    run classify_ci_failure '-n Diff in foo.rs'
+    [ "$status" -eq 0 ]
+    [ "$output" = "format" ]
+}
+
+@test "classify_ci_failure handles input starting with -e" {
+    run classify_ci_failure '-e error[E0425]: cannot find value'
+    [ "$status" -eq 0 ]
+    [ "$output" = "build" ]
+}
+
+@test "classify_ci_failure handles input starting with -E" {
+    run classify_ci_failure '-E test result: FAILED. 0 passed; 1 failed;'
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}
+
 # ===================
 # get_failed_ci_logs テスト
 # ===================

--- a/test/lib/github.bats
+++ b/test/lib/github.bats
@@ -417,6 +417,27 @@ MOCK_EOF
     [ "$status" -eq 0 ]
 }
 
+@test "has_dangerous_patterns detects patterns in input starting with -n" {
+    source "$PROJECT_ROOT/lib/github.sh"
+
+    run has_dangerous_patterns '-n $(rm -rf /)'
+    [ "$status" -eq 0 ]
+}
+
+@test "has_dangerous_patterns detects patterns in input starting with -e" {
+    source "$PROJECT_ROOT/lib/github.sh"
+
+    run has_dangerous_patterns '-e $(whoami)'
+    [ "$status" -eq 0 ]
+}
+
+@test "has_dangerous_patterns detects patterns in input starting with -E" {
+    source "$PROJECT_ROOT/lib/github.sh"
+
+    run has_dangerous_patterns '-E ${HOME}'
+    [ "$status" -eq 0 ]
+}
+
 # ====================
 # get_issue_comments テスト
 # ====================

--- a/test/regression/issue-1280-echo-dash-flags.bats
+++ b/test/regression/issue-1280-echo-dash-flags.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Regression test for Issue #1280
+# echo "$var" mishandles inputs starting with -n, -e, -E
+# Fixed by using printf '%s\n' instead of echo
+
+load '../test_helper'
+
+setup() {
+    source "$PROJECT_ROOT/lib/log.sh"
+    source "$PROJECT_ROOT/lib/github.sh"
+    source "$PROJECT_ROOT/lib/ci-classifier.sh"
+}
+
+# has_dangerous_patterns: inputs starting with echo flags
+
+@test "regression #1280: has_dangerous_patterns detects dangerous pattern in -n prefixed input" {
+    run has_dangerous_patterns '-n $(rm -rf /)'
+    [ "$status" -eq 0 ]
+}
+
+@test "regression #1280: has_dangerous_patterns detects dangerous pattern in -e prefixed input" {
+    run has_dangerous_patterns '-e $(whoami)'
+    [ "$status" -eq 0 ]
+}
+
+@test "regression #1280: has_dangerous_patterns detects dangerous pattern in -E prefixed input" {
+    run has_dangerous_patterns '-E ${PATH}'
+    [ "$status" -eq 0 ]
+}
+
+@test "regression #1280: has_dangerous_patterns detects backtick in -n prefixed input" {
+    run has_dangerous_patterns '-n `id`'
+    [ "$status" -eq 0 ]
+}
+
+# classify_ci_failure: inputs starting with echo flags
+
+@test "regression #1280: classify_ci_failure classifies -n prefixed format error" {
+    run classify_ci_failure '-n Diff in src/main.rs'
+    [ "$status" -eq 0 ]
+    [ "$output" = "format" ]
+}
+
+@test "regression #1280: classify_ci_failure classifies -e prefixed build error" {
+    run classify_ci_failure '-e error[E0308]: expected bool, found i32'
+    [ "$status" -eq 0 ]
+    [ "$output" = "build" ]
+}
+
+@test "regression #1280: classify_ci_failure classifies -E prefixed test failure" {
+    run classify_ci_failure '-E not ok 1 some test'
+    [ "$status" -eq 0 ]
+    [ "$output" = "test" ]
+}


### PR DESCRIPTION
## Summary
Closes #1280

## Changes
- Replace `echo "$var" | grep` with `printf '%s\n' "$var" | grep` in:
  - `lib/github.sh`: 6 occurrences in `has_dangerous_patterns()`
  - `lib/ci-classifier.sh`: 5 occurrences in `classify_ci_failure()`
- Add edge case tests for inputs starting with `-n`, `-e`, `-E` in both test files
- Add regression test: `test/regression/issue-1280-echo-dash-flags.bats`

## Problem
Bash's `echo` builtin interprets `-n`, `-e`, `-E` as flags, causing empty output when input starts with these strings. This could bypass dangerous pattern detection in `has_dangerous_patterns()`.

## Testing
- `bats test/lib/github.bats` - 61 tests passed
- `bats test/lib/ci-classifier.bats` - 44 tests passed (+3 new)
- `bats test/regression/issue-1280-echo-dash-flags.bats` - 7 tests passed
- `shellcheck -x lib/github.sh lib/ci-classifier.sh` - 0 warnings