### PR TITLE
fix: sweep.sh の pipe-pane ログ検索がコードブロック内のマーカーを除外していない

### DIFF
--- a/scripts/sweep.sh
+++ b/scripts/sweep.sh
@@ -138,8 +138,16 @@ check_session_markers() {
         
         if grep -qF "$complete_marker" "$log_file" 2>/dev/null || \
            grep -qF "$alt_complete_marker" "$log_file" 2>/dev/null; then
-            echo "complete"
-            return
+            # コードブロック内のマーカーを除外（watch-session.sh と同じロジック）
+            local log_content
+            log_content=$(cat "$log_file" 2>/dev/null) || log_content=""
+            local verified_count
+            verified_count=$(count_any_markers_outside_codeblock "$log_content" "$complete_marker" "$alt_complete_marker")
+            if [[ "$verified_count" -gt 0 ]]; then
+                echo "complete"
+                return
+            fi
+            log_debug "Marker found but inside code block, ignoring"
         fi
         
         # ERRORマーカーをチェック（オプション）
@@ -149,8 +157,16 @@ check_session_markers() {
             
             if grep -qF "$error_marker" "$log_file" 2>/dev/null || \
                grep -qF "$alt_error_marker" "$log_file" 2>/dev/null; then
-                echo "error"
-                return
+                # コードブロック内のマーカーを除外（watch-session.sh と同じロジック）
+                local err_log_content
+                err_log_content=$(cat "$log_file" 2>/dev/null) || err_log_content=""
+                local err_verified_count
+                err_verified_count=$(count_any_markers_outside_codeblock "$err_log_content" "$error_marker" "$alt_error_marker")
+                if [[ "$err_verified_count" -gt 0 ]]; then
+                    echo "error"
+                    return
+                fi
+                log_debug "Error marker found but inside code block, ignoring"
             fi
         fi
         


### PR DESCRIPTION
## Summary
Closes #1278

## Changes
- `check_session_markers()` の pipe-pane ログパスに `count_any_markers_outside_codeblock()` による検証を追加
- COMPLETE マーカーと ERROR マーカーの両方に適用
- `grep -qF` は高速プリフィルタとして維持し、マッチ後にコードブロック検証を実施
- watch-session.sh の capture-pane フォールバックパスと同じロジック

## Testing
- 3つの新規テストを追加（コードブロック内COMPLETE/ERROR無視、コードブロック外検出）
- `bats test/scripts/sweep.bats` 全26テストパス
- `shellcheck -x scripts/sweep.sh` 警告0件