### PR TITLE
feat: 知識ループ自動化（knowledge-loop）- fixコミットからAGENTS.md更新を提案

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ pi-issue-runner/
 │   ├── generate-config.sh  # プロジェクト解析・設定生成
 │   ├── force-complete.sh  # セッション強制完了
 │   ├── improve.sh     # 継続的改善スクリプト
+│   ├── knowledge-loop.sh  # 知識ループ（fixコミットから知見抽出・AGENTS.md更新提案）
 │   ├── next.sh        # 次のタスク取得
 │   ├── nudge.sh       # セッションへメッセージ送信
 │   ├── test.sh        # テスト一括実行
@@ -81,6 +82,7 @@ pi-issue-runner/
 │   ├── github.sh      # GitHub CLI操作
 │   ├── hooks.sh       # Hook機能
 │   ├── improve.sh     # 継続的改善ライブラリ（オーケストレーター）
+│   ├── knowledge-loop.sh  # 知識ループコアライブラリ
 │   ├── improve/       # 継続的改善モジュール群
 │   │   ├── args.sh    # 引数解析
 │   │   ├── deps.sh    # 依存関係チェック
@@ -178,6 +180,7 @@ pi-issue-runner/
 │   │   │   ├── execution.bats
 │   │   │   └── review.bats
 │   │   ├── improve.bats
+│   │   ├── knowledge-loop.bats  # knowledge-loop.sh のテスト
 │   │   ├── log.bats
 │   │   ├── marker.bats           # marker.sh のテスト
 │   │   ├── notify.bats
@@ -206,6 +209,7 @@ pi-issue-runner/
 │   │   ├── force-complete.bats  # force-complete.sh のテスト
 │   │   ├── generate-config.bats  # generate-config.sh のテスト
 │   │   ├── improve.bats
+│   │   ├── knowledge-loop.bats  # knowledge-loop.sh のテスト
 │   │   ├── init.bats
 │   │   ├── list.bats
 │   │   ├── mux-all.bats         # mux-all.sh のテスト

--- a/lib/improve/review.sh
+++ b/lib/improve/review.sh
@@ -15,6 +15,11 @@ _REVIEW_SH_SOURCED="true"
 
 _REVIEW_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Source knowledge-loop for review context enrichment
+if [[ -z "${_KNOWLEDGE_LOOP_SH_SOURCED:-}" ]]; then
+    source "$_REVIEW_LIB_DIR/../knowledge-loop.sh"
+fi
+
 # ============================================================================
 # Find review prompt template file
 # Search order:
@@ -148,7 +153,16 @@ ${prev_summary}
         fi
     fi
 
-    # 4. AGENTS.md の既知の制約
+    # 4. Knowledge Loop: fix commitからの知見注入
+    local knowledge_context=""
+    if declare -f collect_knowledge_context &>/dev/null; then
+        knowledge_context="$(collect_knowledge_context "1 week ago" "." 2>/dev/null)" || knowledge_context=""
+        if [[ -n "$knowledge_context" ]]; then
+            context+="$knowledge_context"
+        fi
+    fi
+
+    # 5. AGENTS.md の既知の制約
     local agents_constraints=""
     if [[ -f "AGENTS.md" ]]; then
         agents_constraints=$(sed -n '/## 既知の制約/,/^## /p' "AGENTS.md" 2>/dev/null | head -20) || agents_constraints=""

