### PR TITLE
docs: architecture.md のスクリプト一覧に scripts/generate-config.sh を追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,7 @@ pi-issue-runner/
 │   ├── ci-fix-helper.sh  # CI修正ヘルパー
 │   ├── context.sh     # コンテキスト管理
 │   ├── dashboard.sh   # ダッシュボード表示
+│   ├── generate-config.sh  # プロジェクト解析・設定生成
 │   ├── force-complete.sh  # セッション強制完了
 │   ├── improve.sh     # 継続的改善
 │   ├── next.sh        # 次のタスク取得


### PR DESCRIPTION
## Summary
Closes #1345

## Changes
- Added `scripts/generate-config.sh` to the directory structure listing in `docs/architecture.md`
- The entry was present in lib/ section and AGENTS.md but missing from scripts/ section
- Maintains consistency between documentation and actual files in scripts/ directory

## Details
- **sweep.sh**: Already present in the documentation
- **generate-config.sh**: Was missing from scripts/ section, now added between `dashboard.sh` and `force-complete.sh` to match AGENTS.md ordering

## Testing
- Verified that documented scripts match actual files: `diff <(ls scripts/*.sh | sed 's|scripts/||' | sort) <(sed -n '88,111p' docs/architecture.md | grep -oE '[a-z-]+\.sh' | sort)` shows no differences
- Documentation-only change, no functional impact