### PR TITLE
fix: sweep.sh のマーカー検証が pipe-pane ログ全体を bash で逐行処理してパフォーマンスが悪い

### DIFF
--- a/scripts/sweep.sh
+++ b/scripts/sweep.sh
@@ -138,12 +138,9 @@ check_session_markers() {
         
         if grep -qF "$complete_marker" "$log_file" 2>/dev/null || \
            grep -qF "$alt_complete_marker" "$log_file" 2>/dev/null; then
-            # コードブロック内のマーカーを除外（watch-session.sh と同じロジック）
-            local log_content
-            log_content=$(cat "$log_file" 2>/dev/null) || log_content=""
-            local verified_count
-            verified_count=$(count_any_markers_outside_codeblock "$log_content" "$complete_marker" "$alt_complete_marker")
-            if [[ "$verified_count" -gt 0 ]]; then
+            # コードブロック内のマーカーを除外（周辺30行のみ検証で高速化）
+            if verify_marker_outside_codeblock "$log_file" "$complete_marker" "true" || \
+               verify_marker_outside_codeblock "$log_file" "$alt_complete_marker" "true"; then
                 echo "complete"
                 return
             fi
@@ -157,12 +154,9 @@ check_session_markers() {
             
             if grep -qF "$error_marker" "$log_file" 2>/dev/null || \
                grep -qF "$alt_error_marker" "$log_file" 2>/dev/null; then
-                # コードブロック内のマーカーを除外（watch-session.sh と同じロジック）
-                local err_log_content
-                err_log_content=$(cat "$log_file" 2>/dev/null) || err_log_content=""
-                local err_verified_count
-                err_verified_count=$(count_any_markers_outside_codeblock "$err_log_content" "$error_marker" "$alt_error_marker")
-                if [[ "$err_verified_count" -gt 0 ]]; then
+                # コードブロック内のマーカーを除外（周辺30行のみ検証で高速化）
+                if verify_marker_outside_codeblock "$log_file" "$error_marker" "true" || \
+                   verify_marker_outside_codeblock "$log_file" "$alt_error_marker" "true"; then
                     echo "error"
                     return
                 fi


### PR DESCRIPTION
## Summary
Closes #1300

## Changes
- Added `grep_marker_count_in_file`, `verify_marker_outside_codeblock`, and `strip_ansi` to `lib/marker.sh` as shared functions
- `scripts/sweep.sh`: Replaced full-file `cat` + `count_any_markers_outside_codeblock` (bash while-loop over all lines) with `verify_marker_outside_codeblock` (grep -B15 -A15 context extraction, ~30 lines only)
- `scripts/watch-session.sh`: Replaced private `_grep_marker_count_in_file`, `_verify_marker_outside_codeblock`, `_strip_ansi` with thin wrappers to shared library functions
- Added 11 new tests for the shared functions in `test/lib/marker.bats`

## Performance Impact
For large pipe-pane log files (several MB), sweep.sh now processes only ~30 lines around each marker match instead of the entire file, matching the optimization already present in watch-session.sh.

## Testing
- `bats test/lib/marker.bats` - 39/39 pass (11 new tests)
- `bats test/scripts/sweep.bats` - 26/26 pass
- `bats test/scripts/watch-session.bats` - 49/49 pass
- `shellcheck -x scripts/*.sh lib/*.sh lib/ci-fix/*.sh lib/improve/*.sh` - 0 warnings