--- a/lib/knowledge-loop.sh
+++ b/lib/knowledge-loop.sh
@@ -1,0 +1,578 @@
+#!/usr/bin/env bash
+# ============================================================================
+# knowledge-loop.sh - Knowledge Loop: Extract constraints from fix commits
+#
+# Analyzes fix: commits and docs/decisions/ to extract constraints and lessons,
+# then proposes additions to AGENTS.md's "既知の制約" section.
+#
+# Provides:
+#   - extract_fix_commits: Extract fix: commits within a time range
+#   - extract_new_decisions: Find recently added decision files
+#   - extract_tracker_failures: Analyze failure patterns from tracker.jsonl
+#   - check_agents_duplicates: Check if a constraint is already in AGENTS.md
+#   - generate_knowledge_proposals: Generate proposal text
+#   - apply_knowledge_proposals: Append proposals to AGENTS.md
+#   - collect_knowledge_context: Collect knowledge for review context injection
+# ============================================================================
+
+set -euo pipefail
+
+# ソースガード（多重読み込み防止）
+if [[ -n "${_KNOWLEDGE_LOOP_SH_SOURCED:-}" ]]; then
+    return 0
+fi
+_KNOWLEDGE_LOOP_SH_SOURCED="true"
+
+_KNOWLEDGE_LOOP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 依存ライブラリの読み込み（未読み込みの場合のみ）
+if ! declare -f log_info &>/dev/null; then
+    source "$_KNOWLEDGE_LOOP_LIB_DIR/log.sh"
+fi
+
+if ! declare -f get_config &>/dev/null; then
+    source "$_KNOWLEDGE_LOOP_LIB_DIR/config.sh"
+fi
+
+# ============================================================================
+# Fix commit extraction
+# ============================================================================
+
+# Extract fix: commits within a time range
+# Arguments: $1=since (git date string, e.g. "1 week ago"), $2=project_root (optional)
+# Output: One line per commit: "<hash> <subject>"
+extract_fix_commits() {
+    local since="${1:-1 week ago}"
+    local project_root="${2:-.}"
+
+    if ! git -C "$project_root" rev-parse --git-dir &>/dev/null; then
+        return 0
+    fi
+
+    git -C "$project_root" log \
+        --grep="^fix:" \
+        --since="$since" \
+        --format="%h %s" \
+        --no-merges 2>/dev/null || true
+}
+
+# Get diff summary for a commit
+# Arguments: $1=commit_hash, $2=project_root (optional)
+# Output: diff stat lines
+get_commit_diff_summary() {
+    local commit_hash="$1"
+    local project_root="${2:-.}"
+
+    git -C "$project_root" diff-tree --no-commit-id -r --stat "$commit_hash" 2>/dev/null || true
+}
+
+# Get commit message body (full, not just subject)
+# Arguments: $1=commit_hash, $2=project_root (optional)
+# Output: commit body text
+get_commit_body() {
+    local commit_hash="$1"
+    local project_root="${2:-.}"
+
+    git -C "$project_root" log -1 --format="%b" "$commit_hash" 2>/dev/null || true
+}
+
+# ============================================================================
+# Decision file extraction
+# ============================================================================
+
+# Extract recently added decision files
+# Arguments: $1=since (git date string), $2=project_root (optional)
+# Output: One line per file: "<hash> <filepath>"
+extract_new_decisions() {
+    local since="${1:-1 week ago}"
+    local project_root="${2:-.}"
+
+    if ! git -C "$project_root" rev-parse --git-dir &>/dev/null; then
+        return 0
+    fi
+
+    # Find commits that added files in docs/decisions/
+    git -C "$project_root" log \
+        --since="$since" \
+        --diff-filter=A \
+        --format="%h" \
+        --no-merges \
+        -- "docs/decisions/*.md" 2>/dev/null | while IFS= read -r hash; do
+        [[ -z "$hash" ]] && continue
+        # Get the added file paths
+        local files
+        files="$(git -C "$project_root" diff-tree --no-commit-id -r --diff-filter=A --name-only "$hash" -- "docs/decisions/*.md" 2>/dev/null)" || continue
+        while IFS= read -r filepath; do
+            [[ -z "$filepath" ]] && continue
+            # Skip README.md
+            [[ "$filepath" == "docs/decisions/README.md" ]] && continue
+            printf '%s %s\n' "$hash" "$filepath"
+        done <<< "$files"
+    done
+}
+
+# Get decision file title (first heading)
+# Arguments: $1=filepath, $2=project_root (optional)
+# Output: title text
+get_decision_title() {
+    local filepath="$1"
+    local project_root="${2:-.}"
+    local full_path="$project_root/$filepath"
+
+    if [[ ! -f "$full_path" ]]; then
+        return 0
+    fi
+
+    grep -m1 '^#' "$full_path" 2>/dev/null | sed 's/^#* *//' || true
+}
+
+# ============================================================================
+# Tracker failure analysis (optional, depends on #1298)
+# ============================================================================
+
+# Extract failure patterns from tracker.jsonl
+# Arguments: $1=since (git date string), $2=project_root (optional)
+# Output: One line per failure pattern: "<count> <error_type>"
+extract_tracker_failures() {
+    local since="${1:-1 week ago}"
+    local project_root="${2:-.}"
+
+    # Find tracker file
+    local tracker_file=""
+    local status_dir="$project_root/.worktrees/.status"
+    if [[ -f "$status_dir/tracker.jsonl" ]]; then
+        tracker_file="$status_dir/tracker.jsonl"
+    fi
+
+    if [[ -z "$tracker_file" || ! -f "$tracker_file" ]]; then
+        return 0
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        return 0
+    fi
+
+    # Count error_type occurrences
+    jq -r 'select(.result == "error") | .error_type // "unknown"' "$tracker_file" 2>/dev/null \
+        | sort | uniq -c | sort -rn || true
+}
+
+# ============================================================================
+# AGENTS.md duplicate checking
+# ============================================================================
+
+# Check if a constraint text is already present in AGENTS.md
+# Arguments: $1=constraint_text, $2=agents_file (optional, default AGENTS.md)
+# Returns: 0 if duplicate found, 1 if not found
+check_agents_duplicate() {
+    local constraint_text="$1"
+    local agents_file="${2:-AGENTS.md}"
+
+    if [[ ! -f "$agents_file" ]]; then
+        return 1
+    fi
+
+    # Extract keywords from constraint text (at least 3 chars, take first 5 words)
+    local keywords
+    keywords="$(printf '%s' "$constraint_text" | tr -cs '[:alnum:]' '\n' | awk 'length >= 3' | head -5)"
+
+    if [[ -z "$keywords" ]]; then
+        return 1
+    fi
+
+    # Check if any keyword appears in the 既知の制約 section
+    local constraints_section
+    constraints_section="$(sed -n '/## 既知の制約/,/^## /p' "$agents_file" 2>/dev/null)" || constraints_section=""
+
+    if [[ -z "$constraints_section" ]]; then
+        return 1
+    fi
+
+    local keyword match_count=0
+    while IFS= read -r keyword; do
+        [[ -z "$keyword" ]] && continue
+        if printf '%s' "$constraints_section" | grep -qi "$keyword" 2>/dev/null; then
+            match_count=$((match_count + 1))
+        fi
+    done <<< "$keywords"
+
+    # If more than half of keywords match, consider it a duplicate
+    local keyword_count
+    keyword_count="$(printf '%s\n' "$keywords" | wc -l | tr -d ' ')"
+    if [[ "$keyword_count" -gt 0 ]] && [[ "$match_count" -gt $((keyword_count / 2)) ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+# ============================================================================
+# Proposal generation
+# ============================================================================
+
+# Generate knowledge proposals from fix commits and decisions
+# Arguments: $1=since (git date string), $2=project_root (optional)
+# Output: Formatted proposal text to stdout
+generate_knowledge_proposals() {
+    local since="${1:-1 week ago}"
+    local project_root="${2:-.}"
+    local agents_file="$project_root/AGENTS.md"
+
+    local proposal_count=0
+    local proposals=""
+
+    # 1. Extract from fix commits
+    local fix_commits
+    fix_commits="$(extract_fix_commits "$since" "$project_root")"
+
+    if [[ -n "$fix_commits" ]]; then
+        local commit_count
+        commit_count="$(printf '%s\n' "$fix_commits" | wc -l | tr -d ' ')"
+        log_debug "Found $commit_count fix commits"
+
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash subject
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
+
+            # Strip "fix: " prefix for constraint text
+            local constraint
+            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
+
+            # Check for duplicates in AGENTS.md
+            if check_agents_duplicate "$constraint" "$agents_file"; then
+                log_debug "Skipping duplicate: $constraint"
+                continue
+            fi
+
+            proposal_count=$((proposal_count + 1))
+
+            # Get commit body for additional context
+            local body
+            body="$(get_commit_body "$hash" "$project_root")"
+
+            proposals+="
+${proposal_count}. ${constraint}
+   Source: fix: ${subject} (${hash})
+"
+            if [[ -n "$body" ]]; then
+                # Take first non-empty line of body as reason
+                local reason
+                reason="$(printf '%s' "$body" | grep -v '^$' | head -1)"
+                if [[ -n "$reason" ]]; then
+                    proposals+="   Reason: ${reason}
+"
+                fi
+            fi
+        done <<< "$fix_commits"
+    fi
+
+    # 2. Extract from new decision files
+    local new_decisions
+    new_decisions="$(extract_new_decisions "$since" "$project_root")"
+
+    if [[ -n "$new_decisions" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash filepath
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
+
+            local title
+            title="$(get_decision_title "$filepath" "$project_root")"
+            if [[ -z "$title" ]]; then
+                title="$filepath"
+            fi
+
+            # Check for duplicates
+            if check_agents_duplicate "$title" "$agents_file"; then
+                log_debug "Skipping duplicate decision: $title"
+                continue
+            fi
+
+            proposal_count=$((proposal_count + 1))
+            proposals+="
+${proposal_count}. ${title}
+   Source: ${filepath} (${hash})
+   Detail: See ${filepath}
+"
+        done <<< "$new_decisions"
+    fi
+
+    # 3. Check tracker failures (optional)
+    local tracker_failures
+    tracker_failures="$(extract_tracker_failures "$since" "$project_root")"
+
+    if [[ -n "$tracker_failures" ]]; then
+        local has_tracker_header=false
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local count error_type
+            count="$(printf '%s' "$line" | awk '{print $1}')"
+            error_type="$(printf '%s' "$line" | awk '{print $2}')"
+
+            # Only report frequent failures (3+ occurrences)
+            if [[ "$count" -ge 3 ]]; then
+                if [[ "$has_tracker_header" == "false" ]]; then
+                    has_tracker_header=true
+                fi
+                proposal_count=$((proposal_count + 1))
+                proposals+="
+${proposal_count}. [failure pattern] ${error_type} occurred ${count} times
+   Source: tracker.jsonl analysis
+   Action: Consider adding error handling or documentation
+"
+            fi
+        done <<< "$tracker_failures"
+    fi
+
+    # Output report
+    printf '=== Knowledge Loop Analysis (since: %s) ===\n' "$since"
+    printf '\n'
+
+    if [[ "$proposal_count" -eq 0 ]]; then
+        printf 'No new constraints found.\n'
+        return 0
+    fi
+
+    local fix_count=0
+    if [[ -n "$fix_commits" ]]; then
+        fix_count="$(printf '%s\n' "$fix_commits" | wc -l | tr -d ' ')"
+    fi
+
+    printf 'Found %d new constraint(s) from %d fix commit(s):\n' "$proposal_count" "$fix_count"
+    printf '%s\n' "$proposals"
+
+    # Generate suggested AGENTS.md additions
+    printf 'Suggested AGENTS.md additions (既知の制約 section):\n'
+    # Re-parse proposals to generate one-liner additions
+    local idx=0
+    if [[ -n "$fix_commits" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash subject
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
+            local constraint
+            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
+            if check_agents_duplicate "$constraint" "$agents_file"; then
+                continue
+            fi
+            idx=$((idx + 1))
+            printf '  - %s (from commit %s)\n' "$constraint" "$hash"
+        done <<< "$fix_commits"
+    fi
+
+    if [[ -n "$new_decisions" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash filepath
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
+            local title
+            title="$(get_decision_title "$filepath" "$project_root")"
+            if [[ -z "$title" ]]; then
+                title="$filepath"
+            fi
+            if check_agents_duplicate "$title" "$agents_file"; then
+                continue
+            fi
+            # shellcheck disable=SC2016
+            printf '  - %s -> [詳細](%s)\n' "$title" "$filepath"
+        done <<< "$new_decisions"
+    fi
+}
+
+# ============================================================================
+# Apply proposals to AGENTS.md
+# ============================================================================
+
+# Append knowledge proposals to AGENTS.md's 既知の制約 section
+# Arguments: $1=since, $2=project_root (optional)
+# Returns: 0=applied, 1=nothing to apply, 2=AGENTS.md not found
+apply_knowledge_proposals() {
+    local since="${1:-1 week ago}"
+    local project_root="${2:-.}"
+    local agents_file="$project_root/AGENTS.md"
+
+    if [[ ! -f "$agents_file" ]]; then
+        log_error "AGENTS.md not found at: $agents_file"
+        return 2
+    fi
+
+    # Collect entries to add
+    local entries=""
+    local entry_count=0
+
+    # From fix commits
+    local fix_commits
+    fix_commits="$(extract_fix_commits "$since" "$project_root")"
+
+    if [[ -n "$fix_commits" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash subject
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
+            local constraint
+            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
+            if check_agents_duplicate "$constraint" "$agents_file"; then
+                continue
+            fi
+            entry_count=$((entry_count + 1))
+            entries+="- ${constraint} (${hash})
+"
+        done <<< "$fix_commits"
+    fi
+
+    # From decision files
+    local new_decisions
+    new_decisions="$(extract_new_decisions "$since" "$project_root")"
+
+    if [[ -n "$new_decisions" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash filepath
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
+            local title
+            title="$(get_decision_title "$filepath" "$project_root")"
+            if [[ -z "$title" ]]; then
+                title="$filepath"
+            fi
+            if check_agents_duplicate "$title" "$agents_file"; then
+                continue
+            fi
+            entry_count=$((entry_count + 1))
+            # Use printf to avoid issues with special chars in title
+            entries+="$(printf -- '- %s -> [詳細](%s)\n' "$title" "$filepath")"
+            entries+=$'\n'
+        done <<< "$new_decisions"
+    fi
+
+    if [[ "$entry_count" -eq 0 ]]; then
+        log_info "No new constraints to add"
+        return 1
+    fi
+
+    # Find the line number of "## 既知の制約" section
+    local section_line
+    section_line="$(grep -n '^## 既知の制約' "$agents_file" 2>/dev/null | head -1 | cut -d: -f1)" || section_line=""
+
+    if [[ -z "$section_line" ]]; then
+        log_warn "Section '## 既知の制約' not found in AGENTS.md, appending at end"
+        printf '\n## 既知の制約\n\n%s' "$entries" >> "$agents_file"
+    else
+        # Find the next section (## ...) after 既知の制約 or end of file
+        local total_lines
+        total_lines="$(wc -l < "$agents_file" | tr -d ' ')"
+        local next_section_line
+        next_section_line="$(tail -n +"$((section_line + 1))" "$agents_file" | grep -n '^## ' | head -1 | cut -d: -f1)" || next_section_line=""
+
+        local insert_line
+        if [[ -n "$next_section_line" ]]; then
+            # Insert before the next section (adjust for tail offset)
+            insert_line=$((section_line + next_section_line - 1))
+        else
+            # Append at end of file
+            insert_line=$((total_lines + 1))
+        fi
+
+        # Build the new file content
+        local tmp_file="${agents_file}.tmp.$$"
+        {
+            head -n "$((insert_line - 1))" "$agents_file"
+            printf '%s' "$entries"
+            tail -n +"$insert_line" "$agents_file"
+        } > "$tmp_file"
+        mv -f "$tmp_file" "$agents_file"
+    fi
+
+    log_info "Applied $entry_count constraint(s) to AGENTS.md"
+    return 0
+}
+
+# ============================================================================
+# Context collection for improve.sh integration
+# ============================================================================
+
+# Collect knowledge context for review phase injection
+# Arguments: $1=since (git date string), $2=project_root (optional)
+# Output: Context string suitable for injection into review prompt
+collect_knowledge_context() {
+    local since="${1:-1 week ago}"
+    local project_root="${2:-.}"
+
+    local context=""
+
+    # Recent fix commits
+    local fix_commits
+    fix_commits="$(extract_fix_commits "$since" "$project_root")"
+
+    if [[ -n "$fix_commits" ]]; then
+        context+="
+## 最近のfix commitから抽出された知見
+以下のバグ修正から得られた知見です。同様のパターンのバグがないか確認してください。
+\`\`\`
+${fix_commits}
+\`\`\`
+"
+    fi
+
+    # Recent decision files
+    local new_decisions
+    new_decisions="$(extract_new_decisions "$since" "$project_root")"
+
+    if [[ -n "$new_decisions" ]]; then
+        local decision_summaries=""
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local filepath
+            filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
+            local title
+            title="$(get_decision_title "$filepath" "$project_root")"
+            if [[ -n "$title" ]]; then
+                decision_summaries+="  - ${title} (${filepath})
+"
+            fi
+        done <<< "$new_decisions"
+
+        if [[ -n "$decision_summaries" ]]; then
+            context+="
+## 最近追加された設計判断
+以下の制約を考慮してレビューしてください。
+${decision_summaries}
+"
+        fi
+    fi
+
+    # Tracker failure patterns (optional)
+    local tracker_failures
+    tracker_failures="$(extract_tracker_failures "$since" "$project_root")"
+
+    if [[ -n "$tracker_failures" ]]; then
+        local significant_failures=""
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local count
+            count="$(printf '%s' "$line" | awk '{print $1}')"
+            if [[ "$count" -ge 2 ]]; then
+                significant_failures+="  ${line}
+"
+            fi
+        done <<< "$tracker_failures"
+
+        if [[ -n "$significant_failures" ]]; then
+            context+="
+## 繰り返し発生している失敗パターン
+以下のエラータイプが繰り返し発生しています。関連するコードを重点的に確認してください。
+\`\`\`
+${significant_failures}
+\`\`\`
+"
+        fi
+    fi
+
+    printf '%s' "$context"
+}

--- a/scripts/knowledge-loop.sh
+++ b/scripts/knowledge-loop.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# ============================================================================
+# knowledge-loop.sh - Knowledge Loop CLI
+#
+# Extracts constraints from fix commits and docs/decisions/,
+# then proposes (or applies) additions to AGENTS.md.
+#
+# Usage: ./scripts/knowledge-loop.sh [options]
+#
+# Options:
+#   --since "N days ago"  Period to analyze (default: "1 week ago")
+#   --apply               Apply proposals to AGENTS.md
+#   --dry-run             Show proposals only (default)
+#   --json                Output in JSON format
+#   -h, --help            Show help message
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#   2 - AGENTS.md not found (with --apply)
+#
+# Examples:
+#   ./scripts/knowledge-loop.sh
+#   ./scripts/knowledge-loop.sh --since "1 week ago"
+#   ./scripts/knowledge-loop.sh --apply
+#   ./scripts/knowledge-loop.sh --dry-run
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for arg in "$@"; do
+    if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+        cat << 'EOF'
+Usage: knowledge-loop.sh [options]
+
+Options:
+    --since "PERIOD"     Period to analyze (default: "1 week ago")
+                         Examples: "1 week ago", "3 days ago", "1 month ago"
+    --apply              Apply proposals to AGENTS.md
+    --dry-run            Show proposals only (default)
+    --json               Output in JSON format
+    -h, --help           Show this help
+
+Description:
+    Extracts constraints and lessons from recent fix: commits and
+    docs/decisions/ files, then proposes additions to the AGENTS.md
+    "既知の制約" section.
+
+    Sources analyzed:
+    1. fix: commits (git log --grep="^fix:")
+    2. New docs/decisions/*.md files
+    3. tracker.jsonl failure patterns (if available)
+
+Examples:
+    knowledge-loop.sh                         # Analyze last 7 days
+    knowledge-loop.sh --since "1 week ago"    # Same as above
+    knowledge-loop.sh --since "3 days ago"    # Last 3 days only
+    knowledge-loop.sh --apply                 # Apply to AGENTS.md
+    knowledge-loop.sh --dry-run               # Preview only (default)
+EOF
+        exit 0
+    fi
+done
+
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/log.sh"
+source "$SCRIPT_DIR/../lib/knowledge-loop.sh"
+
+main() {
+    local since="1 week ago"
+    local mode="dry-run"
+    local json_output=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --since)
+                since="$2"
+                shift 2
+                ;;
+            --apply)
+                mode="apply"
+                shift
+                ;;
+            --dry-run)
+                mode="dry-run"
+                shift
+                ;;
+            --json)
+                json_output=true
+                shift
+                ;;
+            -h|--help)
+                # Already handled above
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                echo "Usage: $(basename "$0") [--since PERIOD] [--apply] [--dry-run] [--json] [-h]" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    load_config 2>/dev/null || true
+
+    if [[ "$json_output" == "true" ]]; then
+        _output_json "$since"
+        return 0
+    fi
+
+    case "$mode" in
+        dry-run)
+            generate_knowledge_proposals "$since" "."
+            ;;
+        apply)
+            generate_knowledge_proposals "$since" "."
+            echo ""
+            echo "Applying proposals to AGENTS.md..."
+            local apply_result=0
+            apply_knowledge_proposals "$since" "." || apply_result=$?
+            case "$apply_result" in
+                0) echo "Done. Proposals applied to AGENTS.md." ;;
+                1) echo "No new constraints to apply." ;;
+                2) echo "Error: AGENTS.md not found." >&2; exit 2 ;;
+            esac
+            ;;
+    esac
+}
+
+_output_json() {
+    local since="$1"
+
+    local fix_commits
+    fix_commits="$(extract_fix_commits "$since" ".")"
+
+    local new_decisions
+    new_decisions="$(extract_new_decisions "$since" ".")"
+
+    if ! command -v jq &>/dev/null; then
+        log_error "jq is required for --json output"
+        exit 1
+    fi
+
+    local items="[]"
+
+    if [[ -n "$fix_commits" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash subject
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
+            local constraint
+            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
+            if check_agents_duplicate "$constraint" "AGENTS.md"; then
+                continue
+            fi
+            items="$(printf '%s' "$items" | jq -c --arg type "fix_commit" --arg hash "$hash" --arg subject "$subject" --arg constraint "$constraint" '. + [{type: $type, hash: $hash, subject: $subject, constraint: $constraint}]')"
+        done <<< "$fix_commits"
+    fi
+
+    if [[ -n "$new_decisions" ]]; then
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            local hash filepath
+            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
+            local title
+            title="$(get_decision_title "$filepath" ".")"
+            if [[ -z "$title" ]]; then
+                title="$filepath"
+            fi
+            if check_agents_duplicate "$title" "AGENTS.md"; then
+                continue
+            fi
+            items="$(printf '%s' "$items" | jq -c --arg type "decision" --arg hash "$hash" --arg filepath "$filepath" --arg title "$title" '. + [{type: $type, hash: $hash, filepath: $filepath, title: $title}]')"
+        done <<< "$new_decisions"
+    fi
+
+    printf '%s\n' "$items" | jq '.'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/test/scripts/knowledge-loop.bats
+++ b/test/scripts/knowledge-loop.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+
+load '../test_helper'
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+        export BATS_TEST_TMPDIR="$(mktemp -d)"
+        export _CLEANUP_TMPDIR=1
+    fi
+
+    export TEST_PROJECT="$BATS_TEST_TMPDIR/project"
+    mkdir -p "$TEST_PROJECT"
+
+    git -C "$TEST_PROJECT" init -b main >/dev/null 2>&1
+    git -C "$TEST_PROJECT" config user.email "test@example.com"
+    git -C "$TEST_PROJECT" config user.name "Test User"
+
+    printf '# Test\n' > "$TEST_PROJECT/README.md"
+    git -C "$TEST_PROJECT" add -A
+    git -C "$TEST_PROJECT" commit -m "initial commit" >/dev/null 2>&1
+}
+
+teardown() {
+    if [[ "${_CLEANUP_TMPDIR:-}" == "1" && -d "${BATS_TEST_TMPDIR:-}" ]]; then
+        rm -rf "$BATS_TEST_TMPDIR"
+    fi
+}
+
+# ====================
+# --help
+# ====================
+
+@test "knowledge-loop.sh --help shows usage" {
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"--since"* ]]
+    [[ "$output" == *"--apply"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "knowledge-loop.sh -h shows usage" {
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# ====================
+# Unknown option
+# ====================
+
+@test "knowledge-loop.sh rejects unknown option" {
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --unknown
+    [ "$status" -eq 1 ]
+}
+
+# ====================
+# Default (dry-run)
+# ====================
+
+@test "knowledge-loop.sh default mode shows analysis header" {
+    cd "$TEST_PROJECT"
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Knowledge Loop Analysis"* ]]
+}
+
+@test "knowledge-loop.sh shows no constraints when none found" {
+    cd "$TEST_PROJECT"
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No new constraints found"* ]]
+}
+
+@test "knowledge-loop.sh finds fix commits" {
+    cd "$TEST_PROJECT"
+    printf 'fix\n' > "$TEST_PROJECT/file.sh"
+    git -C "$TEST_PROJECT" add -A
+    git -C "$TEST_PROJECT" commit -m "fix: handle edge case in parser" >/dev/null 2>&1
+
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --since "1 week ago"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"handle edge case in parser"* ]]
+}
+
+# ====================
+# --apply
+# ====================
+
+@test "knowledge-loop.sh --apply fails when no AGENTS.md" {
+    cd "$TEST_PROJECT"
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --apply
+    [ "$status" -eq 2 ]
+}
+
+@test "knowledge-loop.sh --apply writes to AGENTS.md" {
+    cd "$TEST_PROJECT"
+    cat > "$TEST_PROJECT/AGENTS.md" << 'EOF'
+## 既知の制約
+
+## 注意事項
+EOF
+
+    printf 'fix\n' > "$TEST_PROJECT/file.sh"
+    git -C "$TEST_PROJECT" add -A
+    git -C "$TEST_PROJECT" commit -m "fix: use portable date format" >/dev/null 2>&1
+
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Applying proposals"* ]]
+
+    local content
+    content="$(cat "$TEST_PROJECT/AGENTS.md")"
+    [[ "$content" == *"use portable date format"* ]]
+}
+
+# ====================
+# --json
+# ====================
+
+@test "knowledge-loop.sh --json outputs valid JSON" {
+    cd "$TEST_PROJECT"
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --json
+    [ "$status" -eq 0 ]
+    echo "$output" | jq . >/dev/null 2>&1
+}
+
+@test "knowledge-loop.sh --json outputs empty array when no constraints" {
+    cd "$TEST_PROJECT"
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --json
+    [ "$status" -eq 0 ]
+    local count
+    count="$(echo "$output" | jq 'length')"
+    [ "$count" = "0" ]
+}
+
+@test "knowledge-loop.sh --json includes fix commits" {
+    cd "$TEST_PROJECT"
+    printf 'fix\n' > "$TEST_PROJECT/file.sh"
+    git -C "$TEST_PROJECT" add -A
+    git -C "$TEST_PROJECT" commit -m "fix: improve error handling" >/dev/null 2>&1
+
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --json --since "1 week ago"
+    [ "$status" -eq 0 ]
+    local count
+    count="$(echo "$output" | jq 'length')"
+    [ "$count" -ge 1 ]
+    local type
+    type="$(echo "$output" | jq -r '.[0].type')"
+    [ "$type" = "fix_commit" ]
+}
+
+# ====================
+# --since
+# ====================
+
+@test "knowledge-loop.sh --since respects time range" {
+    cd "$TEST_PROJECT"
+    run "$PROJECT_ROOT/scripts/knowledge-loop.sh" --since "1 day ago"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Knowledge Loop Analysis"* ]]
+}


### PR DESCRIPTION
## Summary
Closes #1299

fixコミットや docs/decisions/ から制約・知見を自動抽出し、AGENTS.mdへの追記を提案する機能を実装。

## Changes
- **lib/knowledge-loop.sh**: コアライブラリ - fixコミット抽出、decision検出、重複チェック、提案生成、自動追記
- **scripts/knowledge-loop.sh**: CLIラッパー（--since, --apply, --dry-run, --json）
- **lib/improve/review.sh**: `_collect_review_context()`にknowledge contextを注入
- **AGENTS.md**: ディレクトリ構造を更新

## Usage
```bash
scripts/knowledge-loop.sh                        # 直近7日のfix commitを分析（dry-run）
scripts/knowledge-loop.sh --since "3 days ago"   # 期間指定
scripts/knowledge-loop.sh --apply                # AGENTS.mdに自動追記
scripts/knowledge-loop.sh --json                 # JSON形式で出力
```

## Testing
- test/lib/knowledge-loop.bats: 27テスト（コア機能全カバー）
- test/scripts/knowledge-loop.bats: 12テスト（CLI全カバー）
- ShellCheck: 警告なし
- 既存テスト（improve, review, tracker）: 全パス