### PR TITLE
feat: call: ゲート — 別ワークフローをレビューエージェントとして呼び出す

### DIFF
--- a/lib/gates.sh
+++ b/lib/gates.sh
@@ -8,6 +8,7 @@
 #   - parse_gate_config: YAML設定からゲートリストをパース
 #   - expand_gate_variables: テンプレート変数を展開
 #   - run_single_gate: 単一ゲートの実行
+#   - run_call_gate: call形式ゲートの実行（別ワークフローをAIで実行）
 #   - run_gates: ゲートリストを順番に実行
 #   - detect_call_cycle: call: の循環呼び出し検出
 
@@ -25,6 +26,7 @@ _GATES_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_GATES_LIB_DIR/log.sh"
 source "$_GATES_LIB_DIR/yaml.sh"
 source "$_GATES_LIB_DIR/compat.sh"
+source "$_GATES_LIB_DIR/marker.sh"
 
 # ===================
 # 定数
@@ -225,13 +227,218 @@ run_single_gate() {
 }
 
 # ===================
+# run_call_gate - call形式ゲートの実行
+# ===================
+
+# call形式ゲートを実行
+# 別ワークフローを別AIインスタンスとして実行し、結果を判定する
+#
+# Usage: run_call_gate <workflow_name> <timeout> <worktree_path> [config_file] [issue_number] [branch_name] [calling_workflow]
+# Returns: 0=通過（COMPLETEマーカー検出）, 1=失敗（ERROR/タイムアウト/循環）
+# Output: AIの出力をstdoutに出力
+run_call_gate() {
+    local workflow_name="$1"
+    local timeout="${2:-$GATE_DEFAULT_TIMEOUT}"
+    local worktree_path="${3:-.}"
+    local config_file="${4:-}"
+    local issue_number="${5:-${PI_ISSUE_NUMBER:-0}}"
+    local branch_name="${6:-${PI_BRANCH_NAME:-}}"
+    local calling_workflow="${7:-}"
+
+    # 設定ファイルの解決
+    if [[ -z "$config_file" ]]; then
+        config_file="${PI_RUNNER_CONFIG_FILE:-}"
+        if [[ -z "$config_file" ]] && [[ -f "$worktree_path/.pi-runner.yaml" ]]; then
+            config_file="$worktree_path/.pi-runner.yaml"
+        fi
+    fi
+
+    # 循環呼び出し検出
+    if [[ -n "$config_file" ]] && [[ -f "$config_file" ]]; then
+        local cycle_chain="${calling_workflow:-}"
+        if ! detect_call_cycle "$config_file" "$workflow_name" "$cycle_chain"; then
+            echo "Call cycle detected for workflow: $workflow_name"
+            return 1
+        fi
+    fi
+
+    # ワークフロー存在確認
+    if [[ -n "$config_file" ]] && [[ -f "$config_file" ]]; then
+        if ! yaml_exists "$config_file" ".workflows.${workflow_name}"; then
+            log_error "Workflow not found: $workflow_name"
+            echo "Workflow not found: $workflow_name"
+            return 1
+        fi
+    else
+        log_error "Config file not found, cannot resolve call: $workflow_name"
+        echo "Config file not found, cannot resolve call: $workflow_name"
+        return 1
+    fi
+
+    # git diff を取得してプロンプトに含めるための準備
+    local diff_content=""
+    if [[ -d "$worktree_path/.git" ]] || [[ -f "$worktree_path/.git" ]]; then
+        diff_content=$(cd "$worktree_path" && git diff origin/main 2>/dev/null || git diff HEAD 2>/dev/null || echo "")
+    fi
+
+    # プロンプトファイルを生成
+    local prompt_file
+    prompt_file="$(mktemp "${TMPDIR:-/tmp}/pi-call-gate-XXXXXX.md")"
+
+    # ワークフローのステップを取得してプロンプトを構築
+    local steps=""
+    while IFS= read -r step; do
+        [[ -n "$step" ]] && steps="${steps:+$steps }$step"
+    done < <(yaml_get_array "$config_file" ".workflows.${workflow_name}.steps")
+
+    local description=""
+    description=$(yaml_get "$config_file" ".workflows.${workflow_name}.description" 2>/dev/null || echo "")
+
+    # レビュー用プロンプトを構築
+    {
+        printf '# Gate Review: %s\n\n' "$workflow_name"
+        printf 'Workflow: %s\n' "$workflow_name"
+        if [[ -n "$description" ]]; then
+            printf 'Description: %s\n' "$description"
+        fi
+        printf 'Steps: %s\n\n' "$steps"
+        printf 'Issue: #%s\n' "$issue_number"
+        printf 'Branch: %s\n' "$branch_name"
+        printf 'Worktree: %s\n\n' "$worktree_path"
+
+        if [[ -n "$diff_content" ]]; then
+            printf '## Changes to Review\n\n'
+            printf '```diff\n%s\n```\n\n' "$diff_content"
+        fi
+
+        printf '## Instructions\n\n'
+        printf 'Review the changes above. If everything looks good, output the completion marker.\n'
+        printf 'If there are issues, output the error marker with details.\n\n'
+        printf 'Completion marker (output on a single line): ###TASK_COMPLETE_%s###\n' "$issue_number"
+        printf 'Error marker (output on a single line): ###TASK_ERROR_%s###\n' "$issue_number"
+    } > "$prompt_file"
+
+    # エージェント設定を取得・適用
+    # ワークフロー固有のagent設定を読み取る
+    local agent_type="" agent_command="" agent_args="" agent_template=""
+    agent_type=$(yaml_get "$config_file" ".workflows.${workflow_name}.agent.type" 2>/dev/null || echo "")
+    agent_command=$(yaml_get "$config_file" ".workflows.${workflow_name}.agent.command" 2>/dev/null || echo "")
+    agent_template=$(yaml_get "$config_file" ".workflows.${workflow_name}.agent.template" 2>/dev/null || echo "")
+
+    # args は配列
+    while IFS= read -r arg; do
+        [[ -n "$arg" ]] && agent_args="${agent_args:+$agent_args }$arg"
+    done < <(yaml_get_array "$config_file" ".workflows.${workflow_name}.agent.args" 2>/dev/null)
+
+    # ワークフロー固有の設定が未設定の場合はグローバル設定にフォールバック
+    if [[ -z "$agent_type" ]]; then
+        agent_type=$(yaml_get "$config_file" ".agent.type" 2>/dev/null || echo "")
+        if [[ -z "$agent_type" ]]; then
+            agent_type="pi"
+        fi
+    fi
+    if [[ -z "$agent_command" ]]; then
+        agent_command=$(yaml_get "$config_file" ".agent.command" 2>/dev/null || echo "")
+    fi
+    if [[ -z "$agent_template" ]]; then
+        agent_template=$(yaml_get "$config_file" ".agent.template" 2>/dev/null || echo "")
+    fi
+    if [[ -z "$agent_args" ]]; then
+        while IFS= read -r arg; do
+            [[ -n "$arg" ]] && agent_args="${agent_args:+$agent_args }$arg"
+        done < <(yaml_get_array "$config_file" ".agent.args" 2>/dev/null)
+    fi
+
+    # プリセットからコマンド・テンプレートを解決
+    if [[ -z "$agent_command" ]]; then
+        case "$agent_type" in
+            pi)      agent_command="pi" ;;
+            claude)  agent_command="claude" ;;
+            opencode) agent_command="opencode" ;;
+            *)       agent_command="$agent_type" ;;
+        esac
+    fi
+
+    if [[ -z "$agent_template" ]]; then
+        case "$agent_type" in
+            pi)      agent_template='{{command}} {{args}} @"{{prompt_file}}"' ;;
+            claude)  agent_template='{{command}} {{args}} --print "{{prompt_file}}"' ;;
+            opencode) agent_template='cat "{{prompt_file}}" | {{command}} {{args}}' ;;
+            *)       agent_template='{{command}} {{args}} @"{{prompt_file}}"' ;;
+        esac
+    fi
+
+    # テンプレート変数を置換
+    local full_command="$agent_template"
+    full_command="${full_command//\{\{command\}\}/$agent_command}"
+    full_command="${full_command//\{\{args\}\}/$agent_args}"
+    full_command="${full_command//\{\{prompt_file\}\}/$prompt_file}"
+
+    log_info "Call gate: executing workflow '$workflow_name' with agent '$agent_type'"
+    log_debug "Call gate command: $full_command"
+
+    # エージェントを実行してキャプチャ
+    local output=""
+    local exit_code=0
+
+    output=$(
+        cd "$worktree_path" 2>/dev/null || true
+        safe_timeout "$timeout" bash -c "$full_command" 2>&1
+    ) || exit_code=$?
+
+    # プロンプトファイルのクリーンアップ
+    rm -f "$prompt_file"
+
+    # 出力を表示
+    if [[ -n "$output" ]]; then
+        echo "$output"
+    fi
+
+    # タイムアウト判定
+    if [[ $exit_code -eq 124 ]]; then
+        log_warn "Call gate timed out after ${timeout}s: $workflow_name"
+        return 1
+    fi
+
+    # マーカー判定
+    local complete_marker="###TASK_COMPLETE_${issue_number}###"
+    local error_marker="###TASK_ERROR_${issue_number}###"
+
+    # COMPLETEマーカー検出 → 通過
+    local complete_count=0
+    complete_count=$(count_markers_outside_codeblock "$output" "$complete_marker")
+    if [[ $complete_count -gt 0 ]]; then
+        log_info "Call gate passed: $workflow_name (COMPLETE marker detected)"
+        return 0
+    fi
+
+    # ERRORマーカー検出 → 失敗
+    local error_count=0
+    error_count=$(count_markers_outside_codeblock "$output" "$error_marker")
+    if [[ $error_count -gt 0 ]]; then
+        log_error "Call gate failed: $workflow_name (ERROR marker detected)"
+        return 1
+    fi
+
+    # マーカーなし: 終了コードで判定
+    if [[ $exit_code -ne 0 ]]; then
+        log_error "Call gate failed: $workflow_name (exit code: $exit_code)"
+        return 1
+    fi
+
+    # 正常終了だがマーカーなし → 通過扱い
+    log_info "Call gate passed: $workflow_name (no marker, exit 0)"
+    return 0
+}
+
+# ===================
 # run_gates - ゲートリストを順番に実行
 # ===================
 
 # ゲートリストを順番に実行
 # parse_gate_config の出力を入力として受け取る
 #
