### PR TITLE
fix: add safe_timeout wrapper for macOS compatibility

### DIFF
--- a/lib/ci-fix/bash.sh
+++ b/lib/ci-fix/bash.sh
@@ -11,6 +11,7 @@ _CI_FIX_BASH_SH_SOURCED="true"
 
 __CI_FIX_BASH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$__CI_FIX_BASH_DIR/log.sh"
+source "$__CI_FIX_BASH_DIR/compat.sh"
 
 # Bashプロジェクトのlint修正
 # Usage: _fix_lint_bash
@@ -85,7 +86,7 @@ _validate_bash() {
             local timeout_sec="${CI_FIX_BATS_TIMEOUT:-120}"
             log_info "Running bats in $test_dir/ (timeout: ${timeout_sec}s)..."
             local exit_code=0
-            timeout "$timeout_sec" bats "$test_dir/" 2>&1 || exit_code=$?
+            safe_timeout "$timeout_sec" bats "$test_dir/" 2>&1 || exit_code=$?
             if [[ $exit_code -ne 0 ]]; then
                 if [[ $exit_code -eq 124 ]]; then
                     log_warn "Bats test timed out after ${timeout_sec}s (skipping)"

--- a/lib/compat.sh
+++ b/lib/compat.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# ============================================================================
+# lib/compat.sh - クロスプラットフォーム互換性ヘルパー
+#
+# macOS と Linux の差異を吸収するユーティリティ関数群。
+#
+# Provides:
+#   - safe_timeout: timeout コマンドのラッパー（macOS互換）
+# ============================================================================
+
+set -euo pipefail
+
+# ソースガード（多重読み込み防止）
+if [[ -n "${_COMPAT_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_COMPAT_SH_SOURCED="true"
+
+# timeout コマンドのラッパー（macOS互換）
+# timeout が利用可能ならそのまま使用、なければタイムアウトなしで実行
+# Usage: safe_timeout <seconds> <command> [args...]
+safe_timeout() {
+    local seconds="$1"
+    shift
+    if command -v timeout &>/dev/null; then
+        timeout "$seconds" "$@"
+    else
+        # タイムアウトなしで実行（macOS標準環境向け）
+        "$@"
+    fi
+}

--- a/lib/generate-config.sh
+++ b/lib/generate-config.sh
@@ -14,6 +14,9 @@
 
 set -euo pipefail
 
+_GENERATE_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_GENERATE_CONFIG_LIB_DIR/compat.sh"
+
 # ============================================================================
 # Project information collection
 # ============================================================================
@@ -271,7 +274,7 @@ generate_with_ai() {
 
     local response
     local exit_code=0
-    response=$(echo "$prompt" | timeout 60 "$pi_command" --print \
+    response=$(echo "$prompt" | safe_timeout 60 "$pi_command" --print \
         --provider "${PI_RUNNER_AUTO_PROVIDER:-anthropic}" \
         --model "${PI_RUNNER_AUTO_MODEL:-claude-haiku-4-5}" \
         --no-tools \

--- a/lib/workflow-selector.sh
+++ b/lib/workflow-selector.sh
@@ -26,6 +26,7 @@ fi
 if ! declare -f get_config &> /dev/null; then
     source "$_WORKFLOW_SELECTOR_LIB_DIR/config.sh"
 fi
+source "$_WORKFLOW_SELECTOR_LIB_DIR/compat.sh"
 
 # ===================
 # メイン関数
@@ -119,7 +120,7 @@ Workflow name:"
 
     # pi --print で非対話実行（タイムアウト15秒）
     local response
-    response=$(echo "$prompt" | timeout 15 "$pi_command" --print \
+    response=$(echo "$prompt" | safe_timeout 15 "$pi_command" --print \
         --provider "$provider" \
         --model "$model" \
         --no-tools \

--- a/test/lib/compat.bats
+++ b/test/lib/compat.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# test/lib/compat.bats - compat.sh のユニットテスト
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+    fi
+    source "$PROJECT_ROOT/lib/compat.sh"
+}
+
+@test "safe_timeout is defined" {
+    declare -f safe_timeout
+}
+
+@test "safe_timeout runs command successfully" {
+    run safe_timeout 10 echo "hello"
+    [ "$status" -eq 0 ]
+    [ "$output" = "hello" ]
+}
+
+@test "safe_timeout passes arguments correctly" {
+    run safe_timeout 10 printf "%s-%s" foo bar
+    [ "$status" -eq 0 ]
+    [ "$output" = "foo-bar" ]
+}
+
+@test "safe_timeout propagates command failure exit code" {
+    run safe_timeout 10 false
+    [ "$status" -ne 0 ]
+}
+
+@test "safe_timeout works when timeout command is not available" {
+    # timeout コマンドを隠す
+    timeout() { :; }
+    unset -f timeout
+    # PATHからtimeoutを除外
+    local orig_path="$PATH"
+    PATH="/usr/bin:/bin"
+    # command -v timeout が失敗する環境でもコマンドが実行される
+    # compat.sh を再読み込み（ソースガードをリセット）
+    unset _COMPAT_SH_SOURCED
+    source "$PROJECT_ROOT/lib/compat.sh"
+    run safe_timeout 10 echo "no-timeout-ok"
+    PATH="$orig_path"
+    [ "$status" -eq 0 ]
+    [ "$output" = "no-timeout-ok" ]
+}
+
+@test "safe_timeout requires seconds argument" {
+    # 引数なしだと shift で失敗する
+    run safe_timeout
+    [ "$status" -ne 0 ]
+}
+
+@test "compat.sh source guard prevents double loading" {
+    # 既に loaded なので再source しても問題ない
+    source "$PROJECT_ROOT/lib/compat.sh"
+    declare -f safe_timeout
+}


### PR DESCRIPTION
## Summary
Closes #1303

## Changes
- Added `lib/compat.sh` with `safe_timeout()` helper function
  - Uses GNU `timeout` when available, falls back to running without timeout on macOS
- Replaced `timeout` with `safe_timeout` in 3 files:
  - `lib/ci-fix/bash.sh` - bats execution in `_validate_bash()`
  - `lib/generate-config.sh` - pi --print execution in `generate_with_ai()`
  - `lib/workflow-selector.sh` - pi --print execution in `_select_workflow_by_ai()`
- Source guard prevents double-loading

## Testing
- Added `test/lib/compat.bats` with 7 unit tests covering:
  - Basic functionality, argument passing, error propagation
  - Behavior when timeout command is unavailable
  - Source guard
- ShellCheck passes with 0 warnings
- All related tests pass (ci-fix, generate-config, workflow-selector, regression)