### PR TITLE
fix: add tracker section to pi-runner.schema.json

### DIFF
--- a/schemas/pi-runner.schema.json
+++ b/schemas/pi-runner.schema.json
@@ -316,6 +316,18 @@
         }
       }
     },
+    "tracker": {
+      "type": "object",
+      "description": "Prompt tracker settings",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "default": ".worktrees/.status/tracker.jsonl",
+          "description": "Path to the tracker JSONL file"
+        }
+      }
+    },
     "watcher": {
       "type": "object",
       "description": "Session watcher settings",


### PR DESCRIPTION
## Summary
Closes #1371

## Changes
- Added `tracker` property to `schemas/pi-runner.schema.json` with `file` sub-property
- The tracker section was already supported in `lib/config.sh` (tracker_file key) and documented in `docs/configuration.md`, but missing from the JSON Schema
- Since the schema uses `additionalProperties: false`, any `.pi-runner.yaml` with a `tracker:` section was being rejected by validation

## Testing
- `bats test/scripts/verify-config-docs.bats` - all 13 tests pass
- `bats test/lib/config.bats test/lib/tracker.bats` - all tests pass
- `bats test/regression/config-master-table-dry.bats` - all 6 tests pass