### PR TITLE
docs: add missing auto_attach to SPECIFICATION.md watcher config

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -359,6 +359,7 @@ watcher:
   cleanup_retry_interval: 3        # クリーンアップリトライ間隔（秒）
   pr_merge_max_attempts: 10        # PRマージチェック最大試行回数
   pr_merge_retry_interval: 60      # PRマージチェック間隔（秒）
+  auto_attach: true                # エラー検知時にターミナルを自動で開く
 
 # =====================================
 # プロンプトトラッカー設定
@@ -469,6 +470,7 @@ PI_RUNNER_WATCHER_CLEANUP_RETRY_INTERVAL="3"     # リトライ間隔（秒）
 PI_RUNNER_WATCHER_PR_MERGE_MAX_ATTEMPTS="10"     # PRマージ最大試行回数
 PI_RUNNER_WATCHER_PR_MERGE_RETRY_INTERVAL="60"   # PRマージチェック間隔（秒）
 PI_RUNNER_WATCHER_FORCE_CLEANUP_ON_TIMEOUT="false" # タイムアウト時強制クリーンアップ
+PI_RUNNER_WATCHER_AUTO_ATTACH="true"             # エラー検知時にターミナルを自動で開く
 ```
 
 #### プロンプトトラッカー設定


### PR DESCRIPTION
## Summary
Closes #1417

## Changes
- Added `auto_attach: true` to watcher configuration example section
- Added `PI_RUNNER_WATCHER_AUTO_ATTACH` to environment variables section
- Ensures consistency with `docs/configuration.md`

## Testing
- Verified that `auto_attach` appears in watcher config example:
  ```bash
  grep -A 10 "^watcher:" docs/SPECIFICATION.md | grep "auto_attach"
  ```
- Verified that `PI_RUNNER_WATCHER_AUTO_ATTACH` appears in environment variables section:
  ```bash
  grep "PI_RUNNER_WATCHER_AUTO_ATTACH" docs/SPECIFICATION.md
  ```
- All existing tests pass