### PR TITLE
docs: add deprecation notice for workflow (singular) section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,19 +100,20 @@ parallel:
   max_concurrent: 3
 
 # =====================================
-# ワークフロー設定（デフォルト）
+# ワークフロー設定（デフォルト） - 非推奨: workflows.default を推奨
 # =====================================
-# 注: -w オプション未指定時に使用されるデフォルトワークフロー
-#     ワークフロー名を指定する場合は workflows/*.yaml を作成し、-w オプションを使用
-workflow:
-  # 実行するステップ
-  # ビルトイン: plan, implement, review, merge
-  # カスタムステップも定義可能（対応するエージェントテンプレートが必要）
-  steps:
-    - plan
-    - implement
-    - review
-    - merge
+# NOTE: workflow:（単数形）は後方互換のために残されています。
+# 新しいプロジェクトでは workflows.default を使用してください。
+# workflow:
+#   # 実行するステップ
+#   # ビルトイン: plan, implement, test, review, merge, ci-fix
+#   # カスタムステップも定義可能（対応するエージェントテンプレートが必要）
+#   steps:
+#     - plan
+#     - implement
+#     - test
+#     - review
+#     - merge
 
 # =====================================
 # 名前付きワークフロー設定（複数定義）
@@ -772,9 +773,11 @@ PI_RUNNER_AUTO_PROVIDER=anthropic ./scripts/run.sh 42 -w auto
 PI_RUNNER_AUTO_MODEL=claude-haiku-4-5 ./scripts/run.sh 42 -w auto
 ```
 
-### workflow
+### workflow（非推奨）
 
-**重要**: `.pi-runner.yaml` の `workflow` セクションは、**`-w` オプションを指定しない場合に使用される「デフォルトワークフロー」**を定義します。
+> **⚠️ 非推奨**: `workflow:`（単数形）は後方互換のために残されています。新しいプロジェクトでは `workflows.default` を使用してください。`workflows.default` が定義されている場合、`workflow:` は無視されます。
+
+`.pi-runner.yaml` の `workflow` セクションは、`-w` オプション未指定時のデフォルトワークフローを定義します。
 
 | キー | 型 | デフォルト | 説明 |
 |------|------|-----------|------|


### PR DESCRIPTION
## Summary
Closes #1381

## Changes
- Added deprecation notice to `workflow:` section in complete configuration example
- Commented out `workflow:` section and recommended `workflows.default` instead
- Updated `### workflow` section title to `### workflow（非推奨）`
- Added clear deprecation warning stating that `workflows.default` takes precedence
- Updated built-in steps comment to include `test` and `ci-fix`

## Testing
- Verified deprecation notices are present (4 instances in total)
- Verified `workflows.default` recommendation is clearly stated
- Verified `./scripts/verify-config-docs.sh` passes successfully
- All configuration documentation checks pass