### PR TITLE
refactor: replace deprecated session_prefix with multiplexer_session_prefix

### DIFF
--- a/lib/multiplexer-tmux.sh
+++ b/lib/multiplexer-tmux.sh
@@ -25,7 +25,7 @@ mux_generate_session_name() {
     
     load_config
     local prefix
-    prefix="$(get_config session_prefix)"
+    prefix="$(get_config multiplexer_session_prefix)"
     
     if [[ "$prefix" == *"-issue" ]]; then
         echo "${prefix}-${issue_number}"
@@ -176,7 +176,7 @@ mux_list_sessions() {
     
     load_config
     local prefix
-    prefix="$(get_config session_prefix)"
+    prefix="$(get_config multiplexer_session_prefix)"
     
     tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^${prefix}" | grep -v "^${prefix}-monitor$" || true
 }

--- a/lib/multiplexer-zellij.sh
+++ b/lib/multiplexer-zellij.sh
@@ -26,7 +26,7 @@ mux_generate_session_name() {
     
     load_config
     local prefix
-    prefix="$(get_config session_prefix)"  # 同じ設定を使用
+    prefix="$(get_config multiplexer_session_prefix)"
     
     if [[ "$prefix" == *"-issue" ]]; then
         echo "${prefix}-${issue_number}"
@@ -183,7 +183,7 @@ mux_list_sessions() {
     
     load_config
     local prefix
-    prefix="$(get_config session_prefix)"
+    prefix="$(get_config multiplexer_session_prefix)"
     
     # Zellijのlist-sessionsの出力から名前を抽出（monitorセッションは除外）
     zellij list-sessions 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | awk '{print $1}' | grep "^${prefix}" | grep -v "^${prefix}-monitor$" || true


### PR DESCRIPTION
## Summary
Closes #1290

## Changes
- Replace `get_config session_prefix` with `get_config multiplexer_session_prefix` in 4 locations:
  - `lib/multiplexer-tmux.sh` L28, L179
  - `lib/multiplexer-zellij.sh` L29, L186

## Testing
- ShellCheck: 0 warnings on both files
- `bats test/lib/multiplexer-tmux.bats`: all 35 tests pass
- `bats test/lib/multiplexer-zellij.bats`: all 36 tests pass
- `bats test/lib/multiplexer.bats test/lib/tmux.bats test/lib/config.bats`: all pass
- Verified no remaining deprecated `session_prefix` usage via grep