### PR TITLE
docs: README.md のディレクトリ構造に agents/improve-review.md を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ pi-issue-runner/
 │   └── thorough.yaml       # 徹底ワークフロー
 ├── agents/                  # エージェントテンプレート
 │   ├── ci-fix.md           # CI修正エージェント
+│   ├── improve-review.md   # improve.sh レビュープロンプト
 │   ├── plan.md             # 計画エージェント
 │   ├── implement.md        # 実装エージェント
 │   ├── test.md             # テストエージェント


### PR DESCRIPTION
## Summary
Closes #1384

## Changes
- README.md のディレクトリ構造 agents/ セクションに `improve-review.md` を追加
- 実際のファイル構造と一致させた

## Testing
- 全テストスイートの実行: 1337件パス、3件失敗（既存の無関係な失敗）
- `improve-review.md` が実際に agents/ ディレクトリに存在することを確認
- AGENTS.md は既に正しい記載があることを確認