### PR TITLE
docs: add missing test/regression/ and test/fixtures/ to architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,6 +177,8 @@ pi-issue-runner/
 ├── test/              # Batsテスト
 │   ├── lib/           # ライブラリテスト
 │   ├── scripts/       # スクリプトテスト
+│   ├── regression/    # 回帰テスト
+│   ├── fixtures/      # テスト用フィクスチャ
 │   └── test_helper.bash
 ├── .worktrees/        # worktree作業ディレクトリ（実行時生成）
 │   ├── issue-42-*/


### PR DESCRIPTION
## Summary
Closes #1348

## Changes
- Added `test/regression/` directory to the directory structure section in `docs/architecture.md`
- Added `test/fixtures/` directory to the directory structure section in `docs/architecture.md`
- Ensures consistency with actual project structure and AGENTS.md
- Note: `agents/improve-review.md` was already present in the file

## Testing
- Verified all mentioned files and directories exist in the project
- Verified file counts match (7 agent templates, 4 test directories)
- Changes are documentation-only and low-risk