### PR TITLE
refactor: remove unused backward compatibility wrappers from lib/improve/

### DIFF
--- a/lib/improve/args.sh
+++ b/lib/improve/args.sh
@@ -176,8 +176,3 @@ parse_improve_arguments() {
     _PARSE_review_only="$review_only"
     _PARSE_auto_continue="$auto_continue"
 }
-
-# Backward compatibility: keep old function name
-usage() {
-    show_improve_usage "$@"
-}

--- a/lib/improve/deps.sh
+++ b/lib/improve/deps.sh
@@ -50,8 +50,3 @@ check_improve_dependencies() {
 
     return 0
 }
-
-# Backward compatibility: keep old function name
-check_dependencies() {
-    check_improve_dependencies "$@"
-}

--- a/lib/improve/execution.sh
+++ b/lib/improve/execution.sh
@@ -306,24 +306,3 @@ start_improve_next_iteration() {
     
     exec "$0" "${args[@]}"
 }
-
-# Backward compatibility: keep old function names
-cleanup_on_exit() {
-    cleanup_improve_on_exit "$@"
-}
-
-fetch_created_issues() {
-    fetch_improve_created_issues "$@"
-}
-
-execute_issues_in_parallel() {
-    execute_improve_issues_in_parallel "$@"
-}
-
-wait_for_completion() {
-    wait_for_improve_completion "$@"
-}
-
-start_next_iteration() {
-    start_improve_next_iteration "$@"
-}

--- a/lib/improve/review.sh
+++ b/lib/improve/review.sh
@@ -257,8 +257,3 @@ ${review_context}"
         exit 0
     fi
 }
-
-# Backward compatibility: keep old function name
-run_review_phase() {
-    run_improve_review_phase "$@"
-}

--- a/test/lib/improve.bats
+++ b/test/lib/improve.bats
@@ -91,18 +91,8 @@ teardown() {
 }
 
 # ====================
-# 関数定義テスト (backward compatibility)
+# 関数定義テスト
 # ====================
-
-@test "improve.sh library provides cleanup_on_exit function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F cleanup_on_exit"
-    [ "$status" -eq 0 ]
-}
-
-@test "improve.sh library provides usage function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F usage"
-    [ "$status" -eq 0 ]
-}
 
 @test "improve.sh library provides parse_improve_arguments function" {
     run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F parse_improve_arguments"
@@ -114,52 +104,22 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
-@test "improve.sh library provides run_review_phase function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F run_review_phase"
-    [ "$status" -eq 0 ]
-}
-
-@test "improve.sh library provides fetch_created_issues function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F fetch_created_issues"
-    [ "$status" -eq 0 ]
-}
-
-@test "improve.sh library provides execute_issues_in_parallel function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F execute_issues_in_parallel"
-    [ "$status" -eq 0 ]
-}
-
-@test "improve.sh library provides wait_for_completion function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F wait_for_completion"
-    [ "$status" -eq 0 ]
-}
-
-@test "improve.sh library provides start_next_iteration function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F start_next_iteration"
-    [ "$status" -eq 0 ]
-}
-
-@test "improve.sh library provides check_dependencies function" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && declare -F check_dependencies"
-    [ "$status" -eq 0 ]
-}
-
 @test "improve.sh library has improve_main function" {
     grep -q 'improve_main()' "$PROJECT_ROOT/lib/improve.sh"
 }
 
 # ====================
-# usage() 関数テスト
+# show_improve_usage() 関数テスト
 # ====================
 
-@test "usage function displays help text" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && usage"
+@test "show_improve_usage function displays help text" {
+    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && show_improve_usage"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
 }
 
