### PR TITLE
docs: add missing github and hooks sections to complete config example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,6 +282,41 @@ tracker:
   file: ".worktrees/.status/tracker.jsonl"
 
 # =====================================
+# GitHub設定
+# =====================================
+github:
+  # Issueコメントをプロンプトに含めるか
+  # デフォルト: true
+  include_comments: true
+  
+  # 含めるコメント数の上限
+  # デフォルト: 10
+  max_comments: 10
+
+# =====================================
+# Hook設定
+# =====================================
+hooks:
+  # タスク開始時
+  on_start: ""
+  # 成功時
+  on_success: ""
+  # エラー時
+  on_error: ""
+  # クリーンアップ時
+  on_cleanup: ""
+  # improve開始時
+  on_improve_start: ""
+  # improve終了時
+  on_improve_end: ""
+  # イテレーション開始時
+  on_iteration_start: ""
+  # イテレーション終了時
+  on_iteration_end: ""
+  # レビュー完了時
+  on_review_complete: ""
+
+# =====================================
 # Watcher設定
 # =====================================
 watcher:


### PR DESCRIPTION
## Summary
Closes #1375

## Changes
- Added `github` section to the complete configuration example with:
  - `include_comments`: Whether to include issue comments in prompts
  - `max_comments`: Maximum number of comments to include
- Added `hooks` section to the complete configuration example with:
  - Session lifecycle hooks: `on_start`, `on_success`, `on_error`, `on_cleanup`
  - Improve lifecycle hooks: `on_improve_start`, `on_improve_end`, `on_iteration_start`, `on_iteration_end`, `on_review_complete`

Both sections were already documented individually in the file but were missing from the comprehensive configuration example at the top.

## Testing
- Validated that both sections appear in the complete YAML example using the provided grep command
- Verified YAML syntax is correct
- Confirmed comments match the individual section descriptions