### PR TITLE
fix: include test/lib/ci-fix/*.bats (71 tests) in CI and scripts/test.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
             pattern: "improve.bats improve/*.bats dependency.bats priority.bats session-resolver.bats cleanup-improve-logs.bats"
           # Shard 3: multiplexer系 + batch + ci系 + dashboard + log (~281 tests, medium)
           - shard: "3/4"
-            pattern: "multiplexer*.bats tmux.bats batch.bats ci-*.bats context.bats dashboard.bats log.bats"
+            pattern: "multiplexer*.bats tmux.bats batch.bats ci-*.bats ci-fix/*.bats context.bats dashboard.bats log.bats"
           # Shard 4: その他 (~216 tests, medium-heavy)
             # agent, cleanup-orphans, cleanup-plans, daemon, hooks,
             # marker, notify, template, worktree
@@ -70,6 +70,7 @@ jobs:
             # Shard 3: multiplexer系 + batch + ci系 + dashboard + log
             MATCHED+=" $(ls test/lib/multiplexer*.bats test/lib/tmux.bats test/lib/batch.bats 2>/dev/null)"
             MATCHED+=" $(ls test/lib/ci-*.bats test/lib/context.bats test/lib/dashboard.bats test/lib/log.bats 2>/dev/null)"
+            MATCHED+=" $(ls test/lib/ci-fix/*.bats 2>/dev/null)"
 
             # Get all lib test files, exclude matched ones
             for f in test/lib/*.bats; do

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -193,6 +193,7 @@ run_bats_tests() {
                 # lib直下 + lib/improve/ のサブディレクトリ
                 for f in "$TEST_DIR"/lib/*.bats; do [[ -f "$f" ]] && test_files+=("$f"); done
                 for f in "$TEST_DIR"/lib/improve/*.bats; do [[ -f "$f" ]] && test_files+=("$f"); done
+                for f in "$TEST_DIR"/lib/ci-fix/*.bats; do [[ -f "$f" ]] && test_files+=("$f"); done
                 ;;
             scripts)
                 for f in "$TEST_DIR"/scripts/*.bats; do [[ -f "$f" ]] && test_files+=("$f"); done


### PR DESCRIPTION
## Summary
Closes #1337

## Changes
- **`.github/workflows/ci.yaml`**: Added `ci-fix/*.bats` to Shard 3 pattern and REMAINING exclusion list so 71 ci-fix sub-module tests are executed in CI
- **`scripts/test.sh`**: Added `ci-fix/` subdirectory glob when collecting lib tests, matching the existing `improve/` pattern

## Testing
- `bats test/lib/ci-fix/*.bats` — 71 tests, 0 failures
- `./scripts/test.sh lib` — 727 tests pass (previously 656, now includes 71 ci-fix tests)
- `shellcheck -x scripts/test.sh` — clean