### PR TITLE
feat: generate-config.sh で gates 設定を自動提案

### DIFF
--- a/scripts/generate-config.sh
+++ b/scripts/generate-config.sh
@@ -135,6 +135,8 @@ _generate_yaml_content() {
         local project_context
         project_context="$(collect_project_context ".")"
 
+        detect_gates "."
+
         yaml_content="$(generate_with_ai "$project_context")" || {
             log_warn "AI生成に失敗しました。静的テンプレートにフォールバックします。"
             yaml_content=""


### PR DESCRIPTION
## Summary

`generate-config.sh` でプロジェクトの技術スタックを自動検出し、適切な品質ゲート（`gates:`）を `.pi-runner.yaml` に提案する機能を追加。

## Changes

- **`lib/generate-config.sh`**: `detect_gates()` 関数を追加。プロジェクトルートのファイル（`package.json`, `Cargo.toml`, `go.mod`, `Makefile` 等）を解析し、テスト・lint コマンドを自動選定
- **`lib/generate-config.sh`**: `_generate_static_gates()` 関数を追加。検出されたゲートを YAML `gates:` セクションとして出力
- **`lib/generate-config.sh`**: `build_ai_prompt()` を更新。AI パスでも検出結果をヒントとしてプロンプトに注入
- **`scripts/generate-config.sh`**: AI 生成パスで `detect_gates "."` を事前呼び出し
- **`test/scripts/generate-config.bats`**: 9 件のテスト追加（Node.js/Go/Rust/Python/Bash/Makefile/未検出/YAML形式）

## Supported Project Types

| Project Type | Detection | Gates |
|---|---|---|
| Node.js | `package.json` | `npm test`, `npm run lint` |
| Go | `go.mod` | `go test ./...`, `go vet ./...` |
| Rust | `Cargo.toml` | `cargo test`, `cargo clippy` |
| Python | `requirements.txt` / `pyproject.toml` / `setup.py` | `pytest`, `ruff check .` / `flake8` |
| Bash | `*.bats` / `*.sh` | `shellcheck`, `bats test/` |
| Makefile | `Makefile` with targets | `make test`, `make lint` |

## Test Results

全 45 テストパス（既存 36 + 新規 9）、ShellCheck クリーン。

Closes #1402