-@test "usage function shows all options" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && usage"
+@test "show_improve_usage function shows all options" {
+    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && show_improve_usage"
     [[ "$output" == *"--max-iterations"* ]]
     [[ "$output" == *"--max-issues"* ]]
     [[ "$output" == *"--timeout"* ]]
@@ -170,13 +130,13 @@ teardown() {
     [[ "$output" == *"--auto-continue"* ]]
 }
 
-@test "usage function shows description" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && usage"
+@test "show_improve_usage function shows description" {
+    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && show_improve_usage"
     [[ "$output" == *"Description:"* ]]
 }
 
-@test "usage function shows examples" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && usage"
+@test "show_improve_usage function shows examples" {
+    run bash -c "source '$PROJECT_ROOT/lib/improve.sh' && show_improve_usage"
     [[ "$output" == *"Examples:"* ]]
 }
 
@@ -272,12 +232,11 @@ teardown() {
 }
 
 # ====================
-# check_dependencies() 関数テスト
+# check_improve_dependencies() 関数テスト
 # ====================
 
-@test "check_dependencies function exists in deps module" {
-    grep -q 'check_improve_dependencies()' "$PROJECT_ROOT/lib/improve/deps.sh" || \
-    grep -q 'check_dependencies()' "$PROJECT_ROOT/lib/improve/deps.sh"
+@test "check_improve_dependencies function exists in deps module" {
+    grep -q 'check_improve_dependencies()' "$PROJECT_ROOT/lib/improve/deps.sh"
 }
 
 @test "check_dependencies checks for pi command" {
@@ -333,10 +292,10 @@ teardown() {
 }
 
 # ====================
-# cleanup_on_exit() 関数テスト
+# cleanup_improve_on_exit() 関数テスト
 # ====================
 
-@test "cleanup_on_exit function handles active sessions (Issue #1106)" {
+@test "cleanup_improve_on_exit function handles active sessions (Issue #1106)" {
     source_content=$(cat "$PROJECT_ROOT/lib/improve/execution.sh")
     # Should use file-based tracking instead of ACTIVE_ISSUE_NUMBERS
     [[ "$source_content" == *'get_improve_active_issues'* ]]

--- a/test/lib/improve/args.bats
+++ b/test/lib/improve/args.bats
@@ -73,12 +73,6 @@ teardown() {
     [[ "$output" == *"Examples:"* ]]
 }
 
-@test "usage() is backward compatible wrapper" {
-    run bash -c "source '$PROJECT_ROOT/lib/improve/args.sh' && usage"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Usage: improve.sh"* ]]
-}
-
 # ====================
 # parse_improve_arguments() - Normal Cases
 # ====================

--- a/test/lib/improve/deps.bats
+++ b/test/lib/improve/deps.bats
@@ -219,16 +219,6 @@ EOF
 # Backward Compatibility
 # ====================
 
-@test "check_dependencies() is backward compatible wrapper" {
-    grep -q 'check_dependencies()' "$PROJECT_ROOT/lib/improve/deps.sh"
-}
-
-@test "check_dependencies() calls check_improve_dependencies()" {
-    source_content=$(cat "$PROJECT_ROOT/lib/improve/deps.sh")
-    # Check that backward compat wrapper exists and calls the new function
-    [[ "$source_content" =~ check_dependencies[[:space:]]*\(\)[[:space:]]*\{[[:space:]]*check_improve_dependencies ]]
-}
-
 # ====================
 # Output Format Tests
 # ====================

--- a/test/lib/improve/execution.bats
+++ b/test/lib/improve/execution.bats
@@ -631,41 +631,6 @@ EOF
 }
 
 # ====================
-# Backward Compatibility Tests
-# ====================
-
-@test "cleanup_on_exit() is backward compatible wrapper" {
-    grep -q 'cleanup_on_exit()' "$PROJECT_ROOT/lib/improve/execution.sh"
-}
-
-@test "fetch_created_issues() is backward compatible wrapper" {
-    grep -q 'fetch_created_issues()' "$PROJECT_ROOT/lib/improve/execution.sh"
-}
-
-@test "execute_issues_in_parallel() is backward compatible wrapper" {
-    grep -q 'execute_issues_in_parallel()' "$PROJECT_ROOT/lib/improve/execution.sh"
-}
-
-@test "wait_for_completion() is backward compatible wrapper" {
-    grep -q 'wait_for_completion()' "$PROJECT_ROOT/lib/improve/execution.sh"
-}
-
-@test "start_next_iteration() is backward compatible wrapper" {
-    grep -q 'start_next_iteration()' "$PROJECT_ROOT/lib/improve/execution.sh"
-}
-
-@test "all backward compatibility wrappers call new function names" {
-    source_content=$(cat "$PROJECT_ROOT/lib/improve/execution.sh")
-    
-    # Check each wrapper calls the _improve_ version
-    [[ "$source_content" =~ cleanup_on_exit\(\).*cleanup_improve_on_exit ]]
-    [[ "$source_content" =~ fetch_created_issues\(\).*fetch_improve_created_issues ]]
-    [[ "$source_content" =~ execute_issues_in_parallel\(\).*execute_improve_issues_in_parallel ]]
-    [[ "$source_content" =~ wait_for_completion\(\).*wait_for_improve_completion ]]
-    [[ "$source_content" =~ start_next_iteration\(\).*start_improve_next_iteration ]]
-}
-
-# ====================
 # Phase Markers Tests
 # ====================
 

--- a/test/lib/improve/review.bats
+++ b/test/lib/improve/review.bats
@@ -471,16 +471,6 @@ EOF
 # Backward Compatibility
 # ====================
 
-@test "run_review_phase() is backward compatible wrapper" {
-    grep -q 'run_review_phase()' "$PROJECT_ROOT/lib/improve/review.sh"
-}
-
-@test "run_review_phase() calls run_improve_review_phase()" {
-    source_content=$(cat "$PROJECT_ROOT/lib/improve/review.sh")
-    # Check that backward compat wrapper exists and calls the new function
-    [[ "$source_content" =~ run_review_phase\(\).*run_improve_review_phase ]]
-}
-
 # ====================
 # Prompt Content Verification
 # ====================


### PR DESCRIPTION
## Summary
Closes #1320

## Changes
- Removed 8 unused backward compatibility wrapper functions from `lib/improve/` submodules:
  - `args.sh`: `usage()`
  - `deps.sh`: `check_dependencies()` (also eliminates shadowing risk with `lib/github.sh`)
  - `execution.sh`: `cleanup_on_exit()`, `fetch_created_issues()`, `execute_issues_in_parallel()`, `wait_for_completion()`, `start_next_iteration()`
  - `review.sh`: `run_review_phase()`
- Updated test files to remove backward compatibility assertion tests
- Updated test names to reference new function names (`show_improve_usage`, `check_improve_dependencies`, etc.)

## Testing
- All 227 improve-related tests pass (`bats test/lib/improve/*.bats test/lib/improve.bats`)
- ShellCheck passes on all modified files
- Verified old function names no longer exist in `lib/improve/` via grep