### PR TITLE
fix: remove unused get_commit_diff_summary() from lib/knowledge-loop.sh

### DIFF
--- a/lib/knowledge-loop.sh
+++ b/lib/knowledge-loop.sh
@@ -56,16 +56,6 @@ extract_fix_commits() {
         --no-merges 2>/dev/null || true
 }
 
-# Get diff summary for a commit
-# Arguments: $1=commit_hash, $2=project_root (optional)
-# Output: diff stat lines
-get_commit_diff_summary() {
-    local commit_hash="$1"
-    local project_root="${2:-.}"
-
-    git -C "$project_root" diff-tree --no-commit-id -r --stat "$commit_hash" 2>/dev/null || true
-}
-
 # Get commit message body (full, not just subject)
 # Arguments: $1=commit_hash, $2=project_root (optional)
 # Output: commit body text


### PR DESCRIPTION
## Summary
Closes #1378

## Changes
- Removed unused `get_commit_diff_summary()` function from `lib/knowledge-loop.sh`
- The function was defined but never called from any production code, test code, or other functions in the same file
- The `Provides:` header comment also did not list this function

## Testing
- All 27 `test/lib/knowledge-loop.bats` tests pass
- All 12 `test/scripts/knowledge-loop.bats` tests pass
- ShellCheck clean on `lib/knowledge-loop.sh`
- `grep -rn get_commit_diff_summary` returns 0 results after removal