### PR TITLE
docs: add {{signal_dir}} template variable to documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,7 @@ GitHub Issue #{{issue_number}} のテストを実行します。
 | `{{branch_name}}` | ブランチ名 | ✅ |
 | `{{worktree_path}}` | worktreeのパス | ✅ |
 | `{{plans_dir}}` | 計画書ディレクトリパス | ✅ |
+| `{{signal_dir}}` | シグナルファイルディレクトリパス | ✅ |
 | `{{step_name}}` | 現在のステップ名 | *カスタム用 |
 | `{{workflow_name}}` | ワークフロー名 | *カスタム用 |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1203,6 +1203,7 @@ agent:
 | `{{step_name}}` | 現在のステップ名 | `plan`, `implement` |
 | `{{workflow_name}}` | ワークフロー名 | `default`, `simple` |
 | `{{plans_dir}}` | 計画書ディレクトリパス | `docs/plans` |
+| `{{signal_dir}}` | シグナルファイルディレクトリパス | `.worktrees/.status` |
 | `{{pr_number}}` | PR番号 | `123` |
 
 **使用例**:


### PR DESCRIPTION
## Summary
Closes #1301

## Changes
- Added `{{signal_dir}}` to AGENTS.md template variables table
- Added `{{signal_dir}}` to docs/configuration.md agent template variables table
- Variable resolves to `.worktrees/.status` directory for signal files

## Context
The `{{signal_dir}}` template variable is defined in `lib/template.sh` and used in 6 agent templates (`agents/*.md`) for signal-based completion detection, but was missing from documentation.

## Testing
- ShellCheck passed
- Documentation-only change, no code logic affected