### PR TITLE
fix: knowledge-loop の出力品質改善 - 類似コミット集約・重要度スコアリング・件数制限

### DIFF
--- a/lib/knowledge-loop.sh
+++ b/lib/knowledge-loop.sh
@@ -207,166 +207,428 @@ check_agents_duplicate() {
 }
 
 # ============================================================================
-# Proposal generation
+# Commit categorization and grouping
 # ============================================================================
 
-# Generate knowledge proposals from fix commits and decisions
-# Arguments: $1=since (git date string), $2=project_root (optional)
-# Output: Formatted proposal text to stdout
-generate_knowledge_proposals() {
+# Category definitions: pattern -> category name
+# Used by categorize_commit() to classify commits by changed files
+_KNOWLEDGE_CATEGORIES=(
+    "lib/marker.sh|watch-session.sh:マーカー検出"
+    "lib/ci-|ci-fix|ci-classifier|ci-monitor|ci-retry:CI関連"
+    "lib/multiplexer|lib/tmux.sh:マルチプレクサ"
+    "lib/worktree.sh|scripts/cleanup.sh:Worktree管理"
+    "lib/hooks.sh:Hook安全性"
+    "lib/workflow|workflow-:ワークフロー"
+    "lib/config.sh|lib/yaml.sh:設定・YAML"
+    "lib/status.sh|lib/dashboard.sh:状態管理"
+    "lib/improve|scripts/improve.sh:継続的改善"
+    "lib/daemon.sh:デーモン管理"
+    "lib/compat.sh:互換性"
+    "lib/notify.sh:通知"
+)
+
+# Categorize a commit based on changed files
+# Arguments: $1=commit_hash, $2=project_root (optional)
+# Output: category name (e.g., "マーカー検出", "CI関連", "一般")
+categorize_commit() {
+    local commit_hash="$1"
+    local project_root="${2:-.}"
+
+    local changed_files
+    changed_files="$(git -C "$project_root" diff-tree --no-commit-id -r --name-only "$commit_hash" 2>/dev/null)" || changed_files=""
+
+    if [[ -z "$changed_files" ]]; then
+        printf '%s' "一般"
+        return 0
+    fi
+
+    # Check if only test files changed
+    local has_non_test=false
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        if [[ "$f" != test/* ]]; then
+            has_non_test=true
+            break
+        fi
+    done <<< "$changed_files"
+
+    if [[ "$has_non_test" == "false" ]]; then
+        printf '%s' "テスト安定性"
+        return 0
+    fi
+
+    # Match against category patterns
+    local entry pattern category
+    for entry in "${_KNOWLEDGE_CATEGORIES[@]}"; do
+        pattern="${entry%%:*}"
+        category="${entry#*:}"
+        # Split pattern by | and check each
+        local IFS='|'
+        local p
+        for p in $pattern; do
+            if printf '%s\n' "$changed_files" | grep -q "$p" 2>/dev/null; then
+                printf '%s' "$category"
+                return 0
+            fi
+        done
+    done
+
+    printf '%s' "一般"
+}
+
+# Score a commit for importance
+# Arguments: $1=commit_hash, $2=commit_subject, $3=project_root (optional)
+# Output: numeric score (higher = more important)
+score_commit() {
+    local commit_hash="$1"
+    local subject="$2"
+    local project_root="${3:-.}"
+    local score=1
+
+    # Check if commit references an Issue number -> +2
+    if printf '%s' "$subject" | grep -qE '#[0-9]+|Issue[ -]?[0-9]+' 2>/dev/null; then
+        score=$((score + 2))
+    fi
+
+    # Check commit body for Issue references -> +1
+    local body
+    body="$(get_commit_body "$commit_hash" "$project_root")"
+    if [[ -n "$body" ]] && printf '%s' "$body" | grep -qE '#[0-9]+|Refs|Closes|Fixes' 2>/dev/null; then
+        score=$((score + 1))
+    fi
+
+    local changed_files
+    changed_files="$(git -C "$project_root" diff-tree --no-commit-id -r --name-only "$commit_hash" 2>/dev/null)" || changed_files=""
+
+    # Check if only test files changed -> low score
+    local has_non_test=false
+    if [[ -n "$changed_files" ]]; then
+        while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            if [[ "$f" != test/* ]]; then
+                has_non_test=true
+                break
+            fi
+        done <<< "$changed_files"
+    fi
+    if [[ "$has_non_test" == "false" ]]; then
+        score=$((score - 1))
+    fi
+
+    # Typo/ShellCheck-only fix -> lowest score
+    if printf '%s' "$subject" | grep -qiE 'typo|shellcheck|SC[0-9]+|format' 2>/dev/null; then
+        score=$((score - 1))
+    fi
+
+    # Minimum score is 0
+    if [[ "$score" -lt 0 ]]; then
+        score=0
+    fi
+
+    printf '%d' "$score"
+}
+
+# Group commits by category and aggregate
+# Arguments: $1=since, $2=project_root (optional)
+# Output: grouped data in a parseable format (one group per block, separated by empty lines)
+#   Format per group:
+#     CATEGORY:<name>
+#     COUNT:<n>
+#     SCORE:<total_score>
+#     FILES:<comma-separated unique files>
+#     COMMITS:<hash1>:<subject1>
+#     COMMITS:<hash2>:<subject2>
+#     ...
+group_commits_by_category() {
     local since="${1:-1 week ago}"
     local project_root="${2:-.}"
     local agents_file="$project_root/AGENTS.md"
 
-    local proposal_count=0
-    local proposals=""
-
-    # 1. Extract from fix commits
     local fix_commits
     fix_commits="$(extract_fix_commits "$since" "$project_root")"
 
-    if [[ -n "$fix_commits" ]]; then
-        local commit_count
-        commit_count="$(printf '%s\n' "$fix_commits" | wc -l | tr -d ' ')"
-        log_debug "Found $commit_count fix commits"
-
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            local hash subject
-            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
-            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
-
-            # Strip "fix: " prefix for constraint text
-            local constraint
-            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
-
-            # Check for duplicates in AGENTS.md
-            if check_agents_duplicate "$constraint" "$agents_file"; then
-                log_debug "Skipping duplicate: $constraint"
-                continue
-            fi
-
-            proposal_count=$((proposal_count + 1))
-
-            # Get commit body for additional context
-            local body
-            body="$(get_commit_body "$hash" "$project_root")"
-
-            proposals+="
-${proposal_count}. ${constraint}
-   Source: fix: ${subject} (${hash})
-"
-            if [[ -n "$body" ]]; then
-                # Take first non-empty line of body as reason
-                local reason
-                reason="$(printf '%s' "$body" | grep -v '^$' | head -1)"
-                if [[ -n "$reason" ]]; then
-                    proposals+="   Reason: ${reason}
-"
-                fi
-            fi
-        done <<< "$fix_commits"
+    if [[ -z "$fix_commits" ]]; then
+        return 0
     fi
 
-    # 2. Extract from new decision files
+    # Use temp files for grouping (associative arrays are fragile in bash)
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        local hash subject
+        hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+        subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
+
+        local constraint
+        constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
+
+        # Skip duplicates already in AGENTS.md
+        if check_agents_duplicate "$constraint" "$agents_file"; then
+            continue
+        fi
+
+        local category
+        category="$(categorize_commit "$hash" "$project_root")"
+
+        # Sanitize category for filename (cksum is POSIX, handles multibyte)
+        local cat_file
+        cat_file="cat_$(printf '%s' "$category" | cksum | cut -d' ' -f1)"
+
+        # Store category name
+        printf '%s\n' "$category" > "$tmp_dir/${cat_file}.name"
+
+        # Append commit
+        printf '%s:%s\n' "$hash" "$constraint" >> "$tmp_dir/${cat_file}.commits"
+
+        # Append score
+        local commit_score
+        commit_score="$(score_commit "$hash" "$subject" "$project_root")"
+        printf '%d\n' "$commit_score" >> "$tmp_dir/${cat_file}.scores"
+
+        # Append changed files
+        local changed_files
+        changed_files="$(git -C "$project_root" diff-tree --no-commit-id -r --name-only "$hash" 2>/dev/null)" || changed_files=""
+        if [[ -n "$changed_files" ]]; then
+            printf '%s\n' "$changed_files" >> "$tmp_dir/${cat_file}.files"
+        fi
+    done <<< "$fix_commits"
+
+    # Output grouped data, sorted by total score descending
+    local scored_groups=""
+    for name_file in "$tmp_dir"/*.name; do
+        [[ -f "$name_file" ]] || continue
+        local base
+        base="$(basename "$name_file" .name)"
+        local cat_name
+        cat_name="$(cat "$name_file")"
+        local commit_count=0
+        local total_score=0
+
+        if [[ -f "$tmp_dir/${base}.commits" ]]; then
+            commit_count="$(wc -l < "$tmp_dir/${base}.commits" | tr -d ' ')"
+        fi
+
+        # Total score = sum of individual scores + bonus for repeated fixes
+        if [[ -f "$tmp_dir/${base}.scores" ]]; then
+            while IFS= read -r s; do
+                total_score=$((total_score + s))
+            done < "$tmp_dir/${base}.scores"
+        fi
+
+        # Bonus: repeated fixes on same category -> higher score
+        if [[ "$commit_count" -ge 5 ]]; then
+            total_score=$((total_score + 5))
+        elif [[ "$commit_count" -ge 3 ]]; then
+            total_score=$((total_score + 3))
+        elif [[ "$commit_count" -ge 2 ]]; then
+            total_score=$((total_score + 1))
+        fi
+
+        # Count unique files modified
+        local unique_files=""
+        if [[ -f "$tmp_dir/${base}.files" ]]; then
+            unique_files="$(sort -u "$tmp_dir/${base}.files" | head -5 | tr '\n' ',' | sed 's/,$//')"
+        fi
+
+        scored_groups+="$(printf '%05d\t%s\t%s\t%s\t%s\n' "$total_score" "$cat_name" "$commit_count" "$unique_files" "$base")"
+        scored_groups+=$'\n'
+    done
+
+    # Sort by score descending and output
+    if [[ -z "$scored_groups" ]]; then
+        rm -rf "$tmp_dir"
+        return 0
+    fi
+
+    printf '%s' "$scored_groups" | sort -t$'\t' -k1 -rn | while IFS=$'\t' read -r _score cat_name commit_count unique_files base; do
+        [[ -z "$cat_name" ]] && continue
+        printf 'CATEGORY:%s\n' "$cat_name"
+        printf 'COUNT:%s\n' "$commit_count"
+        printf 'SCORE:%d\n' "$(( ${_score#0} ))"  # Strip leading zeros
+        printf 'FILES:%s\n' "$unique_files"
+        if [[ -f "$tmp_dir/${base}.commits" ]]; then
+            while IFS= read -r commit_line; do
+                printf 'COMMITS:%s\n' "$commit_line"
+            done < "$tmp_dir/${base}.commits"
+        fi
+        printf '\n'
+    done
+
+    rm -rf "$tmp_dir"
+}
+
+# Convert a numeric score to a star rating
+# Arguments: $1=score, $2=max_score (optional, for normalization)
+# Output: star string (e.g., "★★★", "★★☆", "★☆☆")
+_score_to_stars() {
+    local score="$1"
+    if [[ "$score" -ge 10 ]]; then
+        printf '★★★'
+    elif [[ "$score" -ge 5 ]]; then
+        printf '★★☆'
+    elif [[ "$score" -ge 2 ]]; then
+        printf '★☆☆'
+    else
+        printf '☆☆☆'
+    fi
+}
+
+# ============================================================================
+# Proposal generation
+# ============================================================================
+
+# Generate knowledge proposals from fix commits and decisions
+# Arguments: $1=since, $2=project_root (optional), $3=top_n (optional, 0=all)
+# Output: Formatted proposal text to stdout
+generate_knowledge_proposals() {
+    local since="${1:-1 week ago}"
+    local project_root="${2:-.}"
+    local top_n="${3:-5}"
+    local agents_file="$project_root/AGENTS.md"
+
+    # Count total fix commits (before filtering)
+    local fix_commits
+    fix_commits="$(extract_fix_commits "$since" "$project_root")"
+    local total_fix_count=0
+    if [[ -n "$fix_commits" ]]; then
+        total_fix_count="$(printf '%s\n' "$fix_commits" | wc -l | tr -d ' ')"
+    fi
+
+    # Get grouped data
+    local grouped_data
+    grouped_data="$(group_commits_by_category "$since" "$project_root")"
+
+    # Count decision proposals
     local new_decisions
     new_decisions="$(extract_new_decisions "$since" "$project_root")"
-
+    local decision_count=0
     if [[ -n "$new_decisions" ]]; then
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
-            local hash filepath
-            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
+            local _hash filepath
+            _hash="$(printf '%s' "$line" | cut -d' ' -f1)"
             filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
-
             local title
             title="$(get_decision_title "$filepath" "$project_root")"
             if [[ -z "$title" ]]; then
                 title="$filepath"
             fi
-
-            # Check for duplicates
-            if check_agents_duplicate "$title" "$agents_file"; then
-                log_debug "Skipping duplicate decision: $title"
-                continue
+            if ! check_agents_duplicate "$title" "$agents_file"; then
+                decision_count=$((decision_count + 1))
             fi
-
-            proposal_count=$((proposal_count + 1))
-            proposals+="
-${proposal_count}. ${title}
-   Source: ${filepath} (${hash})
-   Detail: See ${filepath}
-"
         done <<< "$new_decisions"
     fi
 
-    # 3. Check tracker failures (optional)
-    local tracker_failures
-    tracker_failures="$(extract_tracker_failures "$since" "$project_root")"
-
-    if [[ -n "$tracker_failures" ]]; then
-        local has_tracker_header=false
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            local count error_type
-            count="$(printf '%s' "$line" | awk '{print $1}')"
-            error_type="$(printf '%s' "$line" | awk '{print $2}')"
-
-            # Only report frequent failures (3+ occurrences)
-            if [[ "$count" -ge 3 ]]; then
-                if [[ "$has_tracker_header" == "false" ]]; then
-                    has_tracker_header=true
-                fi
-                proposal_count=$((proposal_count + 1))
-                proposals+="
-${proposal_count}. [failure pattern] ${error_type} occurred ${count} times
-   Source: tracker.jsonl analysis
-   Action: Consider adding error handling or documentation
-"
-            fi
-        done <<< "$tracker_failures"
-    fi
-
-    # Output report
+    # Output report header
     printf '=== Knowledge Loop Analysis (since: %s) ===\n' "$since"
     printf '\n'
 
-    if [[ "$proposal_count" -eq 0 ]]; then
+    # Count total groups
+    local group_count=0
+    if [[ -n "$grouped_data" ]]; then
+        group_count="$(printf '%s\n' "$grouped_data" | grep -c '^CATEGORY:' || true)"
+    fi
+
+    local total_insights=$((group_count + decision_count))
+
+    if [[ "$total_insights" -eq 0 ]]; then
         printf 'No new constraints found.\n'
         return 0
     fi
 
-    local fix_count=0
-    if [[ -n "$fix_commits" ]]; then
-        fix_count="$(printf '%s\n' "$fix_commits" | wc -l | tr -d ' ')"
+    # Determine display count
+    local display_count="$total_insights"
+    if [[ "$top_n" -gt 0 ]] && [[ "$top_n" -lt "$total_insights" ]]; then
+        display_count="$top_n"
     fi
 
-    printf 'Found %d new constraint(s) from %d fix commit(s):\n' "$proposal_count" "$fix_count"
-    printf '%s\n' "$proposals"
+    printf 'Top %d insights (from %d fix commits):\n' "$display_count" "$total_fix_count"
+    printf '\n'
 
-    # Generate suggested AGENTS.md additions
-    printf 'Suggested AGENTS.md additions (既知の制約 section):\n'
-    # Re-parse proposals to generate one-liner additions
-    local idx=0
-    if [[ -n "$fix_commits" ]]; then
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            local hash subject
-            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
-            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
-            local constraint
-            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
-            if check_agents_duplicate "$constraint" "$agents_file"; then
-                continue
+    # Display grouped commit insights
+    local displayed=0
+    if [[ -n "$grouped_data" ]]; then
+        local current_category="" current_count="" current_score="" current_files=""
+        local -a current_commits=()
+        local in_group=false
+
+        _flush_group() {
+            if [[ "$in_group" != "true" ]] || [[ -z "$current_category" ]]; then
+                return
             fi
-            idx=$((idx + 1))
-            printf '  - %s (from commit %s)\n' "$constraint" "$hash"
-        done <<< "$fix_commits"
+            if [[ "$top_n" -gt 0 ]] && [[ "$displayed" -ge "$top_n" ]]; then
+                return
+            fi
+
+            displayed=$((displayed + 1))
+            local stars
+            stars="$(_score_to_stars "$current_score")"
+            printf '%d. [%s] %s (%d fixes)\n' "$displayed" "$current_category" "$stars" "$current_count"
+
+            # Show up to 5 commits
+            local shown=0
+            local commit_line
+            for commit_line in "${current_commits[@]}"; do
+                if [[ "$shown" -ge 5 ]]; then
+                    local remaining=$(( ${#current_commits[@]} - 5 ))
+                    printf '   ... and %d more\n' "$remaining"
+                    break
+                fi
+                local c_hash c_subject
+                c_hash="${commit_line%%:*}"
+                c_subject="${commit_line#*:}"
+                printf '   - %s (%s)\n' "$c_subject" "$c_hash"
+                shown=$((shown + 1))
+            done
+
+            if [[ -n "$current_files" ]]; then
+                printf '   Files: %s\n' "$current_files"
+            fi
+            printf '\n'
+        }
+
+        while IFS= read -r line; do
+            case "$line" in
+                CATEGORY:*)
+                    _flush_group
+                    current_category="${line#CATEGORY:}"
+                    current_count=""
+                    current_score=""
+                    current_files=""
+                    current_commits=()
+                    in_group=true
+                    ;;
+                COUNT:*)
+                    current_count="${line#COUNT:}"
+                    ;;
+                SCORE:*)
+                    current_score="${line#SCORE:}"
+                    ;;
+                FILES:*)
+                    current_files="${line#FILES:}"
+                    ;;
+                COMMITS:*)
+                    current_commits+=("${line#COMMITS:}")
+                    ;;
+                "")
+                    # End of group block - will be flushed on next CATEGORY: or at end
+                    ;;
+            esac
+        done <<< "$grouped_data"
+
+        # Flush last group
+        _flush_group
     fi
 
-    if [[ -n "$new_decisions" ]]; then
+    # Display decision file proposals (within top_n limit)
+    if [[ -n "$new_decisions" ]] && { [[ "$top_n" -eq 0 ]] || [[ "$displayed" -lt "$top_n" ]]; }; then
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
+            if [[ "$top_n" -gt 0 ]] && [[ "$displayed" -ge "$top_n" ]]; then
+                break
+            fi
             local hash filepath
             hash="$(printf '%s' "$line" | cut -d' ' -f1)"
             filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
@@ -378,9 +640,16 @@ ${proposal_count}. [failure pattern] ${error_type} occurred ${count} times
             if check_agents_duplicate "$title" "$agents_file"; then
                 continue
             fi
-            # shellcheck disable=SC2016
-            printf '  - %s -> [詳細](%s)\n' "$title" "$filepath"
+            displayed=$((displayed + 1))
+            printf '%d. [設計判断] %s\n' "$displayed" "$title"
+            printf '   Source: %s (%s)\n' "$filepath" "$hash"
+            printf '\n'
         done <<< "$new_decisions"
+    fi
+
+    # Show total if limited
+    if [[ "$top_n" -gt 0 ]] && [[ "$total_insights" -gt "$display_count" ]]; then
+        printf '(Showing top %d of %d insights. Use --all to see all)\n' "$display_count" "$total_insights"
     fi
 }
 
@@ -389,11 +658,13 @@ ${proposal_count}. [failure pattern] ${error_type} occurred ${count} times
 # ============================================================================
 
 # Append knowledge proposals to AGENTS.md's 既知の制約 section
-# Arguments: $1=since, $2=project_root (optional)
+# Uses grouped/scored results to apply only top N entries
+# Arguments: $1=since, $2=project_root (optional), $3=top_n (optional, 0=all)
 # Returns: 0=applied, 1=nothing to apply, 2=AGENTS.md not found
 apply_knowledge_proposals() {
     local since="${1:-1 week ago}"
     local project_root="${2:-.}"
+    local top_n="${3:-5}"
     local agents_file="$project_root/AGENTS.md"
 
     if [[ ! -f "$agents_file" ]]; then
@@ -401,38 +672,70 @@ apply_knowledge_proposals() {
         return 2
     fi
 
-    # Collect entries to add
+    # Collect entries using grouped data (respects scoring/limiting)
     local entries=""
     local entry_count=0
+    local applied_groups=0
 
-    # From fix commits
-    local fix_commits
-    fix_commits="$(extract_fix_commits "$since" "$project_root")"
+    # From grouped fix commits (sorted by score)
+    local grouped_data
+    grouped_data="$(group_commits_by_category "$since" "$project_root")"
 
-    if [[ -n "$fix_commits" ]]; then
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            local hash subject
-            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
-            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
-            local constraint
-            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
-            if check_agents_duplicate "$constraint" "$agents_file"; then
-                continue
+    if [[ -n "$grouped_data" ]]; then
+        local current_category="" current_commits_text=""
+        local in_group=false
+
+        _apply_flush_group() {
+            if [[ "$in_group" != "true" ]] || [[ -z "$current_category" ]]; then
+                return
             fi
-            entry_count=$((entry_count + 1))
-            entries+="- ${constraint} (${hash})
-"
-        done <<< "$fix_commits"
+            if [[ "$top_n" -gt 0 ]] && [[ "$applied_groups" -ge "$top_n" ]]; then
+                return
+            fi
+            applied_groups=$((applied_groups + 1))
+
+            # Add a summary entry per group
+            if [[ -n "$current_commits_text" ]]; then
+                local first_constraint
+                first_constraint="$(printf '%s' "$current_commits_text" | head -1)"
+                local c_hash="${first_constraint%%:*}"
+                local c_subject="${first_constraint#*:}"
+                entry_count=$((entry_count + 1))
+                entries+="- ${c_subject} (${c_hash})"
+                entries+=$'\n'
+            fi
+        }
+
+        while IFS= read -r line; do
+            case "$line" in
+                CATEGORY:*)
+                    _apply_flush_group
+                    current_category="${line#CATEGORY:}"
+                    current_commits_text=""
+                    in_group=true
+                    ;;
+                COMMITS:*)
+                    current_commits_text+="${line#COMMITS:}"
+                    current_commits_text+=$'\n'
+                    ;;
+                "") ;;
+                *) ;;
+            esac
+        done <<< "$grouped_data"
+
+        _apply_flush_group
     fi
 
-    # From decision files
+    # From decision files (within remaining top_n budget)
     local new_decisions
     new_decisions="$(extract_new_decisions "$since" "$project_root")"
 
     if [[ -n "$new_decisions" ]]; then
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
+            if [[ "$top_n" -gt 0 ]] && [[ "$entry_count" -ge "$top_n" ]]; then
+                break
+            fi
             local hash filepath
             hash="$(printf '%s' "$line" | cut -d' ' -f1)"
             filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"
@@ -445,7 +748,6 @@ apply_knowledge_proposals() {
                 continue
             fi
             entry_count=$((entry_count + 1))
-            # Use printf to avoid issues with special chars in title
             entries+="$(printf -- '- %s -> [詳細](%s)\n' "$title" "$filepath")"
             entries+=$'\n'
         done <<< "$new_decisions"
@@ -498,6 +800,7 @@ apply_knowledge_proposals() {
 # ============================================================================
 
 # Collect knowledge context for review phase injection
+# Uses grouped/scored output for higher quality context
 # Arguments: $1=since (git date string), $2=project_root (optional)
 # Output: Context string suitable for injection into review prompt
 collect_knowledge_context() {
@@ -506,18 +809,71 @@ collect_knowledge_context() {
 
     local context=""
 
-    # Recent fix commits
-    local fix_commits
-    fix_commits="$(extract_fix_commits "$since" "$project_root")"
+    # Use grouped data for structured context (top 5 categories)
+    local grouped_data
+    grouped_data="$(group_commits_by_category "$since" "$project_root")"
 
-    if [[ -n "$fix_commits" ]]; then
-        context+="
-## 最近のfix commitから抽出された知見
-以下のバグ修正から得られた知見です。同様のパターンのバグがないか確認してください。
-\`\`\`
-${fix_commits}
-\`\`\`
+    if [[ -n "$grouped_data" ]]; then
+        local group_summaries=""
+        local group_idx=0
+        local current_category="" current_count="" current_files=""
+        local -a current_commits=()
+        local in_group=false
+
+        _context_flush_group() {
+            if [[ "$in_group" != "true" ]] || [[ -z "$current_category" ]]; then
+                return
+            fi
+            if [[ "$group_idx" -ge 5 ]]; then
+                return
+            fi
+            group_idx=$((group_idx + 1))
+
+            group_summaries+="  - [${current_category}] ${current_count}件の修正"
+            if [[ -n "$current_files" ]]; then
+                group_summaries+=" (${current_files})"
+            fi
+            group_summaries+=$'\n'
+
+            # Show first 3 commits as examples
+            local shown=0
+            local c
+            for c in "${current_commits[@]}"; do
+                if [[ "$shown" -ge 3 ]]; then
+                    break
+                fi
+                local c_subject="${c#*:}"
+                group_summaries+="    - ${c_subject}"
+                group_summaries+=$'\n'
+                shown=$((shown + 1))
+            done
+        }
+
+        while IFS= read -r line; do
+            case "$line" in
+                CATEGORY:*)
+                    _context_flush_group
+                    current_category="${line#CATEGORY:}"
+                    current_count=""
+                    current_files=""
+                    current_commits=()
+                    in_group=true
+                    ;;
+                COUNT:*) current_count="${line#COUNT:}" ;;
+                FILES:*) current_files="${line#FILES:}" ;;
+                COMMITS:*) current_commits+=("${line#COMMITS:}") ;;
+                *) ;;
+            esac
+        done <<< "$grouped_data"
+        _context_flush_group
+
+        if [[ -n "$group_summaries" ]]; then
+            context+="
+## 最近のfix commitから抽出された知見（上位カテゴリ）
+以下のバグ修正パターンが検出されました。同様のバグがないか確認してください。
+${group_summaries}
 "
+        fi
     fi
 
     # Recent decision files

--- a/scripts/knowledge-loop.sh
+++ b/scripts/knowledge-loop.sh
@@ -9,6 +9,8 @@
 #
 # Options:
 #   --since "N days ago"  Period to analyze (default: "1 week ago")
+#   --top N               Show top N insights (default: 5)
+#   --all                 Show all insights (no limit)
 #   --apply               Apply proposals to AGENTS.md
 #   --dry-run             Show proposals only (default)
 #   --json                Output in JSON format
@@ -22,6 +24,8 @@
 # Examples:
 #   ./scripts/knowledge-loop.sh
 #   ./scripts/knowledge-loop.sh --since "1 week ago"
+#   ./scripts/knowledge-loop.sh --top 10
+#   ./scripts/knowledge-loop.sh --all
 #   ./scripts/knowledge-loop.sh --apply
 #   ./scripts/knowledge-loop.sh --dry-run
 # ============================================================================
@@ -38,15 +42,30 @@ Usage: knowledge-loop.sh [options]
 Options:
     --since "PERIOD"     Period to analyze (default: "1 week ago")
                          Examples: "1 week ago", "3 days ago", "1 month ago"
-    --apply              Apply proposals to AGENTS.md
+    --top N              Show top N insights (default: 5)
+    --all                Show all insights (no limit)
+    --apply              Apply top N proposals to AGENTS.md
     --dry-run            Show proposals only (default)
     --json               Output in JSON format
     -h, --help           Show this help
 
 Description:
     Extracts constraints and lessons from recent fix: commits and
-    docs/decisions/ files, then proposes additions to the AGENTS.md
-    "既知の制約" section.
+    docs/decisions/ files, groups them by category, scores by importance,
+    and proposes additions to the AGENTS.md "既知の制約" section.
+
+    Categories are auto-detected from changed file paths:
+    - lib/marker.sh, watch-session.sh → マーカー検出
+    - lib/ci-*.sh → CI関連
+    - test/ only → テスト安定性
+    - lib/multiplexer*.sh → マルチプレクサ
+    - lib/worktree.sh → Worktree管理
+
+    Scoring is based on:
+    - Number of repeated fixes in the same category (highest weight)
+    - Issue number references in commits
+    - Test-only vs production code changes
+    - Typo/ShellCheck fixes (lowest weight)
 
     Sources analyzed:
     1. fix: commits (git log --grep="^fix:")
@@ -54,10 +73,12 @@ Description:
     3. tracker.jsonl failure patterns (if available)
 
 Examples:
-    knowledge-loop.sh                         # Analyze last 7 days
-    knowledge-loop.sh --since "1 week ago"    # Same as above
-    knowledge-loop.sh --since "3 days ago"    # Last 3 days only
-    knowledge-loop.sh --apply                 # Apply to AGENTS.md
+    knowledge-loop.sh                         # Top 5 insights from last 7 days
+    knowledge-loop.sh --since "1 month ago"   # Top 5 from last month
+    knowledge-loop.sh --top 10                # Top 10 insights
+    knowledge-loop.sh --all                   # All insights (no limit)
+    knowledge-loop.sh --apply                 # Apply top 5 to AGENTS.md
+    knowledge-loop.sh --apply --top 3         # Apply top 3 to AGENTS.md
     knowledge-loop.sh --dry-run               # Preview only (default)
 EOF
         exit 0
@@ -72,12 +93,25 @@ main() {
     local since="1 week ago"
     local mode="dry-run"
     local json_output=false
+    local top_n=5
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --since)
                 since="$2"
                 shift 2
+                ;;
+            --top)
+                if [[ -z "${2:-}" ]] || ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                    log_error "--top requires a positive integer argument"
+                    exit 1
+                fi
+                top_n="$2"
+                shift 2
+                ;;
+            --all)
+                top_n=0
+                shift
                 ;;
             --apply)
                 mode="apply"
@@ -97,7 +131,7 @@ main() {
                 ;;
             *)
                 log_error "Unknown option: $1"
-                echo "Usage: $(basename "$0") [--since PERIOD] [--apply] [--dry-run] [--json] [-h]" >&2
+                echo "Usage: $(basename "$0") [--since PERIOD] [--top N] [--all] [--apply] [--dry-run] [--json] [-h]" >&2
                 exit 1
                 ;;
         esac
@@ -106,20 +140,20 @@ main() {
     load_config 2>/dev/null || true
 
     if [[ "$json_output" == "true" ]]; then
-        _output_json "$since"
+        _output_json "$since" "$top_n"
         return 0
     fi
 
     case "$mode" in
         dry-run)
-            generate_knowledge_proposals "$since" "."
+            generate_knowledge_proposals "$since" "." "$top_n"
             ;;
         apply)
-            generate_knowledge_proposals "$since" "."
+            generate_knowledge_proposals "$since" "." "$top_n"
             echo ""
             echo "Applying proposals to AGENTS.md..."
             local apply_result=0
-            apply_knowledge_proposals "$since" "." || apply_result=$?
+            apply_knowledge_proposals "$since" "." "$top_n" || apply_result=$?
             case "$apply_result" in
                 0) echo "Done. Proposals applied to AGENTS.md." ;;
                 1) echo "No new constraints to apply." ;;
@@ -131,12 +165,7 @@ main() {
 
 _output_json() {
     local since="$1"
-
-    local fix_commits
-    fix_commits="$(extract_fix_commits "$since" ".")"
-
-    local new_decisions
-    new_decisions="$(extract_new_decisions "$since" ".")"
+    local top_n="${2:-5}"
 
     if ! command -v jq &>/dev/null; then
         log_error "jq is required for --json output"
@@ -145,24 +174,77 @@ _output_json() {
 
     local items="[]"
 
-    if [[ -n "$fix_commits" ]]; then
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            local hash subject
-            hash="$(printf '%s' "$line" | cut -d' ' -f1)"
-            subject="$(printf '%s' "$line" | cut -d' ' -f2-)"
-            local constraint
-            constraint="$(printf '%s' "$subject" | sed 's/^fix: *//')"
-            if check_agents_duplicate "$constraint" "AGENTS.md"; then
-                continue
+    # Use grouped data for structured JSON output
+    local grouped_data
+    grouped_data="$(group_commits_by_category "$since" ".")"
+
+    if [[ -n "$grouped_data" ]]; then
+        local current_category="" current_count="" current_score="" current_files=""
+        local -a current_commits=()
+        local group_idx=0
+        local in_group=false
+
+        _json_flush_group() {
+            if [[ "$in_group" != "true" ]] || [[ -z "$current_category" ]]; then
+                return
             fi
-            items="$(printf '%s' "$items" | jq -c --arg type "fix_commit" --arg hash "$hash" --arg subject "$subject" --arg constraint "$constraint" '. + [{type: $type, hash: $hash, subject: $subject, constraint: $constraint}]')"
-        done <<< "$fix_commits"
+            if [[ "$top_n" -gt 0 ]] && [[ "$group_idx" -ge "$top_n" ]]; then
+                return
+            fi
+            group_idx=$((group_idx + 1))
+
+            # Build commits array
+            local commits_json="[]"
+            local c
+            for c in "${current_commits[@]}"; do
+                local c_hash="${c%%:*}"
+                local c_subject="${c#*:}"
+                commits_json="$(printf '%s' "$commits_json" | jq -c --arg hash "$c_hash" --arg subject "$c_subject" '. + [{hash: $hash, subject: $subject}]')"
+            done
+
+            items="$(printf '%s' "$items" | jq -c \
+                --arg type "category" \
+                --arg category "$current_category" \
+                --argjson count "${current_count:-0}" \
+                --argjson score "${current_score:-0}" \
+                --arg files "${current_files:-}" \
+                --argjson commits "$commits_json" \
+                '. + [{type: $type, category: $category, count: $count, score: $score, files: $files, commits: $commits}]')"
+        }
+
+        while IFS= read -r line; do
+            case "$line" in
+                CATEGORY:*)
+                    _json_flush_group
+                    current_category="${line#CATEGORY:}"
+                    current_count=""
+                    current_score=""
+                    current_files=""
+                    current_commits=()
+                    in_group=true
+                    ;;
+                COUNT:*) current_count="${line#COUNT:}" ;;
+                SCORE:*) current_score="${line#SCORE:}" ;;
+                FILES:*) current_files="${line#FILES:}" ;;
+                COMMITS:*) current_commits+=("${line#COMMITS:}") ;;
+                *) ;;
+            esac
+        done <<< "$grouped_data"
+        _json_flush_group
     fi
