### PR TITLE
fix: find_orphaned_statuses() の glob パターンが find_worktree_by_issue() と不一致

### DIFF
--- a/lib/status.sh
+++ b/lib/status.sh
@@ -401,8 +401,10 @@ find_orphaned_statuses() {
         issue_number="$(basename "$status_file" .json)"
         
         # 対応するworktreeが存在するか確認
+        # find_worktree_by_issue() と同じパターンで検索
+        # issue-42 と issue-42-fix-bug の両方にマッチし、issue-421 には誤マッチしない
         local has_worktree=false
-        for dir in "$worktree_base"/issue-"${issue_number}"-*; do
+        for dir in "$worktree_base"/issue-"${issue_number}"-* "$worktree_base"/issue-"${issue_number}"; do
             if [[ -d "$dir" ]]; then
                 has_worktree=true
                 break

--- a/test/lib/status.bats
+++ b/test/lib/status.bats
@@ -334,6 +334,36 @@ teardown() {
     [ -z "$result" ]
 }
 
+@test "find_orphaned_statuses does not misdetect worktree without title suffix" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    # worktreeディレクトリをタイトルサフィックスなしで作成（例: issue-42）
+    local worktree_base="${BATS_TEST_TMPDIR}/.worktrees"
+    mkdir -p "$worktree_base/issue-700"
+    
+    # 対応するステータスファイルを作成
+    save_status "700" "running" "pi-issue-700"
+    
+    # worktreeが存在するので孤立ではない
+    result="$(find_orphaned_statuses)"
+    [[ "$result" != *"700"* ]]
+}
+
+@test "find_orphaned_statuses does not false-match similar issue numbers" {
+    source "$PROJECT_ROOT/lib/status.sh"
+    
+    # issue-4 の worktree を作成（issue-42 とは別）
+    local worktree_base="${BATS_TEST_TMPDIR}/.worktrees"
+    mkdir -p "$worktree_base/issue-4-some-title"
+    
+    # issue-42 のステータスファイルを作成（対応するworktreeなし）
+    save_status "42" "running" "pi-issue-42"
+    
+    # issue-4 の worktree は issue-42 にマッチしないので、42 は孤立
+    result="$(find_orphaned_statuses)"
+    [[ "$result" == *"42"* ]]
+}
+
 # ====================
 # count_orphaned_statuses テスト
 # ====================


### PR DESCRIPTION
## Summary
Closes #1292

## Changes
- `lib/status.sh`: `find_orphaned_statuses()` の glob パターンを修正。`issue-{number}-*` のみだったのを `issue-{number}-*` と `issue-{number}` の両方を検索するように変更。これにより `find_worktree_by_issue()` と同じマッチ動作になる。
- `test/lib/status.bats`: タイトルサフィックスなし worktree の誤判定防止テストと、類似 Issue 番号の誤マッチ防止テストを追加。

## Testing
- `bats test/lib/status.bats` 全68テストパス
- `bats test/lib/cleanup-orphans.bats` 全テストパス
- `shellcheck -x lib/status.sh` 警告0件