### PR TITLE
fix: add tracker.file and watcher.force_cleanup_on_timeout to JSON schema

### DIFF
--- a/schemas/pi-runner.schema.json
+++ b/schemas/pi-runner.schema.json
@@ -316,11 +316,28 @@
         }
       }
     },
+    "tracker": {
+      "type": "object",
+      "description": "Prompt tracker settings",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "default": ".worktrees/.status/tracker.jsonl",
+          "description": "Path to the tracker JSONL file"
+        }
+      }
+    },
     "watcher": {
       "type": "object",
       "description": "Session watcher settings",
       "additionalProperties": false,
       "properties": {
+        "force_cleanup_on_timeout": {
+          "type": "boolean",
+          "default": false,
+          "description": "Force cleanup on PR merge timeout"
+        },
         "initial_delay": {
           "type": "integer",
           "minimum": 0,


### PR DESCRIPTION
## Summary
Closes #1362

## Changes
- Added `tracker` section with `file` property to `schemas/pi-runner.schema.json`
- Added `force_cleanup_on_timeout` boolean property to `watcher` section

Both config keys were already registered in `lib/config.sh` and documented in `docs/configuration.md`, but missing from the JSON schema.

## Testing
- JSON validation passes (`python3 -m json.tool`)
- All config keys in `lib/config.sh` now have corresponding schema entries (verified with Python script)
- Config-related Bats tests pass (`config.bats`, `verify-config-docs.bats`, `config-master-table-dry.bats`)
- ShellCheck passes