+
+    # Decision files
+    local new_decisions
+    new_decisions="$(extract_new_decisions "$since" ".")"
 
     if [[ -n "$new_decisions" ]]; then
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
+            local current_items_count
+            current_items_count="$(printf '%s' "$items" | jq 'length')"
+            if [[ "$top_n" -gt 0 ]] && [[ "$current_items_count" -ge "$top_n" ]]; then
+                break
+            fi
             local hash filepath
             hash="$(printf '%s' "$line" | cut -d' ' -f1)"
             filepath="$(printf '%s' "$line" | cut -d' ' -f2-)"


### PR DESCRIPTION
## Summary
Closes #1361

## Changes
- **カテゴリ自動分類**: 変更ファイルパスからカテゴリを推定（マーカー検出/CI関連/テスト安定性/Worktree管理等）
- **重要度スコアリング**: 繰り返し修正（最高重み）、Issue番号参照（中）、テスト修正のみ（低）、typo/ShellCheck（最低）
- **グループ化表示**: 同一カテゴリのコミットを集約し、星評価（★★★/★★☆/★☆☆/☆☆☆）で表示
- **`--top N` オプション**: デフォルト上位5件のみ表示（`--top 10` で件数変更可能）
- **`--all` オプション**: 全件表示（従来互換）
- **`--apply` の安全性向上**: top_n 件数制限を適用した上位のみ適用対象
- **`collect_knowledge_context()` の改善**: 上位カテゴリのみ注入（improve.sh連携にもフィルタリング適用）
- **JSON出力**: グループ化形式に対応（type=category, commits配列含む）

## Testing
- 既存テスト27件全てパス（2件のみ出力フォーマット変更に対応して更新）
- 新規テスト25件追加（categorize_commit, score_commit, group_commits_by_category, top_n制限, --all等）
- ShellCheck警告ゼロ
- improve/review.sh からの collect_knowledge_context 呼び出しの後方互換性確認済み