-# Usage: run_gates <gate_definitions> [issue_number] [pr_number] [branch_name] [worktree_path]
+# Usage: run_gates <gate_definitions> [issue_number] [pr_number] [branch_name] [worktree_path] [config_file] [calling_workflow]
 # gate_definitions: parse_gate_config の出力（タブ区切り形式）
 # Returns: 0=全通過, 1=いずれか失敗
 # Output: 失敗ゲートの出力をstdoutに出力
@@ -241,6 +448,8 @@ run_gates() {
     local pr_number="${3:-${PI_PR_NUMBER:-}}"
     local branch_name="${4:-${PI_BRANCH_NAME:-}}"
     local worktree_path="${5:-${PI_WORKTREE_PATH:-.}}"
+    local config_file="${6:-${PI_RUNNER_CONFIG_FILE:-}}"
+    local calling_workflow="${7:-}"
 
     if [[ -z "$gate_definitions" ]]; then
         log_debug "No gates defined, skipping"
@@ -258,20 +467,58 @@ run_gates() {
         local gate_type gate_cmd_or_name gate_timeout gate_max_retry gate_retry_interval gate_continue_on_fail gate_description
         IFS=$'\t' read -r gate_type gate_cmd_or_name gate_timeout gate_max_retry gate_retry_interval gate_continue_on_fail gate_description <<< "$gate_line"
 
-        # call 形式は本Issueではスキップ（後続Issue実装）
         if [[ "$gate_type" == "call" ]]; then
-            log_info "Gate $gate_index: call:${gate_cmd_or_name} (skipped - not yet implemented)"
+            local display_name="${gate_description:-call:${gate_cmd_or_name}}"
+            log_info "Gate $gate_index: $display_name"
+
+            local attempt=0
+            local gate_passed=false
+
+            while [[ $attempt -le ${gate_max_retry:-0} ]]; do
+                if [[ $attempt -gt 0 ]]; then
+                    log_info "Gate $gate_index: retry $attempt/${gate_max_retry} (waiting ${gate_retry_interval}s)"
+                    sleep "${gate_retry_interval:-$GATE_DEFAULT_RETRY_INTERVAL}"
+                fi
+
+                local output=""
+                local gate_exit=0
+                output=$(run_call_gate "$gate_cmd_or_name" "${gate_timeout:-$GATE_DEFAULT_TIMEOUT}" "$worktree_path" "$config_file" "$issue_number" "$branch_name" "$calling_workflow") || gate_exit=$?
+
+                if [[ $gate_exit -eq 0 ]]; then
+                    gate_passed=true
+                    log_info "Gate $gate_index: PASSED"
+                    break
+                fi
+
+                attempt=$((attempt + 1))
+            done
+
+            if [[ "$gate_passed" == "false" ]]; then
+                log_error "Gate $gate_index: FAILED - $display_name"
+                if [[ -n "$output" ]]; then
+                    failed_output+="Gate failed: ${display_name}"$'\n'"${output}"$'\n'
+                else
+                    failed_output+="Gate failed: ${display_name}"$'\n'
+                fi
+
+                if [[ "$gate_continue_on_fail" == "true" ]]; then
+                    log_warn "Gate $gate_index: continue_on_fail=true, continuing..."
+                    has_failure=true
+                else
+                    echo "$failed_output"
+                    return 1
+                fi
+            fi
+
             continue
         fi
 
-        # 変数展開
         local expanded_cmd
         expanded_cmd=$(expand_gate_variables "$gate_cmd_or_name" "$issue_number" "$pr_number" "$branch_name" "$worktree_path")
 
         local display_name="${gate_description:-$expanded_cmd}"
         log_info "Gate $gate_index: $display_name"
 
-        # リトライループ
         local attempt=0
         local gate_passed=false
 


### PR DESCRIPTION
## Summary

`call:` ゲートタイプを実装し、ワークフローのステップから別のワークフローを独立したAIエージェントセッションとして呼び出せるようにしました。

### Changes

- **`lib/gates.sh`**: `run_call_gate()` 関数を追加（~190行）
  - エージェント設定の3階層フォールバック（ワークフロー固有 → グローバル → プリセット）
  - `detect_call_cycle()` による循環呼び出し検出
  - Git diffベースのレビュープロンプト生成
  - COMPLETE/ERROR マーカー検出（終了コードフォールバック付き）
  - `run_gates()` の後方互換性維持（新パラメータ6-7はオプション）

- **`test/lib/gates.bats`**: 10個の新テスト追加（合計50テスト）
  - マーカー成功/失敗、タイムアウト、循環検出、存在しないワークフロー
  - 終了コードフォールバック、グローバル設定フォールバック
  - `run_gates` 統合テスト（call ゲート実行・失敗停止）

### Backward Compatibility

`run_gates()` は新しいパラメータ（`config_file`, `calling_workflow`）をオプションとして追加。既存の5引数呼び出し（`watch-session.sh:462`）は環境変数 `PI_RUNNER_CONFIG_FILE` へのフォールバックで互換性を維持。

Closes #1390