### PR TITLE
fix: add hooks and tracker sections to check_document_structure()

### DIFF
--- a/scripts/verify-config-docs.sh
+++ b/scripts/verify-config-docs.sh
@@ -127,10 +127,12 @@ check_document_structure() {
         "improve"
         "agents"
         "github"
+        "hooks"
         "watcher"
         "auto"
         "workflow"
         "workflows"
+        "tracker"
     )
 
     for section in "${sections[@]}"; do


### PR DESCRIPTION
## Summary
Closes #1372

## Changes
- Added `hooks` and `tracker` to the `sections` array in `check_document_structure()` in `scripts/verify-config-docs.sh`
- Both sections exist in `docs/configuration.md` (L1071, L1157) but were not being validated

## Testing
- `./scripts/verify-config-docs.sh --verbose` now reports both sections as found
- All verify-config-docs.bats tests pass (13/13)
- ShellCheck passes with no warnings