### PR TITLE
fix: lib/generate-config.sh にソースガード（多重読み込み防止）を追加

### DIFF
--- a/lib/generate-config.sh
+++ b/lib/generate-config.sh
@@ -14,6 +14,12 @@
 
 set -euo pipefail
 
+# ソースガード（多重読み込み防止）
+if [[ -n "${_GENERATE_CONFIG_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_GENERATE_CONFIG_SH_SOURCED="true"
+
 _GENERATE_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_GENERATE_CONFIG_LIB_DIR/compat.sh"
 


### PR DESCRIPTION
## Summary
Closes #1311

## Changes
- `lib/generate-config.sh` にソースガード（`_GENERATE_CONFIG_SH_SOURCED`）を追加
- 他の全 lib/*.sh ファイルと同じパターンに統一

## Testing
- `bats test/scripts/generate-config.bats` 全36テスト パス
- 全テストスイート（lib/scripts/regression）パス
- ShellCheck クリーン