### PR TITLE
feat: integrate gates into watch-session.sh for quality checks before PR confirmation

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -66,6 +66,7 @@ Options:
     -l, --label LABEL   セッションラベル（識別用タグ）
     --no-attach         セッション作成後にアタッチしない
     --no-cleanup        エージェント終了後の自動クリーンアップを無効化
+    --no-gates          ゲート（品質チェック）を無効化
     --reattach          既存セッションがあればアタッチ
     --force             既存セッション/worktreeを削除して再作成
     --agent-args ARGS   エージェントに渡す追加の引数
@@ -165,6 +166,7 @@ parse_run_arguments() {
     local list_workflows=false
     local ignore_blockers=false
     local session_label=""
+    local no_gates=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -207,6 +209,10 @@ parse_run_arguments() {
                 ;;
             --no-cleanup)
                 cleanup_mode="none"
+                shift
+                ;;
+            --no-gates)
+                no_gates=true
                 shift
                 ;;
             --ignore-blockers)
@@ -264,6 +270,7 @@ parse_run_arguments() {
     _PARSE_list_workflows="$list_workflows"
     _PARSE_ignore_blockers="$ignore_blockers"
     _PARSE_session_label="$session_label"
+    _PARSE_no_gates="$no_gates"
 }
 
 # ============================================================================
@@ -591,6 +598,7 @@ main() {
     local list_workflows="$_PARSE_list_workflows"
     local ignore_blockers="$_PARSE_ignore_blockers"
     local session_label="$_PARSE_session_label"
+    local no_gates="$_PARSE_no_gates"
     
     # Validate inputs
     validate_run_inputs "$issue_number" "$list_workflows"
@@ -630,6 +638,9 @@ main() {
     start_agent_session "$session_name" "$issue_number" "$issue_title" "$issue_body" "$branch_name" "$full_worktree_path" "$workflow_name" "$issue_comments" "$extra_agent_args" "$session_label"
     
     # Setup completion watcher
+    if [[ "$no_gates" == "true" ]]; then
+        export PI_NO_GATES=1
+    fi
     setup_completion_watcher "$cleanup_mode" "$session_name" "$issue_number"
     
     # Display summary and attach

--- a/test/scripts/run.bats
+++ b/test/scripts/run.bats
@@ -49,6 +49,7 @@ teardown() {
     [[ "$output" == *"--no-attach"* ]]
     [[ "$output" == *"--force"* ]]
     [[ "$output" == *"--ignore-blockers"* ]]
+    [[ "$output" == *"--no-gates"* ]]
 }
 
 @test "help includes examples" {
@@ -158,6 +159,31 @@ teardown() {
 @test "run.sh accepts --ignore-blockers option" {
     run "$PROJECT_ROOT/scripts/run.sh" --help
     [[ "$output" == *"--ignore-blockers"* ]]
+}
+
+@test "run.sh accepts --no-gates option" {
+    run "$PROJECT_ROOT/scripts/run.sh" --help
+    [[ "$output" == *"--no-gates"* ]]
+}
+
+@test "run.sh --no-gates is parsed into _PARSE_no_gates" {
+    source "$PROJECT_ROOT/scripts/run.sh" 2>/dev/null || true
+
+    # Mock functions called during parse
+    resolve_default_workflow() { echo "default"; }
+
+    parse_run_arguments 42 --no-gates
+    [ "$_PARSE_no_gates" = "true" ]
+    [ "$_PARSE_issue_number" = "42" ]
+}
+
+@test "run.sh _PARSE_no_gates defaults to false" {
+    source "$PROJECT_ROOT/scripts/run.sh" 2>/dev/null || true
+
+    resolve_default_workflow() { echo "default"; }
+
+    parse_run_arguments 42
+    [ "$_PARSE_no_gates" = "false" ]
 }
 
 # ====================


### PR DESCRIPTION
## Summary

- Add `_run_gates_check()` to `watch-session.sh`: when COMPLETE marker is detected, gates (quality checks) run before PR confirmation. If gates fail, a nudge with error details is sent to the AI session and monitoring continues for re-completion.
- Add `--no-gates` option to `run.sh` to disable gate checks (passes `PI_NO_GATES=1` env var to the watcher process)
- Gate failure causes `handle_complete()` to return 2 (continue monitoring), preventing premature status changes and PR checks

## Test Plan

- 9 new tests in `test/scripts/watch-session.bats` covering: PI_NO_GATES skip, no config file, no gates defined, gates pass, gates fail with nudge, session not existing for nudge, return code verification, and step ordering
- 3 new tests in `test/scripts/run.bats` covering: --no-gates in help, argument parsing, and default value
- All existing tests pass (141 tests across run.bats + watch-session.bats + gates.bats)
- ShellCheck passes clean

Closes #1389