### PR TITLE
docs: add deprecation notice to force-complete.sh section in SPECIFICATION.md

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1042,7 +1042,10 @@ Examples:
     generate-config.sh -o custom.yaml   # カスタム出力先
 ```
 
-### force-complete.sh - セッション強制完了
+### force-complete.sh - セッション強制完了（⚠️ 非推奨）
+
+> **⚠️ 非推奨**: `force-complete.sh` は非推奨です。代わりに `stop.sh <target> --cleanup` を使用してください。
+> このスクリプトは内部的に `stop.sh --cleanup` にリダイレクトされます。
 
 ```bash
 ./scripts/force-complete.sh <session-name|issue-number> [options]
@@ -1066,6 +1069,11 @@ AIが完了マーカーを出力し忘れた場合や、手動でタスク完了
 #### 使用例
 
 ```bash
+# 推奨: stop.sh --cleanup を直接使用
+./scripts/stop.sh 42 --cleanup
+./scripts/stop.sh pi-issue-42 --cleanup
+
+# 非推奨（force-complete.sh は stop.sh にリダイレクト）
 ./scripts/force-complete.sh 42
 ./scripts/force-complete.sh pi-issue-42
 ./scripts/force-complete.sh 42 --error


### PR DESCRIPTION
## Summary
Closes #1409

## Changes
- Added deprecation notice to the `force-complete.sh` section title
- Added a warning box explaining that `force-complete.sh` is deprecated
- Updated usage examples to show the recommended `stop.sh --cleanup` command first
- Kept legacy examples but marked them as deprecated

## Testing
- Verified deprecation notice is present: `grep -A 2 'force-complete' docs/SPECIFICATION.md | grep -i 'deprecat\|非推奨\|廃止'`
- Confirmed only SPECIFICATION.md was modified
- Documentation now aligns with AGENTS.md which already had the deprecation warning