### PR TITLE
fix: force-complete.sh の --message オプションがシングルクォートを含む文字列で壊れる

### DIFF
--- a/scripts/force-complete.sh
+++ b/scripts/force-complete.sh
@@ -159,12 +159,16 @@ main() {
 
     # セッションにマーカーを送信
     # echoコマンドを送信して改行を含む出力を強制
-    send_keys "$session_name" "echo '$marker'"
+    # markerは固定形式(###TASK_COMPLETE_N###)のためダブルクォートで安全
+    local escaped_marker="${marker//\"/\\\"}"
+    send_keys "$session_name" "echo \"$escaped_marker\""
 
     # カスタムメッセージがある場合は追加送信
+    # ユーザー入力のためシングルクォート・ダブルクォートの両方をエスケープ
     if [[ -n "$custom_message" ]]; then
         log_info "Sending custom message: $custom_message"
-        send_keys "$session_name" "echo '$custom_message'"
+        local escaped_message="${custom_message//\"/\\\"}"
+        send_keys "$session_name" "echo \"$escaped_message\""
     fi
 
     log_info "Marker sent. watch-session.sh will detect and cleanup."

--- a/test/regression/issue-1338-force-complete-quotes.bats
+++ b/test/regression/issue-1338-force-complete-quotes.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Regression test for Issue #1338
+# force-complete.sh --message with single quotes should not break
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+
+    export PI_RUNNER_MULTIPLEXER_TYPE="tmux"
+    unset _CONFIG_LOADED
+    unset _MUX_TYPE
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# クォート処理の検証
+# ====================
+
+@test "force-complete.sh uses double-quote escaping for marker (not single quotes)" {
+    # マーカー送信がダブルクォートを使用していることを確認
+    # シングルクォートで囲む旧パターンが存在しないこと
+    run grep -n "send_keys.*echo '.*marker'" "$PROJECT_ROOT/scripts/force-complete.sh"
+    [ "$status" -ne 0 ]  # マッチしない = シングルクォートパターンがない
+}
+
+@test "force-complete.sh uses double-quote escaping for custom_message (not single quotes)" {
+    # カスタムメッセージ送信がダブルクォートを使用していることを確認
+    run grep -n "send_keys.*echo '.*custom_message'" "$PROJECT_ROOT/scripts/force-complete.sh"
+    [ "$status" -ne 0 ]  # マッチしない = シングルクォートパターンがない
+}
+
+@test "force-complete.sh escapes double quotes in marker" {
+    grep -q 'escaped_marker=.*marker.*\\"' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh escapes double quotes in custom_message" {
+    grep -q 'escaped_message=.*custom_message.*\\"' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh send_keys uses escaped_marker with double quotes" {
+    grep -q 'send_keys.*"echo \\".*escaped_marker' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+@test "force-complete.sh send_keys uses escaped_message with double quotes" {
+    grep -q 'send_keys.*"echo \\".*escaped_message' "$PROJECT_ROOT/scripts/force-complete.sh"
+}
+
+# ====================
+# エスケープロジック検証（ユニットテスト的）
+# ====================
+
+@test "bash parameter expansion correctly escapes double quotes" {
+    # force-complete.shで使用しているエスケープパターンの検証
+    local input='Said "hello" world'
+    local escaped="${input//\"/\\\"}"
+    [ "$escaped" = 'Said \"hello\" world' ]
+}
+
+@test "bash parameter expansion leaves single quotes intact" {
+    # シングルクォートはダブルクォート内では特殊文字ではないため、そのまま
+    local input="User's task is done"
+    local escaped="${input//\"/\\\"}"
+    [ "$escaped" = "User's task is done" ]
+}
+
+@test "bash parameter expansion handles mixed quotes" {
+    local input="User's \"task\" is done"
+    local escaped="${input//\"/\\\"}"
+    [ "$escaped" = "User's \\\"task\\\" is done" ]
+}
+
+@test "marker format does not contain problematic characters" {
+    # マーカーは ###TASK_COMPLETE_N### 形式で、クォートを含まない
+    local issue_number=42
+    local marker="###TASK_COMPLETE_${issue_number}###"
+    local escaped="${marker//\"/\\\"}"
+    # エスケープ前後で変化なし（ダブルクォートを含まないため）
+    [ "$marker" = "$escaped" ]
+}


### PR DESCRIPTION
## Summary
Closes #1338

## Changes
- `scripts/force-complete.sh`: `send_keys` の echo コマンドをシングルクォートからダブルクォート（エスケープ済み）に変更
  - `echo '$marker'` → `echo \"$escaped_marker\"`
  - `echo '$custom_message'` → `echo \"$escaped_message\"`
  - ダブルクォートは `${var//\"/\\\"}` でエスケープ
- `test/regression/issue-1338-force-complete-quotes.bats`: 回帰テスト追加（10テストケース）

## Testing
- `bats test/scripts/force-complete.bats` - 全32テストパス
- `bats test/regression/issue-1338-force-complete-quotes.bats` - 全10テストパス
- `shellcheck -x scripts/force-complete.sh` - 警告なし
- シングルクォート・ダブルクォート・混合クォートのエスケープ検証済み