### PR TITLE
docs: add .github/actions/setup-deps/ to AGENTS.md directory structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@
 ```
 pi-issue-runner/
 ├── .github/
+│   ├── actions/
+│   │   └── setup-deps/
+│   │       └── action.yaml    # CI依存セットアップ（Bats, yq, tmux）
 │   └── workflows/
 │       └── ci.yaml    # CI設定
 ├── SKILL.md           # スキル定義（必須）


### PR DESCRIPTION
## Summary
Closes #1340

## Changes
- Added missing `.github/actions/setup-deps/action.yaml` to the directory structure section in AGENTS.md
- This CI composite action manages installation and caching of Bats, yq, and tmux dependencies

## Testing
- Verified directory structure in AGENTS.md now matches actual file structure (`find .github -type f`)
- Documentation-only change, no code logic affected