### PR TITLE
fix: watch-session.sh のpipe-paneモードで dead code（error_count_current の二重代入）を削除

### DIFF
--- a/scripts/watch-session.sh
+++ b/scripts/watch-session.sh
@@ -769,8 +769,6 @@ run_watch_loop() {
             file_error_count=$(_grep_marker_count_in_file "$output_log" "$error_marker" "$ALT_ERROR_MARKER")
             file_complete_count=$(_grep_marker_count_in_file "$output_log" "$marker" "$ALT_COMPLETE_MARKER")
 
-            # ベースラインのカウントを加算（pipe-paneログはwatcher開始後のみ記録）
-            error_count_current=$((cumulative_error_count - cumulative_error_count + file_error_count))
             # ベースラインにあったカウントは check_initial_markers で処理済みなので
             # ファイル内のカウントがそのまま新規検出数
             error_count_current=$file_error_count


### PR DESCRIPTION
## Summary
Closes #1289

## Changes
- Remove dead code: redundant `error_count_current` assignment in `run_watch_loop()` pipe-pane mode (L773)
- The calculation `cumulative_error_count - cumulative_error_count + file_error_count` simplified to `file_error_count`, identical to the kept assignment

## Testing
- `shellcheck -x scripts/watch-session.sh` — 0 warnings
- `bats test/scripts/watch-session.bats` — all 49 tests pass
- Regression tests pass