### PR TITLE
fix: force-complete.sh にシグナルファイル作成を追加

### DIFF
--- a/test/scripts/force-complete.bats
+++ b/test/scripts/force-complete.bats
@@ -115,6 +115,10 @@ teardown() {
     grep -q "lib/log.sh" "$PROJECT_ROOT/scripts/force-complete.sh"
 }
 
+@test "force-complete.sh sources status.sh" {
+    grep -q "lib/status.sh" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
 @test "force-complete.sh sources tmux.sh" {
     grep -q "lib/tmux.sh" "$PROJECT_ROOT/scripts/force-complete.sh"
 }
@@ -169,4 +173,20 @@ teardown() {
 
 @test "force-complete.sh error marker format is correct" {
     grep -q 'TASK_ERROR_.*issue_number' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+# ====================
+# シグナルファイル作成テスト
+# ====================
+
+@test "force-complete.sh creates signal file via get_status_dir" {
+    grep -q "get_status_dir" "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh creates signal-complete file" {
+    grep -q 'signal-complete-' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh creates signal-error file" {
+    grep -q 'signal-error-' "$PROJECT_ROOT/scripts/force-complete.sh"
 }


### PR DESCRIPTION
## Summary
Closes #1314

## Changes
- `scripts/force-complete.sh` に `lib/status.sh` の `get_status_dir` を使ったシグナルファイル作成処理を追加
- 完了時: `signal-complete-{issue_number}` を作成
- エラー時: `signal-error-{issue_number}` を作成
- テキストマーカー送信は後方互換として維持
- テストケース3件追加（status.sh のsource確認、signal-complete/signal-error ファイル作成確認）

## Why
決定記録 [003](docs/decisions/003-signal-file-completion.md) でシグナルファイルが最優先の完了検出方式と定められているが、`force-complete.sh` はテキストマーカーのみ送信していた。これにより `watch-session.sh` での検出信頼性が低下していた。

## Testing
- `bats test/scripts/force-complete.bats` - 32テスト全パス
- `shellcheck -x scripts/force-complete.sh` - 警告なし